### PR TITLE
GH-157: Body Tag: Explicit Line Height & Min-Width

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
@@ -28,7 +28,12 @@ body {
 }
 
 body {
+  /* To avoid negative whitespace at right on horz scroll on tiny screen */
+  min-width: 290px; /* developer-decided value */
+
   font-family: var(--global-font-family);
+
+  line-height: 1.4; /* overwrite Bootstrap */
 }
 
 


### PR DESCRIPTION
# Overview

This is part of the [Frontera Homepage Redesign](https://github.com/TACC/Core-CMS/issues/157) that is being propagated to Core.

- Set a minimum width for all page `body`'s.
- Explicitly set TACC line-height of `1.4` to override Bootstrap.
# Issues

- GH-157

# Testing

This is already tested in context via https://frontera-portal.tacc.utexas.edu/home-2021-03/ or (if launched) https://frontera-portal.tacc.utexas.edu/ and locally by developer with other related changes via https://github.com/TACC/Core-CMS/pull/174.

> __Tip:__ Use "Inspect Element" context menu to access Developer Tools to investigate CSS for body element.

1. Ensure active `body` line-height is `1.4`.
1. Ensure active `body` line-height comes from TACC CSS.
1. Ensure active `body` min-width is `290px`.