### PR TITLE
GH-195: Clone Portal Nav

### DIFF
--- a/taccsite_cms/static/site_cms/js/nav_portal.js
+++ b/taccsite_cms/static/site_cms/js/nav_portal.js
@@ -1,8 +1,4 @@
-/* WARNING: This is merely a polished version of Frontera CMS rush code */
-/* SEE: https://gitlab.tacc.utexas.edu/wma-cms/frontera-cms/blob/4a0d198/taccsite_cms/static/site_cms/scripts/base.js#L86 */
-
-/* RFC: If we dynamically load isolated nav DOM from Portal, then do we need this solution? */
-/* SEE: https://github.com/TACC/Frontera-Portal/blob/d4c3895/server/portal/templates/includes/navigation.html#L78-L92 */
+/* WARNING: This code is deprecated. It must be removed AFTER GH-195/FP-1015. */
 
 /**
  * Load JSON from an endpoint, and perform success-dependent actions

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -9,7 +9,6 @@
 
 </ul>
 <script type="module">
-  import flagLinkActive from '/static/site_cms/js/modules/flagLinkActive.js';
   import * as importHTML from '/static/site_cms/js/modules/importHTML.js';
 
   const container = document.getElementById('portal-nav');

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -1,48 +1,18 @@
-{% load static %}
 {# @var className #}
 
 {# WARNING: Some markup is duplicated in other repositories #}
 {# SEE: https://confluence.tacc.utexas.edu/x/LoCnCQ #}
-{# NOTE: The `id` attr's are identified by a CMS script which changes markup #}
-<ul class="s-portal-nav  {{ className }}">
-  <div id="auth-menu" class="navbar-nav  d-none">
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle"
-        id="auth-menu-button"
-        href="#"
-        data-toggle="dropdown"
-        aria-haspopup="true"
-        aria-expanded="false"
-      >
-        <i class="fas fa-user-circle fa-lg  nav-icon"></i>
-        <span id="portal-username">Workbench</span>
-        <span class="sr-only">Toggle Dropdown</span>
-      </a>
-      <div class="dropdown-menu dropdown-menu-right"
-        aria-labelledby="auth-menu-button"
-        id="auth-menu-list">
-        {% for link in settings.PORTAL_AUTH_LINKS %}
-          <a id="auth-menu-link-{{ link.name }}"
-            class="dropdown-item"
-            href="{{ link.url }}"
-          >
-            <i class="fas fa-{{ link.icon }}  nav-icon"></i>
-            {{ link.text }}
-          </a>
-        {% endfor %}
-      </div>
-    </li>
-  </div>
-  <li id="unauth-menu" class="nav-item  d-none">
-    {% for link in settings.PORTAL_UNAUTH_LINKS %}
-      <a id="unauth-menu-link-{{ link.name }}"
-        class="nav-link"
-        href="{{ link.url }}"
-      >
-        <i class="fas fa-{{ link.icon }}  nav-icon"></i>
-        {{ link.text }}
-      </a>
-    {% endfor %}
-  </li>
+<ul class="s-portal-nav  {{ className }}" id="portal-nav">
+
+  <!-- All top-level CMS controlled nav elements handled here. -->
+  {# FAQ: Content populated via JavaScript, below #}
+
 </ul>
-<script src="{% static 'site_cms/js/nav_portal.js' %}"></script>
+<script type="module">
+  import flagLinkActive from '/static/site_cms/js/modules/flagLinkActive.js';
+  import * as importHTML from '/static/site_cms/js/modules/importHTML.js';
+
+  const container = document.getElementById('portal-nav');
+
+  importHTML.insertFromURL('/core/markup/nav', container);
+</script>

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -4,7 +4,7 @@
 {# SEE: https://confluence.tacc.utexas.edu/x/LoCnCQ #}
 <ul class="s-portal-nav  {{ className }}" id="portal-nav">
 
-  <!-- All top-level CMS controlled nav elements handled here. -->
+  <!-- All Portal-controlled nav elements handled here. -->
   {# FAQ: Content populated via JavaScript, below #}
 
 </ul>


### PR DESCRIPTION
# Status

Postponing merge to ensure no other Portal CMS accidentally deploys this without [TACC/Core-Portal PR #390](https://github.com/TACC/Core-Portal/pull/390).

- Must **only** be deployed **with _or_ after** [TACC/Core-Portal PR #390](https://github.com/TACC/Core-Portal/pull/390).
- Should be deployed **with** [taccaci/frontera-tech-docs PR #18](https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/18).

# Overview

**Replace** replicated Portal nav template code and unique update script **with** common code to load external markup.

# Related

## Issues

- Portal & Docs: [FP-1015](https://jira.tacc.utexas.edu/browse/FP-1015)
- CMS: GH-195

## PRs

- CMS: https://github.com/TACC/Core-CMS/pull/211
- Portal: https://github.com/TACC/Core-Portal/pull/390
- Docs: https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/17/fp-1015-clone-portal-nav

# Changes

- _Minor_: Add comment about deprecation of `nav_portal.js`.
- __New__: Replace Portal nav markup with use of `importHTML` to load nav from Portal.

# Testing

> __Notice__: Local testing should not be necessary if this and related code is deployed to Frontera Dev via [FP-1032](https://jira.tacc.utexas.edu/browse/FP-1032).

1. Test on [dev.fronteraweb.tacc.utexas.edu](https://dev.fronteraweb.tacc.utexas.edu/) or local environment ([instructions](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes)).
2. For CMS & Docs:
    1. If not logged in, then portal nav should load as "Log in" link.
3. For CMS & Portal & Docs:
    1. If logged in, then portal nav should load as "[username]" dropdown menu link.
    2. If logged in, then dropdown menu link should able able to open and close as it has.
    3. When loading page with no browser cache, portal nav *should __not__* load _too much_ later than search.\*
4. For Docs:
    1. Ensure header text is white, not gray.
5. For Portal:
    1. _(As of 2020-04-28, [this feature](https://github.com/TACC/Core-Portal/pull/388) is __not__ yet available to test on [dev.fronteraweb.tacc.utexas.edu](https://dev.fronteraweb.tacc.utexas.edu/).)_
    When logged in as staff, confirm "Onboarding Admin" is in the portal nav dropdown for staff ([how to become staff](https://github.com/TACC/Core-Portal/wiki/How-to-Set-Your-User-to-Staff)).

<details><summary>Footnotes</summary>

> \* Were it to load _too much_ later, then the user experience is affected. Loading less than a second later (if not at the same time or earlier) is acceptable (confirmed with Design via video comparison). The solution, were it to load _too much_ later, may be to animate its appearance such that it slides in from the right, pushing search to the left to make space for itself. Branch with animation solution is `task/FP-1015-GH-195-clone-portal-nav--animate-load`.

</details>

# Screenshots

## CMS

![Local CMS](https://user-images.githubusercontent.com/62723358/116322913-9c039680-a782-11eb-968f-855baf0b8641.png)

<details><summary>Videos</summary>

https://user-images.githubusercontent.com/62723358/116322399-a3767000-a781-11eb-9ae7-93325a5e1e44.mov

https://user-images.githubusercontent.com/62723358/116322400-a40f0680-a781-11eb-80bc-ee5b31d6418a.mov

</details>

## Portal

![Local Portal](https://user-images.githubusercontent.com/62723358/116322953-b0479380-a782-11eb-9e9f-e782f00f0d85.png)

<details><summary>Videos</summary>

https://user-images.githubusercontent.com/62723358/116322439-b6894000-a781-11eb-8328-3a4139836ab2.mov

https://user-images.githubusercontent.com/62723358/116322426-affac880-a781-11eb-8f3c-088677feb17a.mov

</details>

## Docs

![Local Docs](https://user-images.githubusercontent.com/62723358/116322919-9efe8700-a782-11eb-9882-f6baee2bbe11.png)

<details><summary>Videos</summary>

https://user-images.githubusercontent.com/62723358/116322455-bc7f2100-a781-11eb-8834-a7e6649ac95d.mov

https://user-images.githubusercontent.com/62723358/116322449-bab55d80-a781-11eb-80c5-4e9f6972c424.mov

</details>

## Onboarding Admin

> This new link requires (A) latest of Portal branch (since https://github.com/TACC/Core-Portal/pull/390/commits/f82b29b67bceb122fd4f48205cadaa4ba3998bc1) and (B) that [your user is staff](https://github.com/TACC/Core-Portal/wiki/How-to-Set-Your-User-to-Staff).

![Onboarding Admin](https://user-images.githubusercontent.com/62723358/116480218-8c4d8600-a846-11eb-973d-0d2b5757a0e2.png)

# Notes

Please mention discrepancies you may notice beyond the loading of the Portal nav, but unless it is related to the code change, such discrepancies will likely be recorded for another ticket to resolve.

<details><summary>Known Issues</summary>

- **CMS**: Different font for header text. _Caused by https://github.com/TACC/Core-CMS/pull/185._
- **Portal**: Larger search bar. _Cause unknown._
- **Docs**: Gray background on bottom of header before complete header load. _Cause unknown._

</details>
<details><summary>Existing Tickets</summary>

- https://github.com/TACC/Core-CMS/issues/62: Frontera/Core Header Differences
- https://github.com/TACC/Core-CMS/issues/101: Header Redesign
- https://github.com/TACC/Core-CMS/issues/12: Nav Component

</details>