### PR TITLE
task/FP-982: Add `rebuild_index` haystack signal processor

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -460,6 +460,7 @@ SETTINGS_EXPORT_VARIABLE_NAME = 'settings'
 
 # Elasticsearch Indexing
 HAYSTACK_ROUTERS = ['aldryn_search.router.LanguageRouter',]
+HAYSTACK_SIGNAL_PROCESSOR = 'taccsite_cms.signal_processor.RealtimeSignalProcessor'
 ALDRYN_SEARCH_DEFAULT_LANGUAGE = 'en'
 ALDRYN_SEARCH_REGISTER_APPHOOK = True
 HAYSTACK_CONNECTIONS = {

--- a/taccsite_cms/signal_processor.py
+++ b/taccsite_cms/signal_processor.py
@@ -1,0 +1,20 @@
+from haystack.signals import BaseSignalProcessor
+from django.db import models
+from django.core.management import call_command
+from cms import signals
+
+
+class RealtimeSignalProcessor(BaseSignalProcessor):
+
+    def setup(self):
+        signals.post_publish.connect(self.handle_save)
+        signals.post_unpublish.connect(self.handle_save)
+        models.signals.post_delete.connect(self.handle_save)
+
+    def teardown(self):
+        signals.post_publish.disconnect(self.handle_save)
+        signals.post_unpublish.disconnect(self.handle_save)
+        models.signals.post_delete.disconnect(self.handle_save)
+
+    def handle_save(self, **kwargs):
+        call_command('rebuild_index', '--noinput')

--- a/taccsite_cms/signal_processor.py
+++ b/taccsite_cms/signal_processor.py
@@ -5,6 +5,15 @@ from cms import signals
 
 
 class RealtimeSignalProcessor(BaseSignalProcessor):
+    """
+    A signal processor to make a call to the Django Haystack
+    `rebuild_index` management command when a CMS document is
+    published, unpublished, or deleted.
+
+    Usage:
+        This signal processor hooks into Haystack via the
+        `HAYSTACK_SIGNAL_PROCESSOR` Django setting.
+    """
 
     def setup(self):
         signals.post_publish.connect(self.handle_save)

--- a/taccsite_cms/signal_processor.py
+++ b/taccsite_cms/signal_processor.py
@@ -8,7 +8,9 @@ class RealtimeSignalProcessor(BaseSignalProcessor):
     """
     A signal processor to make a call to the Django Haystack
     `rebuild_index` management command when a CMS document is
-    published, unpublished, or deleted.
+    published, unpublished, or deleted. This will allow the
+    ElasticSearch index to remain up-to-date with the latest
+    published CMS content when a user searches the site.
 
     Usage:
         This signal processor hooks into Haystack via the


### PR DESCRIPTION
### Overview
On a document publish, unpublish, or delete event, we want the cms index to rebuild. This adds a new signal processor that hooks into Haystack, and subclasses the [BaseSignalProcessor](https://django-haystack.readthedocs.io/en/master/signal_processors.html#default-basesignalprocessor) [class](https://github.com/django-haystack/django-haystack/blob/master/haystack/signals.py#L7).

### Notes:
An improvement would be to add/remove the document from the index instead of rebuilding, but I had trouble updating the index with the instance object returned from the `post_publish` signal. Since we have relatively few documents and activity on each cms, the occasional [rebuild_index](https://django-haystack.readthedocs.io/en/master/management_commands.html#rebuild-index) call will not be a resource burden.

### Testing:
1. Load the cms locally, and add an unpublished document.
2. Curl `localhost:9201/cms-dev-cms/_search` and verify the document is not in the index
3. Publish the document, curl `localhost:9201/cms-dev-cms/_search`, and verify the document is now there
4. Unpublish or delete the document, curl `localhost:9201/cms-dev-cms/_search`, and verify the document is gone