### PR TITLE
GH-157: Search Bar: Match Portal Font (Roboto)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/tacc-search-bar.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/tacc-search-bar.css
@@ -18,6 +18,10 @@ Styleguide Elements.TACC.SearchBar
 
 /* tacc-search-bar.s-search-bar::part(form) { */
 [part="form"] {
+  /* FAQ: Ensure search field font matches Portal */
+  /* SEE: https://confluence.tacc.utexas.edu/x/cYAZCg */
+  font-family: "Roboto";
+
   /* Copied from `.container` from Portal */
   /* SEE: https://github.com/TACC/Frontera-Portal/blob/master/client/src/components/DataFiles/DataFilesSearchbar/DataFilesSearchbar.module.css */
   display: flex;


### PR DESCRIPTION
# Overview

Fix a Core bug that was revealed by [Frontera Homepage Redesign](https://github.com/TACC/Core-CMS/issues/157).

Set search bar font to be Roboto, so per-project styles do __not__ override it. — [source](https://confluence.tacc.utexas.edu/x/cYAZCg)

# Issues

- GH-157

# Testing

This is already tested in context via https://frontera-portal.tacc.utexas.edu/home-2021-03/ or (if launched) https://frontera-portal.tacc.utexas.edu/ and locally by developer with other related changes via https://github.com/TACC/Core-CMS/pull/174.

1. Ensure header search bar font is explicitly\* Roboto.

\* Explicitly as in defined within the element, not inherited from page.