### PR TITLE
GH-157: Add New Stylesheets for Frontera Redesign

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-read-more.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-read-more.css
@@ -1,0 +1,50 @@
+/*
+Read More
+
+A CSS-only way to support a "Read More…" feature. It requires a container and three children in order:
+- state checkbox (must be first)
+- target text
+- toggle element
+
+.c-read-more--one-line   - Truncated text may only be one line tall.
+.c-read-more--many-lines - Truncated text may be many lines tall.
+
+Styleguide: Components.ReadMore
+*/
+@import url("_imports/tools/x-truncate.css");
+
+/* Truncation */
+
+/* Many Lines */
+.c-read-more--many-lines .c-read-more__target {
+  @extend .x-truncate--many-lines;
+}
+.c-read-more--many-lines .c-read-more__state:checked ~ .c-read-more__target {
+  @extend .x-untruncate--many-lines;
+}
+
+/* One Line */
+.c-read-more--one-line .c-read-more__target {
+  @extend .x-truncate--one-line;
+}
+.c-read-more--one-line .c-read-more__state:checked ~ .c-read-more__target {
+  @extend .x-untruncate--one-line;
+}
+
+/* Read More / Read Less */
+
+/* State */
+.c-read-more__state,
+.c-read-more__on-text,
+.c-read-more__off-text {
+  display: none;
+}
+.c-read-more__state:not(:checked) ~ .c-read-more__toggle .c-read-more__on-text,
+.c-read-more__state:checked ~ .c-read-more__toggle .c-read-more__off-text {
+  display: block;
+}
+
+/* Toggle */
+.c-read-more__toggle {
+  cursor: pointer;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -1,0 +1,232 @@
+/*
+Section
+
+Horizontal
+
+Markup: o-section.html
+
+Styleguide Objects.Section
+*/
+@import url("../../../../../../../taccsite_cms/static/site_shared/css/src/_imports/tools/media-queries.css");
+@import url("../../../../../../../taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css");
+
+
+
+
+
+/* Block */
+
+[class*="o-section--"] {
+  /* GH-99: Use standard spacing value */
+  /* NOTE: The Design varies, but this is the approx. average */
+  --vert-space: 4.5rem;
+  --horz-space: 4.5rem;
+
+  padding-top: var(--vert-space);
+  padding-bottom: var(--vert-space);
+}
+[class*="o-section--"] > [class*="o-section--"] {
+  --vert-space: 0;
+  --horz-space: 0;
+}
+
+/* Overwrite Bootstrap */
+[class*="o-section--"].container,
+[class*="o-section--"].container-fluid {
+  width: auto; /* Bootstrap forcing `width: 100%` prevented usable margin */
+  margin-left: var(--horz-space);
+  margin-right: var(--horz-space);
+}
+[class*="o-section--"].container {
+  --horz-space: auto;
+}
+/* To take control of padding away from Bootstrap on MOST screen sizes */
+@media (--x-narrow-and-above) {
+  [class*="o-section--"].container,
+  [class*="o-section--"].container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+
+
+
+
+
+/* Modifers */
+
+
+
+/* Modifers: Banner */
+
+.o-section--banner {
+  --vert-space: 0;
+  --horz-space: 0;
+
+  gap: 0 !important; /* overwrite `o-section--layout-*` */
+}
+/* To take control of padding away from Bootstrap on ALL screen sizes */
+.o-section--banner.container,
+.o-section--banner.container-fluid {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+
+
+/* Modifers: Intro */
+
+.o-section--intro > :empty:not(img),
+.o-section--intro .u-empty {
+  display: none;
+}
+
+
+
+/* Modifers: Style */
+
+[class*="o-section--style"] {
+  --hr-height: var(--global-border-width--normal);
+}
+
+/* Modifers: Style: Dark & Light */
+
+.o-section--style-dark,
+.o-section--style-dark::before {
+  color: var(--global-color-primary--xx-light);
+  background-color: var(--global-color-primary--xx-dark);
+}
+/* FAQ: Banners should not touch a border of the following section */
+.o-section--style-dark:not(.o-section--banner)
++ .o-section--style-dark:not(.o-section--banner) {
+  border-top: var(--hr-height) solid var(--global-color-primary--xx-light);
+}
+
+.o-section--style-light,
+.o-section--style-light::before {
+  color: var(--global-color-primary--dark);
+  background-color: var(--global-color-primary--xx-light);
+}
+/* FAQ: Banners should not touch a border of the following section */
+.o-section--style-light:not(.o-section--banner)
++ .o-section--style-light:not(.o-section--banner) {
+  border-top: var(--hr-height) solid var(--global-color-primary--xx-light);
+}
+
+/* Modifers: Style: (Fake) Endless Background */
+
+[class*="o-section--style"] {
+  /* To anchor the `position: absolute` pseudo-element */
+  /* To allow `z-index` on children as necessary */
+  position: relative;
+
+  /* CAVEAT: We MUST maintain intentional horizontal overflow of pseudo-child */
+  overflow-x: visible !important; /* do not allow accidental hide of fake bkgd */
+}
+[class*="o-section--style"] > * {
+  /* To ensure children are above `position: absolute` pseudo-element */
+  position: relative;
+  z-index: 1;
+}
+[class*="o-section--style"]::before {
+  content: '';
+  z-index: 0; /* To ensure real element children are above this */
+
+  position: absolute;
+  display: block;
+  width: 100vw;
+  top: 0;
+  /* FAQ: Covers space of following sibling's border without covering border */
+  bottom: calc(-1 * var(--hr-height));
+
+  /* To horizontally center */
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+
+
+/* Modifers: Layout */
+
+.o-section--layout-a,
+.o-section--layout-b,
+.o-section--layout-c,
+.o-section--layout-d {
+  gap: 3.0rem; /* GH-99: Use standard spacing value */
+}
+.o-section--layout-a { @extend .x-layout--a; }
+.o-section--layout-b { @extend .x-layout--b; }
+.o-section--layout-c { @extend .x-layout--c; }
+.o-section--layout-d { @extend .x-layout--d; }
+
+
+
+
+
+/* Children */
+
+
+
+/* Children: Banner Image */
+
+/* Added `.o-section--banner` to require parent modifier class in markup */
+.o-section--banner .o-section__banner-image {
+  position: absolute;
+  z-index: 1;
+
+  /* To size image to cover section dimensions but maintain ratio */
+  /* CAVEAT: This causes image to overflow beyond section */
+  /* CAVEAT: The `vw` causes shrinkage on screen narrower than body min-width */
+  /* SEE: "Tricks" section */
+  width: 100vw;
+  min-height: 100%;
+  object-fit: cover;
+
+  /* To vertically center image within section */
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+
+
+/* Children: Banner Overlay */
+
+/* Added `.o-section--banner` to require parent modifier class in markup */
+.o-section--banner .o-section__banner-overlay {
+  position: relative;
+  z-index: 2;
+
+  /* Avoids the need to add placeholder markup for empty column */
+  /* FAQ: The image "leaves" the column via `position: absolute` */
+  grid-column-start: 2;
+
+  background-color: rgba(var(--color-bkgd-rgb), 0.65);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+.o-section--banner.o-section--style-dark .o-section__banner-overlay {
+  --color-bkgd-rgb: var(--global-color-primary--x-dark-rgb);
+}
+.o-section--banner.o-section--style-light .o-section__banner-overlay {
+  --color-bkgd-rgb: var(--global-color-primary--x-light-rgb);
+}
+
+
+
+
+
+/* Tricks */
+
+
+
+/* Tricks: /* Children: Banner Image */
+
+/* HACK: To hide vertical overflow by placing sibling sections atop */
+/* NOTE: This selector assumes only a banner section has vertical overflow */
+/* CAVEAT: Any banner pop-out el's can NOT overflow atop sibling sections */
+[class*="o-section--style"].o-section--banner { z-index: 0; }
+/* NOTE: A `z-index` > 0 is only necessary for sections before banner */
+/* CAVEAT: Any section pop-out el's can NOT overflow atop section after it */
+[class*="o-section--style"] { z-index: 1; }

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
@@ -1,0 +1,20 @@
+<section class="o-section--style-dark">
+  <p><strong>Style "Dark"</strong></p>
+  <p>This section is styled dark, and <strong>must not</strong> have top border (because it does not have the same style section before it).</p>
+</section>
+<section class="o-section--style-dark">
+  <p><strong>Style "Dark"</strong></p>
+  <p>This section is styled dark, and <strong>must</strong> a top border (because it does not have the same style section before it).</p>
+</section>
+<section class="o-section--style-light">
+  <p><strong>Style "Light"</strong></p>
+  <p>This section is styled light, and <strong>must not</strong> have top border (because it does not have the same style section before it).</p>
+</section>
+<section class="o-section--style-light">
+  <p><strong>Style "Light"</strong></p>
+  <p>This section is styled light, and <strong>must</strong> have a top border (because it does not have the same style section before it).</p>
+</section>
+<section class="o-section--style-dark">
+  <p><strong>Style "Dark"</strong></p>
+  <p>This section is styled dark, and <strong>must not</strong> have top border (because it does not have the same style section before it).</p>
+</section>

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-site.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-site.css
@@ -23,4 +23,8 @@ Styleguide Objects.Site
 .o-site__head,
 .o-site__foot {
   flex-shrink: 0;
+
+  /* Hides any overflow from `o-site__body` (e.g. `o-section__banner-image`) */
+  position: relative;
+  z-index: 1;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-article-link.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-article-link.css
@@ -1,0 +1,37 @@
+/*
+Article Link
+
+Styles that allow visible link hover for article lists.
+
+.x-article-link-stretch          - Stretch link to cover container
+.x-article-link-stretch--gapless - Make link box fix gapless layout
+.x-article-link-hover            - Give link a hover state
+.x-article-link-hover--gapless   - Make link hover state fix gapless layout
+
+Styleguide Tools.ExtendsAndMixins.ArticleLink
+*/
+
+/* WARNING: A link ancestor must have its `position` set (not to static) */
+
+/* Expand link to cover container */
+.x-article-link-stretch {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  /* An explicit position (in case container has top padding) */
+  top: 0;
+}
+.x-article-link-stretch--gapless {
+  width: calc(100% + 30px); /* GH-99: Use standard spacing value */
+  left: -15px;
+}
+
+/* Give link state (pseudo-class) feedback */
+.x-article-link-hover {
+  outline: 1px solid var(--global-color-accent--normal);
+
+  outline-offset: 1em;
+}
+.x-article-link-hover--gapless {
+  outline-offset: 0;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css
@@ -1,0 +1,71 @@
+/*
+Layout
+
+Styles that allow re-usable layouts.
+
+.x-layout--a - Widest: two even columns
+.x-layout--b - Widest: one wide column & one narrow column
+.x-layout--c - Widest: one narrow column & one wide column
+.x-layout--d - Widest: three even columns
+.x-layout--d - Always: multiple even rows
+
+Styleguide Tools.ExtendsAndMixins.Layout
+*/
+
+
+
+/* Column-Based */
+
+.x-layout--a,
+.x-layout--b,
+.x-layout--c,
+.x-layout--d {
+  display: grid;
+}
+
+/* A (two even columns) */
+
+@media (--medium-and-below) {
+  .x-layout--a { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+}
+@media (--medium-and-above) {
+  .x-layout--a { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+/* B (one wide column & one narrow column) */
+
+@media (--medium-and-below) {
+  .x-layout--b { grid-template-columns: 1fr; }
+}
+@media (--medium-and-above) {
+  .x-layout--b { grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); }
+}
+
+/* C (one narrow column & one wide column) */
+
+@media (--medium-and-below) {
+  .x-layout--c { grid-template-columns: 1fr; }
+}
+@media (--medium-and-above) {
+  .x-layout--c { grid-template-columns: minmax(0, 1fr) minmax(0, 2fr); }
+}
+
+/* D (three equal columns) */
+
+@media (--x-narrow-and-below) {
+  .x-layout--d { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+}
+@media (--narrow-to-medium), (--x-narrow-to-narrow) {
+  .x-layout--d { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (--medium-and-above) {
+  .x-layout--d { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+
+/* Row-Based */
+
+.x-layout--e {
+  display: flex;
+  flex-direction: column;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-truncate.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-truncate.css
@@ -1,0 +1,43 @@
+/*
+Truncate
+
+Styles that allow truncating text.
+
+.x-truncate--one-line     - Truncated text may only be one line tall.
+.x-untruncate--one-line   - Remove one-line truncation after it's added.
+.x-truncate--many-lines   - Truncated text may be many lines tall.
+.x-untruncate--many-lines - Remove many-lines truncation after it's added.
+
+Styleguide Tools.ExtendsAndMixins.Truncate
+*/
+
+/* Many Lines */
+/* WARNING: Relies on proprietary and undocumented rules (that work well) */
+
+.x-truncate--many-lines {
+  --lines: 2;
+
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+
+  overflow: hidden;
+  -webkit-line-clamp: var(--lines);
+}
+.x-untruncate--many-lines {
+  overflow: visible;
+  -webkit-line-clamp: inherit;
+}
+
+/* One Line */
+
+.x-truncate--one-line {
+	text-overflow: ellipsis;
+
+	overflow: hidden;
+	white-space: nowrap;
+}
+.x-untruncate--one-line {
+  overflow: visible;
+	white-space: normal;
+}
+

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
@@ -1,0 +1,236 @@
+/*
+Article List
+
+A list of article previews. Content __must__ use the tags defined by the example markup.
+
+Markup: s-article-list.html
+
+Styleguide Trumps.Scopes.ArticleList
+*/
+@import url("_imports/tools/x-layout.css");
+@import url("_imports/tools/x-article-link.css");
+
+
+
+
+
+/* Block */
+
+[class*="s-article-list--"] {
+  /* … */
+}
+
+
+
+
+
+/* Children */
+
+
+
+/* Children: All */
+
+/* Not "Title" & Not "See More" */
+.s-article-list--layout-e > :not(h2):not(p:last-child) {
+  /* To shrink heading */
+  flex-grow: 1;
+}
+
+
+
+/* Children: Title */
+
+.s-article-list--layout-a > h2,
+.s-article-list--layout-b > h2,
+.s-article-list--layout-c > h2,
+.s-article-list--layout-d > h2 {
+  /* To span all columns */
+  grid-column-start: 1;
+  grid-column-end: -1;
+}
+
+[class*="s-article-list--"] > h2 {
+  margin-top: 0; /* overwrite Bootstrap */
+  margin-bottom: 3.0rem; /* overwrite Bootstrap */
+
+  color: var(--global-color-accent--normal);
+
+  font-size: 1.6rem;
+  font-weight: var(--bold);
+  text-transform: uppercase;
+
+  @extend .x-truncate--one-line;
+}
+/* Add a fake short border above title */
+[class*="s-article-list--"] > h2 {
+  position: relative;
+  padding-top: 1em;
+}
+[class*="s-article-list--"] > h2::before {
+  content: '';
+  display: block;
+
+  position: absolute;
+  top: 0;
+  height: 0.5em;
+  width: 2.5em;
+
+  background-color: var(--global-color-accent--normal);
+}
+
+
+
+/* Children: "See More" */
+
+/* Anchor */
+
+.s-article-list--layout-a > p:last-child,
+.s-article-list--layout-b > p:last-child,
+.s-article-list--layout-c > p:last-child,
+.s-article-list--layout-d > p:last-child {
+  /* To span all columns */
+  grid-column-start: 1;
+  grid-column-end: -1;
+}
+
+[class*="s-article-list--"] > p:last-child {
+  border-top-width: var(--global-border-width--thick);
+  border-top-style: solid;
+
+  margin-top: 3.0rem; /* GH-99: Use standard spacing value */
+  margin-bottom: -1.0rem; /* to "undo" space added from `padding-bottom` */
+
+  font-size: 1.2rem;
+  font-weight: var(--bold);
+}
+[class*="s-article-list--"] > p:last-child a {
+  display: inline-block;
+
+  padding-top: 1.0rem;
+  padding-bottom: 1.0rem;
+  padding-right: 1.0rem;
+
+  @extend .x-truncate--one-line;
+  max-width: 100%; /* SEE: https://stackoverflow.com/a/44521595 */
+}
+/* Dark section */
+.o-section--style-dark [class*="s-article-list--"] > p:last-child {
+  border-color: var(--global-color-primary--xx-light);
+}
+.o-section--style-dark [class*="s-article-list--"] > p:last-child a {
+  color: var(--global-color-primary--xx-light);
+}
+/* Light section */
+.o-section--style-light [class*="s-article-list--"] > p:last-child {
+  border-color: var(--global-color-primary--xx-dark);
+}
+.o-section--style-light [class*="s-article-list--"] > p:last-child a {
+  color: var(--global-color-primary--xx-dark);
+}
+
+/* Icon */
+
+[class*="s-article-list--"] > p:last-child a::before {
+  font-family: "Font Awesome 5 Free";
+  content: "\f35a";
+  margin-right: 10px;
+
+  font-size: 1.4rem;
+  vertical-align: middle;
+
+  /* To hide the `text-decoration: underline` of the anchor */
+  /* SEE: https://stackoverflow.com/a/15688237/11817077 */
+  display: inline-block;
+}
+
+
+
+
+
+/* Modifiers */
+
+
+
+/* Modifiers: Links */
+
+.s-article-list--links {
+  font-size: 1.4rem;
+  color: var(--global-color-primary--xx-dark);
+}
+.s-article-list--links p:not(:last-child) {
+  margin: 0; /* Overwrite Bootstrap and browser */
+}
+.s-article-list--links p:not(:last-child) a {
+  font-weight: var(--bold);
+  color: var(--global-color-primary--xx-dark);
+}
+
+/* Expand link to cover its container */
+.s-article-list--links p:not(:last-child) { position: relative; }
+.s-article-list--links p:not(:last-child) a::before {
+  content: '';
+
+  @extend .x-article-link-stretch;
+}
+.s-article-list--layout-gapless.s-article-list--links p:not(:last-child) a::before {
+  @extend .x-article-link-stretch--gapless;
+}
+/* Give link state (pseudo-class) feedback */
+.s-article-list--links p:not(:last-child) a:hover::before {
+  @extend .x-article-link-hover;
+}
+.s-article-list--layout-gapless.s-article-list--links p:not(:last-child) a:hover::before {
+  @extend .x-article-link-hover--gapless;
+}
+
+
+
+/* Modifiers: Layout */
+
+.s-article-list--layout-a { @extend .x-layout--a; }
+.s-article-list--layout-b { @extend .x-layout--b; }
+.s-article-list--layout-c { @extend .x-layout--c; }
+.s-article-list--layout-d { @extend .x-layout--d; }
+.s-article-list--layout-e { @extend .x-layout--e; }
+
+/* Modifiers: Layout: Column-Based */
+
+.s-article-list--layout-a,
+.s-article-list--layout-b,
+.s-article-list--layout-c,
+.s-article-list--layout-d {
+  column-gap: 3.0rem; /* GH-99: Use standard spacing value */
+}
+
+/* Modifiers: Layout: Row-Based */
+
+.s-article-list--layout-e {
+  /* … */
+}
+
+/* Modifiers: Layout: Options */
+
+.s-article-list--layout-gapless {
+  gap: 0;
+}
+
+.s-article-list--layout-compact > p:last-child {
+  margin-top: 0;
+}
+
+.s-article-list--layout-divided > :not(h2):not(p:last-child) {
+  padding-top: 0.8rem;
+
+  border-width: var(--global-border-width--normal) 0 0;
+  border-style: solid;
+}
+/* Dark section */
+.o-section--style-dark.s-article-list--layout-divided > :not(h2):not(p:last-child),
+.o-section--style-dark .s-article-list--layout-divided > :not(h2):not(p:last-child) {
+  border-color: var(--global-color-primary--light);
+}
+/* Light section */
+.o-section--style-light.s-article-list--layout-divided > :not(h2):not(p:last-child),
+.o-section--style-light .s-article-list--layout-divided > :not(h2):not(p:last-child) {
+  border-color: var(--global-color-primary--dark);
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.html
@@ -1,0 +1,20 @@
+<article class="s-article-list">
+  <h2>
+    News &amp; Stuff
+  </h2>
+  <article>
+    Article Placeholder
+  </article>
+</article>
+
+<!-- TODO: Use a component (requires a plugin) -->
+<!--
+<article class="c-article-list">
+  <h2 class="c-article-list__title">
+    News &amp; Stuff
+  </h2>
+  <article class="c-article-list__item">
+    Article Placeholder
+  </article>
+</article>
+-->

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.css
@@ -1,0 +1,247 @@
+/*
+Article Preview
+
+A preview of an article (to be used in a `s-article-list`). Content __must__ come in the order and use the tags defined by the example markup.
+
+Markup: s-article-preview.html
+
+Styleguide Trumps.Scopes.ArticlePreview
+*/
+@import url("_imports/tools/x-truncate.css");
+@import url("_imports/tools/x-article-link.css");
+
+
+
+
+
+/* Block */
+
+.s-article-preview {
+  position: relative; /* for absolutely positioned "Children: Link" */
+
+  display: flex;
+  flex-direction: column;
+}
+
+
+
+
+
+/* Children */
+
+
+
+/* Children: Media */
+
+.s-article-preview p:first-child {
+  order: 1;
+
+  overflow: hidden;
+
+  margin-bottom: 0.8rem; /* overwrite Bootstrap */
+}
+.s-article-preview p:first-child > img {
+  /* To center image within container */
+  position: relative;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+.s-article-preview p:first-child > img.img-fluid {
+  /* To ensure super wide or tall image do not have negative space / gaps */
+  width: 100%;
+  object-fit: cover;
+  height: 100%; /* overwrite `.img-fluid` *//* NOTE: Sould this be standard? */
+}
+/* (List) News */
+.s-article-list--news .s-article-preview p:first-child {
+  height: 180px;
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview p:first-child {
+  height: 10.0rem;
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview p:first-child {
+  display: none;
+}
+
+
+/* Children: Title */
+
+.s-article-preview h3 {
+  order: 3;
+
+  margin-top: 0; /* overwrite Bootstrap and browser */
+  margin-bottom: 0.8rem; /* overwrite Bootstrap and browser */
+
+  font-size: 1.8rem;
+  font-weight: var(--bold);
+  line-height: 2.4rem;
+
+  @extend .x-truncate--one-line;
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview h3 {
+  font-size: 1.6rem;
+  font-weight: var(--bold);
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview h3 {
+  font-size: 1.4rem;
+  color: var(--global-color-primary--xx-dark);
+}
+
+
+
+/* Children: Abstract */
+
+.s-article-preview p:not(:first-child):not(:last-child) {
+  order: 4;
+
+  margin-bottom: 0; /* overwrite Bootstrap and browser */
+
+  font-size: 1.6rem;
+  line-height: 2.4rem;
+
+  @extend .x-truncate--many-lines;
+  --lines: 3;
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview p:not(:first-child):not(:last-child) {
+  display: none;
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview p:not(:first-child):not(:last-child) {
+  font-size: 1.4rem;
+  color: var(--global-color-primary--xx-dark);
+}
+
+
+
+/* Children: Metadata */
+
+.s-article-preview ul {
+  order: 2;
+
+  display: flex;
+  flex-direction: column;
+
+  list-style: none;
+  padding-left: 0; /* overwrite `site.css` and browser */
+
+  margin-bottom: 0.8rem; /* overwrite Bootstrap */
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview ul {
+  order: 5;
+}
+
+/* Children: Metadata: Date */
+
+.s-article-preview ul > li:nth-child(1) {
+  order: 2;
+
+  font-weight: var(--medium);
+
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+/* (List) News */
+.s-article-list--news .s-article-preview ul > li:nth-child(1) {
+  margin-bottom: 0.8rem; /* overwrite Bootstrap */
+  font-size: 1.0rem;
+}
+.s-article-list--news .s-article-preview ul > li:nth-child(1)::before {
+  content: 'Published: ';
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview ul > li:nth-child(1) {
+  font-size: 1.4rem;
+  color: var(--global-color-accent--normal);
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview ul > li:nth-child(1) {
+  font-size: 1.6rem;
+}
+.s-article-list--allocations .s-article-preview ul > li:nth-child(1)::before {
+  content: 'Submission Deadlines: ';
+}
+
+/* Children: Metadata: Type */
+
+.s-article-preview ul > li:nth-child(2) {
+  order: 1;
+
+  font-size: 1.2rem;
+  font-weight: var(--bold);
+  text-transform: uppercase;
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview ul > li:nth-child(2),
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview ul > li:nth-child(2) {
+  display: none;
+}
+
+/* Children: Metadata: Author */
+
+.s-article-preview ul > li:nth-child(3) {
+  order: 3;
+}
+/* (List) News */
+.s-article-list--news .s-article-preview ul > li:nth-child(3),
+/* (List) Events */
+.s-article-list--events .s-article-preview ul > li:nth-child(3),
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview ul > li:nth-child(3) {
+  display: none;
+}
+
+
+
+/* Children: Link */
+
+.s-article-preview p:last-child {
+  margin-bottom: 0; /* overwite Bootstrap and browser */
+}
+
+/* Expand link to cover its container */
+.s-article-preview p:last-child {
+  z-index: 1; /* ensure Link appears over Media */
+}
+.s-article-preview p:last-child > a {
+  color: transparent; /* ensure Link _text_ is invisible (allow decoration) */
+
+  @extend .x-article-link-stretch;
+}
+.s-article-list--layout-gapless .s-article-preview p:last-child > a {
+  @extend .x-article-link-stretch--gapless;
+}
+/* Give link state (pseudo-class) feedback */
+.s-article-preview p:last-child > a:hover {
+  @extend .x-article-link-hover;
+}
+.s-article-list--layout-gapless .s-article-preview p:last-child > a:hover {
+  @extend .x-article-link-hover--gapless;
+}
+
+
+
+
+
+/* Modifiers */
+
+
+
+/* Modifiers: (List) News, Allocations, Evetns, etc. */
+/* SEE: All "Children" styles */
+
+
+
+/* Modifiers: (List) Layout: Options */
+
+.s-article-list--layout-compact .s-article-preview > * {
+  margin-bottom: 0; /* overwrite `.s-article-preview > …` */
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.html
@@ -1,0 +1,30 @@
+<article class="s-article-preview">
+  <p><img src="…" alt="…" /></p>
+  <h3>
+    A Long or Short Title of Article
+  </h3>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  </p>
+  <ul>
+    <li>July 7</li>
+    <li>Science News</li>
+    <li>Wesley Bomar</li>
+  </ul>
+</article>
+
+<!-- TODO: Use a component (requires a plugin) -->
+<!--
+<article class="c-article-preview">
+  <img class="c-article-preview__media" src="…" alt="…" />
+  <h3 class="c-article-preview__title">
+    A Long or Short Title of Article
+  </h3>
+  <p class="c-article-preview__abstract">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  </p>
+  <time class="c-article-preview__date" datetime="2018-07-07">July 7</time>
+  <small class="c-article-preview__type">Science News</small>
+  <small class="c-article-preview__author">Wesley Bomar</small>
+</article>
+-->

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/u-empty.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/u-empty.css
@@ -1,0 +1,24 @@
+/*
+Empty
+
+Any element that must be treated as `:empty` (even if it is not).
+
+Examples:
+- `o-section.css`:
+  ```
+  .o-section--layout-halfway-split > :not(:empty),
+  .o-section--layout-halfway-split > :not(.u-empty) {
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: 50%;
+  }
+  .o-section--layout-halfway-split > :empty,
+  .o-section--layout-halfway-split > .u-empty { display: none; }
+  ```
+
+Styleguide Utilities.Empty
+*/
+
+.u-empty {
+  /* FAQ: This class should NOT have any styles on its own. It is a unique class that allows non-empty content to appear empty to TACC stylesheets that recognize it. Any TACC stylesheet selector that recognizes `:empty` elements should also recognize `u-empty` elements. */
+}

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -19,6 +19,7 @@
 
 /* OBJECTS */
 @import url("_imports/objects/o-site.css");
+@import url("_imports/objects/o-section.css");
 
 /* COMPONENTS */
 @import url("_imports/components/c-footer.css");
@@ -28,3 +29,4 @@
 
 /* TRUMPS */
 @import url("_imports/trumps/s-footer.css");
+@import url("_imports/trumps/u-empty.css");

--- a/taccsite_cms/static/site_shared/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_shared/css/src/_imports/settings/color.css
@@ -13,17 +13,30 @@
     --weak:     transparent instance
     --(…)light: lighter value
     --(…)dark:  darker value
+    --(…)rgb:   "R, G, B" value partial (ex. usage: `rgba(var(--...-rgb), 0.5)`)
 */
 
 :root {
     /* Primary (Text, Layout) */
+    /* WARNING: Do not use `-alt-` hues; "round up" to nearest color, instead */
     --global-color-primary--xx-light: #FFFFFF;
     --global-color-primary--x-light: #F4F4F4;
-    --global-color-primary--light: #C6C6C6;
-    --global-color-primary--normal: #AFAFAF;
-    --global-color-primary--dark: #707070;
+    --global-color-primary--x-light-rgb: 244, 244, 244;
+    --global-color-primary--light: #C6C6C6;/*
+        --global-color-primary--light-alt-2: #DBDBDB;
+        --global-color-primary--light-alt-2: #D8D8D8; */
+    --global-color-primary--normal: #AFAFAF;/*
+        --global-color-primary--normal-alt-2: #B7B7B7;
+        --global-color-primary--normal-alt-1: #9B9B9B; */
+    --global-color-primary--dark: #707070;/*
+        --global-color-primary--dark-alt-1: #696666;
+        --global-color-primary--dark-alt-2: #5F5C5C; */
     --global-color-primary--x-dark: #484848;
-    --global-color-primary--xx-dark: #222222; /* Unused. For header background, which is styled by CMS styles */
+    --global-color-primary--x-dark-rgb: 72, 72, 72;/*
+        --global-color-primary--x-dark-alt-1: #464646; */
+    --global-color-primary--xx-dark: #222222; /*
+        --global-color-primary--xx-dark-alt-1: #2C2C2B;
+        --global-color-primary--xx-dark-alt-2: #1C1B1B; */
 
     /* Distinct Hues */
     --global-color-accent--normal: #9D85EF;

--- a/taccsite_cms/static/site_shared/css/src/_imports/tools/x-center.css
+++ b/taccsite_cms/static/site_shared/css/src/_imports/tools/x-center.css
@@ -1,0 +1,55 @@
+/*
+Center
+
+Styles that allow centering for specific contexts.
+
+Caveat: Only generic solutions with limited side effects are supported. See "Reference" section for more solutions.
+
+Reference:
+- [Centering in CSS: A Complete Guide](https://css-tricks.com/centering-css-complete-guide/)
+
+.x-center--horz-inline                     - Horz. align any num of inline el's
+.x-center--horz-block                      - Horz. align any num of block el's
+.x-center--horz-block-multiple-children    - Horz. align multiple block el's
+.x-center--vert-inline-multiline--flex     - Vert. align multiple inline el's: Flex Method
+.x-center--both--flex                      - Vert. & Horz. align any el's
+
+Styleguide Tools.ExtendsAndMixins.Center
+*/
+
+/* Horizontal */
+
+/* Horizontal: Inline */
+.x-center--horz-inline {
+  text-align: center;
+}
+
+/* Horizontal: Block */
+.x-center--horz-block {
+  margin: 0 auto;
+}
+
+/* Horizontal: Block: Multiple Children */
+.x-center--horz-block-multiple-children {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+/* Vertical */
+
+/* Vertical: Inline: Multiple Lines - via Flexbox */
+.x-center--vert-inline-multiline--flex {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+/* Both */
+
+/* Both: Any - via Flexbox */
+.x-center--both--flex {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}


### PR DESCRIPTION
# Overview

- Create many new stylesheets.
- Update some related stylesheets.
- Import only two stylesheets into `site.css`\*
- Add to color settings.

> \* The rest are imported by [Frontera's temporary homepage template stylesheet](https://github.com/TACC/cms-site-resources/compare/task/GH-35-redesign-home-page).

# Issues

- GH-157

# Changes

- Import new object and utility into `site.css`.
- Add new object for sections.
- Add new scope styles for article lists.
- Add new mixins.
- Add new component for read more.
- Tweak existing section for site layout to support oddity of section's object.
- Add new utility to support hiding content with a paper trail that can lead to the context/reason.
- Add RGB versions of colors (and note color deviations to avoid).

# Testing

This is already tested in context via https://frontera-portal.tacc.utexas.edu/home-2021-03/ or (if launched) https://frontera-portal.tacc.utexas.edu/ and locally by developer with other related changes via https://github.com/TACC/Core-CMS/pull/174.