### PR TITLE
hotfix/gh 157 frontera redesign gh 181 use global color vars

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/site.header.css
+++ b/taccsite_cms/static/site_cms/css/src/site.header.css
@@ -10,6 +10,8 @@
 /* NOTE: These are already imported in `site.css` */
 /* TODO: Find a way to be modular, but not redundant */
 @import url("_imports/settings/font.css");
+/* NOTE: Portal does not need this, because it has independent copy of these,
+         but the User Guides do not. This can be removed in Core-CMS PR #192 */
 @import url("../../../site_shared/css/src/_imports/settings/color.css");
 
 /* TRUMPS */

--- a/taccsite_cms/static/site_cms/css/src/site.header.css
+++ b/taccsite_cms/static/site_cms/css/src/site.header.css
@@ -7,9 +7,10 @@
 
 /* SETTINGS */
 
-/* NOTE: This is already imported in `site.css` */
+/* NOTE: These are already imported in `site.css` */
 /* TODO: Find a way to be modular, but not redundant */
 @import url("_imports/settings/font.css");
+@import url("../../../site_shared/css/src/_imports/settings/color.css");
 
 /* TRUMPS */
 


### PR DESCRIPTION
# Overview

Fix gray text in header on Frontera User Guide.

_I.e. fix bug introduced by https://github.com/TACC/Core-CMS/pull/181._

# Changes

1. __Fix__: Include global color variables (only needed for User Guide).\*

> \* This solution can be removed in PR #192.

# Testing

1. On https://dev.fronteraweb.tacc.utexas.edu/user-guide/, ensure header text is white, not gray.

# Screenshots

## Before

### Pre-Prod (Before)

<details open><summary>Pre-Prod Frontera Docs sans Fix</summary>

![Pre-Prod Frontera Docs sans Fix](https://user-images.githubusercontent.com/62723358/116310322-74ef9980-a76f-11eb-9617-6e57ca45ac70.png)

</details>
<details><summary>Pre-Prod Frontera Portal sans Fix</summary>

![Pre-Prod Frontera Portal sans Fix](https://user-images.githubusercontent.com/62723358/116310326-75883000-a76f-11eb-9cb4-28e7a834e0de.png)

</details>
<details><summary>Pre-Prod Frontera CMS sans Fix</summary>

![Pre-Prod Frontera CMS sans Fix](https://user-images.githubusercontent.com/62723358/116310316-73be6c80-a76f-11eb-8b9c-e2ad1bea6ec4.png)

</details>

### Local (Before)

<details open><summary>Local Frontera Docs sans Fix</summary>

![Local Frontera Docs sans Fix](https://user-images.githubusercontent.com/62723358/116310312-7325d600-a76f-11eb-82bc-2419292a1733.png)

</details>
<details><summary>Local Frontera Portal sans Fix</summary>

![Local Frontera Portal sans Fix](https://user-images.githubusercontent.com/62723358/116310329-7620c680-a76f-11eb-9aa7-723122e29504.png)

</details>
<details><summary>Local Frontera CMS sans Fix</summary>

![Local Frontera CMS sans Fix](https://user-images.githubusercontent.com/62723358/116310334-7751f380-a76f-11eb-8872-e7dc99a41f0b.png)

</details>

## After

### Dev (After)

<details open><summary>Dev Frontera Docs with Fix</summary>

![Dev Frontera Docs with Fix](https://user-images.githubusercontent.com/62723358/116310300-702ae580-a76f-11eb-8945-4da0a8277046.png)

</details>
<details><summary>Dev Frontera Portal with Fix</summary>

![Dev Frontera Portal with Fix](https://user-images.githubusercontent.com/62723358/116310305-715c1280-a76f-11eb-8043-ca61fb6d337b.png)

</details>
<details><summary>Dev Frontera CMS with Fix</summary>

![Dev Frontera CMS with Fix](https://user-images.githubusercontent.com/62723358/116310308-71f4a900-a76f-11eb-9a83-b42a6d4909f9.png)

</details>

### Local (After)

<details open><summary>Local Frontera Docs with Fix</summary>

![Local Frontera Docs with Fix](https://user-images.githubusercontent.com/62723358/116310315-73be6c80-a76f-11eb-9013-be6bf2cddea0.png)

</details>
<details><summary>Local Frontera Portal with Fix</summary>

![Local Frontera Portal with Fix](https://user-images.githubusercontent.com/62723358/116310331-76b95d00-a76f-11eb-8c81-99e25e2bf801.png)

</details>
<details><summary>Local Frontera CMS with Fix</summary>

![Local Frontera CMS with Fix](https://user-images.githubusercontent.com/62723358/116310336-7751f380-a76f-11eb-8eae-40c53aa23518.png)

</details>

# Notes

The search bar is bigger on Portal than in CMS and User Guide. This is true on production, pre-prod, dev, and local. It will be fixed separately from this hotfix.