### PR TITLE
Noop: Delete outdated README.md

### DIFF
--- a/taccsite_cms/static/build/README.md
+++ b/taccsite_cms/static/build/README.md
@@ -1,9 +1,0 @@
-# TACC CMS - Built Files
-
-DO NOT ADD SOURCE FILES HERE!
-
-Files here are the output of the `npm run build` step.
-
-Files here will be picked up by the django `collectstatic` step and served.
-
-See project `README.md` at ["Static Files"](/README.md#static-files).


### PR DESCRIPTION
# Overview

Delete a `build/README.md` from an outdated and otherwise empty build directory.