### PR TITLE
Task/gh 3 replace repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ Whenever static files are changed, the CMS may need to be manually told to serve
 5. (For templates) Restart server.
 6. Commit changes:
     1. In `/taccsite_custom` submodule repo, commit changes (__not__ to `master`).
-    2. In `cms-site-template` parent repo, add `/taccsite_custom` change.
-    3. In `cms-site-template` parent repo, commit changes (__not__ to `master`).
+    2. In this parent repo, add `/taccsite_custom` change.
+    3. In this parent repo, commit changes (__not__ to `master`).
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Whenever static files are changed, the CMS may need to be manually told to serve
 6. Commit changes:
     1. In `/taccsite_custom` submodule repo, commit changes (__not__ to `master`).
     2. In this parent repo, add `/taccsite_custom` change.
-    3. In this parent repo, commit changes (__not__ to `master`).
+    3. In this parent repo, commit changes (__not__ to `main`).
 
 ## Reference
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "build:css": "Build stylesheets from source files",
         "watch": "Build static files when source files change"
     },
-    "repository": "git@gitlab.tacc.utexas.edu:wma-cms/cms-site-template.git",
+    "repository": "git@github.com:TACC/CORE-cms.git",
     "devDependencies": {
         "async": "^3.2.0",
         "cssnano": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "portal-cms",
     "version": "0.0.0",
     "license": "MIT",
-    "description": "The master CMS codebase for all downstream TACC stand alone CMS sites.",
+    "description": "The core CMS codebase for all new and updated TACC CMS sites.",
     "scripts": {
         "build": "npm run build:css",
         "build:css": "node postcss.js",

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.css
@@ -5,7 +5,7 @@ Components for [Django CMS Blog](https://djangocms-blog.readthedocs.io) UI. Thes
 
 Reference:
 
-- [Django CMS Blog `.blog-` Class Components](https://gitlab.tacc.utexas.edu/wma-cms/cms-site-template/tree/master/taccsite_cms/templates/djangocms_blog)
+- [Django CMS Blog `.blog-` Class Components](https://github.com/TACC/CORE-cms/tree/main/taccsite_cms/templates/djangocms_blog)
 
 Styleguide Components.DjangoCMS.Blog
 */

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.post.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.post.css
@@ -5,7 +5,7 @@ Components for [Django CMS Blog Post](https://djangocms-blog.readthedocs.io) UI.
 
 Reference:
 
-- [Django CMS Blog `.post-` Class Components](https://gitlab.tacc.utexas.edu/wma-cms/cms-site-template/tree/master/taccsite_cms/templates/djangocms_blog)
+- [Django CMS Blog `.post-` Class Components](https://github.com/TACC/CORE-cms/tree/main/taccsite_cms/templates/djangocms_blog)
 
 Styleguide Components.DjangoCMS.Post
 */


### PR DESCRIPTION
## Overview: ##

Update references to repo and its primary branch.

## Related Jira tickets: ##

* Closes GH-3

## Summary of Changes: ##

- __New__: Replace links to repo `cms-site-template` to be to repo `CORE-cms`.
- __New__: Replace references to branch `master` (in this repo) to be to branch `main`.

## Testing Steps: ##
N/A

## UI Photos:
N/A

## Notes: ##
The `dev_notes/cms-site-template…` files have been ignored. They are expected to be updated, migrated, or removed in future documentation efforts.