### PR TITLE
Task/gh 101 header redesign  env variables (update)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
     "license": "MIT",
     "description": "The core CMS codebase for all new and updated TACC CMS sites.",
     "scripts": {
-        "prebuild": "python3 taccsite_cms/settings_to_json.py",
+        "prebuild": "npm run build:settings",
+        "prewatch": "npm run build:settings",
         "build": "npm run build:css",
         "build:css": "node postcss.js",
-        "watch": "npm-watch"
+        "watch": "npm-watch",
+        "build:settings": "python3 taccsite_cms/settings_to_json.py"
     },
     "// scripts": {
         "prebuild": "Export Django settings to JSON (for Node to use)",


### PR DESCRIPTION
# Overview

- Update support for `env()` (new commit for GH-191).
- Allow GH-101 to _continue to_ work off of important change in GH-191 to relevant files.

> This is the _second_ time I've merged in GH-191 code; the first was https://github.com/TACC/Core-CMS/pull/221.

# Changes, Testing, Etc.

See https://github.com/TACC/Core-CMS/pull/192 (as of b81f789).