### PR TITLE
GH-157: Header & Footer: Update Colors. Use Vars

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/branding_logos.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/branding_logos.css
@@ -23,8 +23,8 @@
   height: 49px;
 
 
-  background-color: rgb(51, 51, 51);
-  color: #fff;
+  background-color: var(--global-color-primary--xx-dark);
+  color: var(--global-color-primary--xx-light);
   border-bottom: 1px solid #aaa;
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-footer.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-footer.css
@@ -28,8 +28,8 @@ Styleguide Components.Footer
   padding-top: 20px;
   padding-bottom: 20px;
 
-  color: rgb(255, 255, 255);
-  background-color: rgb(51, 51, 51);
+  color: var(--global-color-primary--xx-light);
+  background-color: var(--global-color-primary--xx-dark);
 
   font-size: 12px;
   text-align: center;

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -22,7 +22,7 @@ Styleguide Trumps.Scopes.Header
             - On any other CMS, `1rem` = `16px` (browser default). */
 
 .s-header {
-  --text-color: rgb(255, 255, 255);
+  --text-color: var(--global-color-primary--xx-light);
 
   font-size: 16px; /* NO-R/EM: Overwrite `bootstrap.3.3.7.css` */
 
@@ -78,7 +78,7 @@ Styleguide Trumps.Scopes.Header
   --nav-padding-vert: 5px;
   --nav-padding-horz: calc(16px + 20px);
 
-  background-color: rgb(51, 51, 51);
+  background-color: var(--global-color-primary--xx-dark);
   padding: var(--nav-padding-vert) var(--nav-padding-horz);
 }
 


### PR DESCRIPTION
# Overview

Minor visual darkening of the dark gray of the header and footer.

This is part of the [Frontera Homepage Redesign](https://github.com/TACC/Core-CMS/issues/157) that is being propagated to Core.

# Issues

- GH-157

# Changes

- Change color of header and footer to be darkest (TACC standard) primary color.
- Change colors of header and footer to use CSS variables a.k.a. custom properties.

# Testing

This is already tested in context via https://frontera-portal.tacc.utexas.edu/home-2021-03/ or (if launched) https://frontera-portal.tacc.utexas.edu/ and locally by developer with other related changes via https://github.com/TACC/Core-CMS/pull/174.

1. Ensure header text color is `#FFFFFF`.
1. Ensure header background color is `#222222`.
1. Ensure footer text color is `#FFFFFF`.
1. Ensure footer background color is `#222222`.