### PR TITLE
Quick: Create & Skip empty Core cms directory

### DIFF
--- a/postcss.js
+++ b/postcss.js
@@ -75,9 +75,14 @@ console.warn('The commands are run in parallel so the output may be out of order
 // Build process for styles may be run in parallel because they are independent
 // SEE: https://stackoverflow.com/a/10776939/11817077
 parallel([
+  // Always build Core assets
   buildStylesCore,
-  buildStylesCustom,
+
+  // Build custom assets, except for Core
+  () => { if (env.CUSTOM_ASSET_DIR !== 'core-cms') buildStylesCustom() },
+
+  // Temporarily build "frozen variables" from Core
+  // FAQ: This is an advanced solution to a problem that should not exist
   () => { buildStylesCore({shouldFreezeVariables: true}) },
-  // Do NOT support freezing variables for custom projects
-  // FAQ: The variable freezing is advanced and (hopefully) temporary
+  // NOTE: Do NOT support freezing variables for custom projects
 ], parallelCallback);


### PR DESCRIPTION
# Dependencies

- [x] https://github.com/TACC/cms-site-resources/pull/38

# Overview

Support `core-cms` as `CUSTOM_ASSET_DIR` in image build configuration.

> This will allow us to combine `dockerhub_repo` and `CUSTOM_ASSET_DIR` into one parameter.

# Related Tickets

- [FP-981](https://jira.tacc.utexas.edu/browse/FP-981)

# Changes

1. Change custom asset build logic:
    - __Before__: <del><em>Always</em> build custom stylesheets.</del>
    - __After__: <ins><em>If</em> <strong>not</strong> `core-cms`, <em>then</em> build custom stylesheets.</ins>
2. Include (from submodule) new `core-cms` directory that just has a `README.md`.

# Testing

See https://github.com/TACC/cms-site-resources/pull/38.