### PR TITLE
Task/fp 947 support favicon as custom asset

### DIFF
--- a/taccsite_cms/default_secrets.py
+++ b/taccsite_cms/default_secrets.py
@@ -136,8 +136,9 @@ _FEATURES = {
 }
 
 ########################
-# BRANDING & LOGOS
+# BRANDING & LOGOS & FAVION
 ########################
+# TODO: GH-59: Use Dict Not Array for Branding Settings
 
 # Branding settings for portal and navigation.
 
@@ -154,18 +155,24 @@ Usage:
     - Any new selectors or css styles (add to /taccsite_cms/static/site_cms/css/src/_imports/branding_logos.css)
     - Image files being references (add to /taccsite_cms/static/site_cms/img/org_logos)
 
-Values to populate:
+Values to populate (for an array):
 
-_SETTING_NAME = [                 # The name of the branding or logo config setting object.
-    "org_name",                         # The name of the organization the branding belongs too.
-    "img_file_src",                      # Path and filename relative to the static files folder.
-    "img_element_classes",        # The list of selectors to apply to the rendered element, these need to exist in the css/scss.
-    "a_target_url",                      # The href link to follow when clicked, use "/" for portal logos.
-    "a_target_type",                    # The target to open the new link in, use _blank for external links, _self for internal links.
-    "alt_text",                             # The text to read or render for web assistance standards.
-    "cors_setting",                      # The CORS setting for the image, set to anonymous by default.
-    "visibility"                             # Toggles wether or not to display the element in the template, use True to render, False to hide.
+_SETTING_NAME = [                # The name of the branding or logo config setting object.
+    "org_name",                    # The name of the organization the branding belongs too.
+    "img_file_src",                # Path and filename relative to the static files folder.
+    "img_element_classes",         # The list of selectors to apply to the rendered element, these need to exist in the css/scss.
+    "a_target_url",                # The href link to follow when clicked, use "/" for portal logos.
+    "a_target_type",               # The target to open the new link in, use _blank for external links, _self for internal links.
+    "alt_text",                    # The text to read or render for web assistance standards.
+    "cors_setting",                # The CORS setting for the image, set to anonymous by default.
+    "visibility"                   # Toggles wether or not to display the element in the template, use True to render, False to hide.
 ]
+
+Values to populate (for a dict):
+
+_SETTING_NAME = {                  # The name of the favicon config setting object.
+    "img_file_src": "…",             # Path and filename relative to the static files folder.
+}
 
 Branding Configuration Example.
 
@@ -192,6 +199,12 @@ _ANORG_LOGO = [
    "anonymous",
    "True"
 ]
+
+Favicon Configuration Example.
+
+_ANORG_FAVICON = {
+    "img_file_src": "site_cms/img/favicons/favicon.ico"
+}
 """
 
 ########################
@@ -208,7 +221,7 @@ _TACC_BRANDING = [
     "True"
 ]
 
-_UTEXAS_BRANDING =  [
+_UTEXAS_BRANDING = [
     "utexas",
     "site_cms/img/org_logos/utaustin-white.png",
     "branding-utaustin",
@@ -236,7 +249,7 @@ _BRANDING = [ _TACC_BRANDING, _UTEXAS_BRANDING ]        # Default TACC Portal.
 ########################
 # LOGOS
 
-_PORTAL_LOGO =  [
+_PORTAL_LOGO = [
     "portal",
     "site_cms/img/org_logos/portal.png",
     "",
@@ -248,6 +261,15 @@ _PORTAL_LOGO =  [
 ]
 
 _LOGO = _PORTAL_LOGO                # Default Portal Logo.
+
+########################
+# FAVICON
+
+_PORTAL_FAVICON = {
+    "img_file_src": "site_cms/img/favicons/favicon.ico"
+}
+
+_FAVICON = _PORTAL_FAVICON                # Default Favicon.
 
 ########################
 # PORTAL
@@ -262,7 +284,6 @@ Usage:
 
 - For each link used in the templating, add new links values (see example below).
 - New links must be added to the _PORTAL_AUTH_LINKS and _PORTAL_UNAUTH_LINKS lists.
-- The order of the _PORTAL_[…]_LINKS lists determine the rendering order of the elements.
 
 Values to populate:
 

--- a/taccsite_cms/default_secrets.py
+++ b/taccsite_cms/default_secrets.py
@@ -136,7 +136,7 @@ _FEATURES = {
 }
 
 ########################
-# BRANDING & LOGOS & FAVION
+# BRANDING & LOGOS & FAVICON
 ########################
 # TODO: GH-59: Use Dict Not Array for Branding Settings
 

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -91,7 +91,8 @@ ALLOWED_HOSTS = current_secrets._ALLOWED_HOSTS
 
 # Custom Branding.
 BRANDING = current_secrets._BRANDING
-LOGO  = current_secrets._LOGO
+LOGO = current_secrets._LOGO
+FAVICON = current_secrets._FAVICON
 
 # Configure Portal.
 PORTAL = current_secrets._PORTAL
@@ -471,6 +472,7 @@ SETTINGS_EXPORT = [
     'DEBUG',
     'BRANDING',
     'LOGO',
+    'FAVICON',
     'PORTAL',
     'PORTAL_AUTH_LINKS',
     'PORTAL_UNAUTH_LINKS',

--- a/taccsite_cms/templates/assets_custom.html
+++ b/taccsite_cms/templates/assets_custom.html
@@ -1,3 +1,5 @@
+{% load staticfiles %}
+
 {# Load assets as external files, to cache independently of markup. #}
 {% comment %}
 FAQ: IF a script or style is better cached with markup, THEN:
@@ -9,20 +11,25 @@ FAQ: IF a script or style is better cached with markup, THEN:
 
 
 
-{# Do NOT directly load assets here. Load as needed by template or brand. #}
+<!-- Custom Site Assets: Favicon. -->
+{% with settings.FAVICON as favicon %}
+<link rel="icon" href="{% static favicon.img_file_src %}" type="image/x-icon" />
+{% endwith %}
 
 
+
+{# Do NOT directly load project-specific assets here; see `/taccsite_custom` #}
 
 {# Example #}
 {% comment %}
   {% block assets_custom %}
     {{ block.super }}
 
-    {# Example: Site Assets. #}
+    {# Example: Custom Site Assets. #}
     <link rel="stylesheet" href="{% static '__PROJECT__/css/build/site.css' %}">
     <script src="{% static '__PROJECT__/js/site.js' %}"></script>
 
-    {# Example: Template-Specific Assets. #}
+    {# Example: Custom Template-Specific Assets. #}
     <link rel="stylesheet" href="{% static '__PROJECT__/css/build/template.___.css' %}">
     <script src="{% static '__PROJECT__/js/template.___.js' %}"></script>
 

--- a/taccsite_cms/templates/assets_custom_delayed.html
+++ b/taccsite_cms/templates/assets_custom_delayed.html
@@ -5,26 +5,26 @@ Consider asset load via `assets_custom`, not `assets_custom_delayed`:
   - Scripts can use `defer` or `async` attr's to manage load time.
 {% endcomment %}
 
+{# NOTE: Fonts may be loaded early via `assets_font` #}
 
 
-{# Do NOT directly load assets here. Load as needed by template or brand. #}
 
-
+{# Do NOT directly load project-specific assets here; see `/taccsite_custom` #}
 
 {# Example #}
 {% comment %}
   {% block assets_custom_delayed %}
     {{ block.super }}
 
-    {# Example: Site Assets. #}
+    {# Example: Custom Site Assets. #}
     <link rel="stylesheet" href="{% static '__PROJECT__/css/build/site.css' %}">
     <script src="{% static '__PROJECT__/js/site.js' %}"></script>
 
-    {# Example: Template-Specific Assets. #}
+    {# Example: Custom Template-Specific Assets. #}
     <link rel="stylesheet" href="{% static '__PROJECT__/css/build/template.___.css' %}">
     <script src="{% static '__PROJECT__/js/template.___.js' %}"></script>
 
-    {# Example: Page-Specific Assets. #}
+    {# Example: Custom Page-Specific Assets. #}
     {# WARNING: Undesired use case. Create re-usable code instead. #}
     {# SEE: https://confluence.tacc.utexas.edu/x/54AZCg #}
 

--- a/taccsite_cms/templates/assets_site.html
+++ b/taccsite_cms/templates/assets_site.html
@@ -12,9 +12,6 @@ FAQ: IF a script or style is better cached with markup, THEN:
 
 
 
-<!-- Site Assets: Favicon. -->
-<link rel="icon" href="{% static 'site_cms/img/favicons/favicon.ico' %}" type="image/x-icon" />
-
 <!-- Site Assets: Styles. -->
 <link id="css-bootstrap" rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 

--- a/taccsite_cms/templates/fullwidth.html
+++ b/taccsite_cms/templates/fullwidth.html
@@ -4,6 +4,8 @@
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}
 
 {% block assets_custom %}
+{{ block.super }}
+
 <script>
   console.info('Core `fullwidth.html` loads no custom assets');
 </script>

--- a/taccsite_cms/templates/sidebar_left.html
+++ b/taccsite_cms/templates/sidebar_left.html
@@ -4,6 +4,8 @@
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}
 
 {% block assets_custom %}
+{{ block.super }}
+
 <script>
   console.info('Core `sidebar_left.html` loads no custom assets');
 </script>

--- a/taccsite_cms/templates/sidebar_right.html
+++ b/taccsite_cms/templates/sidebar_right.html
@@ -4,6 +4,8 @@
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}
 
 {% block assets_custom %}
+{{ block.super }}
+
 <script>
   console.info('Core `sidebar_right.html` loads no custom assets');
 </script>


### PR DESCRIPTION
## Overview

Support custom favicon, and add new 3Dem project (via submodule).

## Related Tickets & PRs

* [FP-947](https://jira.tacc.utexas.edu/browse/FP-947)
* https://github.com/TACC/cms-site-resources/pull/27

## Summary of Changes

- _Minor_: Clarify dict versus array settings for branding, logo, and favicon secrets.
- _Minor_: Clean up comments and whitespace for branding, logo, and favicon secrets.
- __New__: Add favicon instructions, example, and support to secrets.
- __New__: Export new {{FAVICON}} secret to templates.
- __New__: Move favicon load from `assets_site.html` to `assets_custom.html`.
    - This makes it the first standard misc. custom asset. Other standard custom assets are part of specialized templates.
- _Minor_: Update comments of related templates for consistency and accuracy.
- __Fix__: Add `{{ block.super }}` to templates that would have otherwise failed to load favicon after its markup moved.
- __New__: (via submodule) Add 3dem project.

## Testing Steps

### Example CMS

0. Follow [Wiki: Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes) instructions.
    - (optional) remote CMS docker image: `taccwma/core-cms:fa75889`
1. Confirm that favicon still loads (check markup, not just browser tab icon which browser would cache).

### 3Dem CMS

- Follow https://github.com/TACC/cms-site-resources/pull/27 "Testing Steps".

## UI Photos

<details><summary>Example CMS Favicon</summary>

![FP-947 Example](https://user-images.githubusercontent.com/62723358/111530260-162b0f00-8731-11eb-8768-240607dea7ba.png)

</details>
<details><summary>3Dem Logo & Favicon</summary>

![FP-947 3Dem](https://user-images.githubusercontent.com/62723358/111530400-3ce94580-8731-11eb-8f6c-47e9d3e078b2.png)

<details>


