### PR TITLE
GH-101: Navigation Bar (Sans Search & Portal Nav Button)

### DIFF
--- a/conf/css/.postcssrc.yml
+++ b/conf/css/.postcssrc.yml
@@ -16,6 +16,9 @@ plugins:
     features:
       custom-media-queries: true
       media-query-ranges: true
+      # RFE: Fix bug on the Internet so we can use these reliably
+      # SEE: https://github.com/postcss/postcss-custom-selectors/issues/40
+      custom-selectors: true
   cssnano:
     preset:
       - 'default'

--- a/conf/css/freeze_variables/.postcssrc.yml
+++ b/conf/css/freeze_variables/.postcssrc.yml
@@ -2,6 +2,9 @@ plugins:
   postcss-import:
     path:
       - './taccsite_cms/static/site_cms/css/src'
+  postcss-env-function:
+    importFrom:
+      - './taccsite_cms/static/site_cms/css/src/_themes/export.js'
   postcss-css-variables:
     preserve: 'computed'
     preserveAtRulesOrder: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "async": "^3.2.0",
                 "cssnano": "^4.1.10",
                 "dotenv": "^8.2.0",
+                "merge-lite": "^1.0.2",
                 "npm-watch": "^0.7.0",
                 "postcss-cli": "^7.1.2",
                 "postcss-css-variables": "^0.17.0",
@@ -1974,6 +1975,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
             "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+            "dev": true
+        },
+        "node_modules/merge-lite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/merge-lite/-/merge-lite-1.0.2.tgz",
+            "integrity": "sha512-28Q9aFRLzLCSp/2MLV49sbilBcCw7pIxq9YfOuX8+g/cMbPgYcAZgI0BLHnsb7ZRgvYOuaEGQPYJk8OWcGHk4A==",
             "dev": true
         },
         "node_modules/merge2": {
@@ -5939,6 +5946,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
             "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+            "dev": true
+        },
+        "merge-lite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/merge-lite/-/merge-lite-1.0.2.tgz",
+            "integrity": "sha512-28Q9aFRLzLCSp/2MLV49sbilBcCw7pIxq9YfOuX8+g/cMbPgYcAZgI0BLHnsb7ZRgvYOuaEGQPYJk8OWcGHk4A==",
             "dev": true
         },
         "merge2": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "async": "^3.2.0",
         "cssnano": "^4.1.10",
         "dotenv": "^8.2.0",
+        "merge-lite": "^1.0.2",
         "npm-watch": "^0.7.0",
         "postcss-cli": "^7.1.2",
         "postcss-css-variables": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
     "license": "MIT",
     "description": "The core CMS codebase for all new and updated TACC CMS sites.",
     "scripts": {
-        "prebuild": "python3 taccsite_cms/settings_to_json.py",
+        "prebuild": "npm run build:settings",
+        "prewatch": "npm run build:settings",
         "build": "npm run build:css",
         "build:css": "node postcss.js",
-        "watch": "npm-watch"
+        "watch": "npm-watch",
+        "build:settings": "python3 taccsite_cms/settings_to_json.py"
     },
     "// scripts": {
         "prebuild": "Export Django settings to JSON (for Node to use)",

--- a/taccsite_cms/static/site_cms/css/src/_imports/_tests/postcss-preset-env.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/_tests/postcss-preset-env.css
@@ -56,3 +56,33 @@ Styleguide _Test
 @media (--wide-window) {
   ._test{ background-color:red; }
 }
+
+
+/*! Custom Selectors */
+/* SEE: https://preset-env.cssdb.org/features#custom-selectors */
+
+/*! Goal: */
+article h1+p,article h2+p,article h3+p{color: #000;}
+
+/*! Test: */
+@custom-selector :--heading h1, h2, h3;
+
+article :--heading + p {
+  color: #000;
+}
+
+/*! Goal: */
+.nav-link:hover,.nav-link:focus,.nav-link:active{color:red;}
+
+/*! See: https://github.com/postcss/postcss-custom-selectors/issues/40 */
+
+/*! Test: */
+@custom-selector :--nav-link-hover  .nav-link:hover;
+@custom-selector :--nav-link-focus  .nav-link:focus;
+@custom-selector :--nav-link-active .nav-link:active;
+
+:--nav-link-hover,
+:--nav-link-focus,
+:--nav-link-active {
+  color: red;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
@@ -50,9 +50,7 @@ Styleguide Components.Branding
 /* Elements */
 
 .c-branding__link {
-  --height: 90%;
-
-  height: var(--height);
+  height: var(--height, 90%);
 }
 .c-branding__separator {
   /* To add border */

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
@@ -30,7 +30,7 @@ Styleguide Components.Branding
 :--for-docs .branding-header,
 :--for-portal .branding-header {
   /* To prevent zero-height element as it is loaded */
-  height: 40px;
+  height: env(--header-brandbar-height);
 
   color: var(--global-color-primary--xx-light);
   background-color: env(--header-bkgd-color);

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
@@ -26,7 +26,6 @@ Styleguide Components.Branding
 
   /* This prevents header bar resize when branding is dynamically added */
   /* CAVEAT: This is only for Portal and Docs which dynamically load content */
-  /* FAQ: Do not use `48.78px`, because Safari only accepts whole numbers */
   height: 40px;
 
   background-color: var(--global-color-primary--xx-dark);

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
@@ -25,17 +25,6 @@ Styleguide Components.Branding
   justify-content: center;
   align-items: center;
 }
-.c-branding,
-/* To force style on old markup before new markup dynamically replaces it */
-:--for-docs .branding-header,
-:--for-portal .branding-header {
-  /* To prevent zero-height element as it is loaded */
-  height: env(--header-brandbar-height);
-
-  color: var(--global-color-primary--xx-light);
-  background-color: var(--global-color-primary--xx-dark);
-  border-bottom: 1px solid var(--global-color-primary--normal);
-}
 
 
 /* A responsive column gap */

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
@@ -7,6 +7,7 @@ Markup: c-branding.twig.html
 
 Styleguide Components.Branding
 */
+@import url("_imports/tools/selectors.css");
 @import url("_imports/tools/media-queries.css");
 
 /* IDEA: Use multi-column (`column-*`) to simplify border, margin, separator */
@@ -23,15 +24,19 @@ Styleguide Components.Branding
   flex-direction: row;
   justify-content: center;
   align-items: center;
-
-  /* This prevents header bar resize when branding is dynamically added */
-  /* CAVEAT: This is only for Portal and Docs which dynamically load content */
+}
+.c-branding,
+/* To force style on old markup before new markup dynamically replaces it */
+:--for-docs .branding-header,
+:--for-portal .branding-header {
+  /* To prevent zero height branding bar as it is loaded */
   height: 40px;
 
-  background-color: var(--global-color-primary--xx-dark);
   color: var(--global-color-primary--xx-light);
+  background-color: env(--header-bkgd-color);
   border-bottom: 1px solid var(--global-color-primary--normal);
 }
+
 
 /* A responsive column gap */
 .c-branding__link:first-child .c-branding__image {

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
@@ -29,7 +29,7 @@ Styleguide Components.Branding
 /* To force style on old markup before new markup dynamically replaces it */
 :--for-docs .branding-header,
 :--for-portal .branding-header {
-  /* To prevent zero height branding bar as it is loaded */
+  /* To prevent zero-height element as it is loaded */
   height: 40px;
 
   color: var(--global-color-primary--xx-light);

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
@@ -33,7 +33,7 @@ Styleguide Components.Branding
   height: env(--header-brandbar-height);
 
   color: var(--global-color-primary--xx-light);
-  background-color: env(--header-bkgd-color);
+  background-color: var(--global-color-primary--xx-dark);
   border-bottom: 1px solid var(--global-color-primary--normal);
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-logo.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-logo.css
@@ -23,5 +23,5 @@ Styleguide Components.Logo
 /* Elements  */
 
 .c-logo__image {
-  /* … */
+  height: 100%;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-logo.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-logo.css
@@ -23,5 +23,8 @@ Styleguide Components.Logo
 /* Elements  */
 
 .c-logo__image {
+  /* To delegate height control to base/container */
   height: 100%;
+  /* To prevent length wider than (but allow narrower than) base/container */
+  max-width: 100%;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
@@ -18,6 +18,7 @@ Styleguide Elements.MainSectioningRoots
 html {
   /* Set base font but support user-defined browser font size */
   /* SEE: https://snook.ca/archives/html_and_css/font-size-with-rem */
+  /* TODO: Use 62.5% (requires recalculating NON-Frontera instances of `rem`) */
   font-size: 100%; /* 16px */
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/border.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/border.css
@@ -7,13 +7,17 @@
 /* Usage: `var(--global-border-width--normal)` */
 /* SEE: https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties */
 
+/* TODO: Replace use of `var(--global-border…)` with `env(--border…)` */
 :root {
-    --global-border-width--normal: 1px;
+    --global-border-width--normal: env(--border-width--normal);
     --global-border--normal: var(--global-border-width--normal) solid var(--global-color-primary--normal);
 
-    --global-border-width--thick: 2px;
+    --global-border-width--thick: env(--border-width--thick);
     --global-border--thick: var(--global-border-width--thick) solid var(--global-color-primary--normal);
 
-    --global-border-width--x-thick: 3px;
+    --global-border-width--x-thick: env(--border-width--x-thick);
     --global-border--x-thick: var(--global-border-width--x-thick) solid var(--global-color-primary--normal);
+
+    --global-border-width--xx-thick: env(--border-width--xx-thick);
+    --global-border--xx-thick: var(--global-border-width--xx-thick) solid var(--global-color-primary--normal);
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/font.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/font.css
@@ -55,14 +55,8 @@ Styleguide Settings.CustomProperties.Font
 
 
   /* Weight */
-  /* SEE: https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight */
-
-  /* NOTE: Long names to be consistent (opinions welcome) */
-  --global-font-weight--regular: 400;
-  --global-font-weight--medium: 500;
-  --global-font-weight--bold: 700;
-
-  /* NOTE: Short names to increase adoption (opinions welcome) */
+  /* TODO: Replace use of `var(--…)` with `env(--…)` for font weights */
+  /* WARNING: Deprecated! Do NOT use. Use `env(--…)` instead for font weights */
   --regular: 400;
   --medium: 500;
   --bold: 700;

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/selectors.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/selectors.css
@@ -5,7 +5,7 @@ For Other Sites
 
 These are global selectors to target known subsites.
 
-Usage: `:--for-portal .some-class { … }`
+Usage: `:--for-subsite .some-class { … }`
 
 Notice: These must be Tools (imported as needed) until native browser support, at which time they can become Settings (imported globally).
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/selectors.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/selectors.css
@@ -1,0 +1,19 @@
+/* DO NOT ADD STYLES HERE; ADD CUSTOM SELECTORS TO USE IN OTHER STYLESHEETS */
+
+/*
+For Other Sites
+
+These are global selectors to target known subsites.
+
+Usage: `:--for-portal .some-class { … }`
+
+Notice: These must be Tools (imported as needed) until native browser support, at which time they can become Settings (imported globally).
+
+Reference:
+- https://drafts.csswg.org/css-extensions/#custom-selectors
+
+Styleguide Tools.CustomSelectors.ForOtherSites
+*/
+@custom-selector :--for-cms    body > .o-site__body;
+@custom-selector :--for-portal body > .content;
+@custom-selector :--for-docs   .wy-body-for-nav;

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-arrow.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-arrow.css
@@ -1,0 +1,35 @@
+/*
+Arrow
+
+An arrow generator. Set variables for specific use cases.
+
+.x-arrow--right - Rightward (>)
+.x-arrow--left  - Leftward  (<)
+.x-arrow--up    - Upward    (^)
+.x-arrow--down  - Downward  (v)
+
+Styleguide Components.Branding
+*/
+
+/* SEE: https://www.w3schools.com/howto/howto_css_arrows.asp */
+%x-arrow {
+  --size: 5px;
+  --line: 2px;
+  --color: black;
+
+  display: inline-block;
+  vertical-align: middle;
+
+  /* arrow size */
+  padding: var(--size);
+
+  /* line width */
+  border-width: 0 var(--line) var(--line) 0;
+  border-style: solid;
+  border-color: var(--color);
+}
+
+%x-arrow--right { transform: rotate(-45deg); }
+%x-arrow--left  { transform: rotate(135deg); }
+%x-arrow--up    { transform: rotate(-135deg); }
+%x-arrow--down  { transform: rotate(45deg); }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/README.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/README.css
@@ -46,6 +46,47 @@ Styleguide Trumps.Scopes
 */
 
 /*
+For (Other Sites)
+
+For (Other Sites) styles are functional overrides and styles that are scoped to a specific subsite that shares elements with sibling subsites. These are meant to be used sparingly. The for-other-site styles are specifically intended for needs specific to Docs, CMS, or Portal.
+
+Guidelines:
+
+- For (Other Site) styles are especially rare, evaluate before creating.
+- For reliable results, use a consistent selector for each subsite.
+
+Rules:
+
+- The `!important` may be used.
+- All styles **must** have a comment.
+
+Styleguide Trumps.ForOtherSites
+*/
+
+/*
+Scopes
+
+Scope styles are functional overrides and styles that are scoped to a specific area. These are meant to be used sparingly. Examples of scopes are functional styles for third-party markup, WYSIWIG editor tags, form elements, components with a forced relationship.
+
+Reference:
+
+- [BEM with Namespaces: Scope Namespaces](https://csswizardry.com/2015/03/more-transparent-ui-code-with-namespaces/#scope-namespaces-s-)
+
+Guidelines:
+
+- Scopes are pretty rare, evaluate before creating.
+- A consistent way to author these in nested inside `.s-* {}`.
+
+Rules:
+
+- The `!important` may be used.
+- All overrides **must** have a comment.
+- Scope styles should have a comment.
+
+Styleguide Trumps.Scopes
+*/
+
+/*
 Utility
 
 Utility styles exist to overwrite other styles. They are seldom modified. Example use case is one-time use on modules that are not meant to be extended to have the desired behavior.

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
@@ -1,0 +1,29 @@
+/*
+Docs
+
+The [Core Docs](https://github.com/TACC/Core-Docs).
+
+Styleguide Trumps.ForOtherSites.Docs
+*/
+@import url("_imports/tools/selectors.css");
+
+:--for-docs nav.stickynav {
+  top: 95px;
+}
+:--for-docs #frontera-top-nav {
+  /* To ensure header has height for a layout resize script */
+  /* SEE: https://bitbucket.org/taccaci/frontera-tech-docs/src/429f05f/frontera_theme/base.html#lines-69 */
+  min-height: 95px;
+
+  /* WARNING: Unknown purpose! */
+  background-color: rgb(51, 51, 51);
+}
+
+/* To compensate for Docs not having `.form-inline` in _its_ Bootstrap 4.3.1 */
+:--for-docs .form-inline {
+  /* SEE: CMS https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/… */
+  /* SEE: Portal https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/… */
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
@@ -7,17 +7,24 @@ Styleguide Trumps.ForOtherSites.Docs
 */
 @import url("_imports/tools/selectors.css");
 
+/* Sidebar Nav Dependency on Header Height */
+/* FAQ: These stylesare intentionally overriden by Docs layout resize script */
+/* SEE: https://bitbucket.org/taccaci/frontera-tech-docs/src/429f05f/frontera_theme/base.html#lines-69 */
+
+/* To position Docs' sidebar nav at expected initial vertical location ASAP */
 :--for-docs nav.stickynav {
+  /* Override `top: 0` (in `theme.css`) */
   top: 95px;
 }
 :--for-docs #frontera-top-nav {
-  /* To ensure header has height for a layout resize script */
-  /* SEE: https://bitbucket.org/taccaci/frontera-tech-docs/src/429f05f/frontera_theme/base.html#lines-69 */
+  /* To ensure header has expected height before Docs AJAX content load */
   min-height: 95px;
 
   /* WARNING: Unknown purpose! */
   background-color: rgb(51, 51, 51);
 }
+
+
 
 /* To compensate for Docs not having `.form-inline` in _its_ Bootstrap 4.3.1 */
 :--for-docs .form-inline {

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
@@ -27,3 +27,9 @@ Styleguide Trumps.ForOtherSites.Docs
   flex-flow: row wrap;
   align-items: center;
 }
+
+/* To overwrite `img { max-width: 100% }` */
+:--for-docs .s-header img,
+:--for-docs .c-branding img {
+  max-width: unset;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
@@ -7,33 +7,37 @@ Styleguide Trumps.ForOtherSites.Docs
 */
 @import url("_imports/tools/selectors.css");
 
-/* Sidebar Nav Dependency on Header Height */
-/* FAQ: These stylesare intentionally overriden by Docs layout resize script */
-/* SEE: https://bitbucket.org/taccaci/frontera-tech-docs/src/429f05f/frontera_theme/base.html#lines-69 */
+
+
+/* Initialize Sidebar Position (for Dependency on Header Height) */
 
 /* To position Docs' sidebar nav at expected initial vertical location ASAP */
 :--for-docs nav.stickynav {
-  /* Override `top: 0` (in `theme.css`) */
-  top: 95px;
-}
-:--for-docs #frontera-top-nav {
-  /* To ensure header has expected height before Docs AJAX content load */
-  min-height: 95px;
-
-  /* WARNING: Unknown purpose! */
-  background-color: rgb(51, 51, 51);
+  /* To override `top: 0` (in `theme.css`) */
+  /* FAQ: This is an initial value that is re-calculated by a Docs script */
+  /* SEE: https://bitbucket.org/taccaci/frontera-tech-docs/src/429f05f/frontera_theme/base.html#lines-69 */
+  top: calc(env(--header-brandbar-height) + env(--header-navbar-height));
 }
 
 
+
+/* Overwrite Bootstrap (for Search Form in Header) */
 
 /* To compensate for Docs not having `.form-inline` in _its_ Bootstrap 4.3.1 */
 :--for-docs .form-inline {
-  /* SEE: CMS https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/… */
-  /* SEE: Portal https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/… */
+  /* The search bar expects these styles to be available */
+  /* SEE: CMS //maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap… */
+  /* SEE: Portal //stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap… */
+  /* SEE: Docs /src/5b223a5/docs/css/cms.bootstrap.4.3.1.css */
   display: flex;
+  /* NOTE: These are perceptibly ineffectual but consistent with Portal & CMS */
   flex-flow: row wrap;
   align-items: center;
 }
+
+
+
+/* Overwrite ReadTheDocs (for Images in Header) */
 
 /* To overwrite `img { max-width: 100% }` */
 :--for-docs .s-header img,

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -199,7 +199,7 @@ Styleguide Trumps.Scopes.Header
 
 /* Dropdown Menus */
 
-.dropdown-menu {
+.s-header .dropdown-menu {
   padding: 7px 0 0;
   margin: unset; /* undo Bootstrap */
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -15,11 +15,14 @@ Markup: s-header.html.twig
 
 Styleguide Trumps.Scopes.Header
 */
+@import url("_imports/tools/selectors.css");
 @import url("_imports/tools/x-arrow.css");
 
-@custom-selector :--in-cms    body > .o-site__body;
-@custom-selector :--in-portal body > .content;
-@custom-selector :--in-docs   body > #frontera-top-nav-container;
+
+
+
+
+/* Container */
 
 .s-header {
   /* FAQ: Other flex styles come from Bootstrap via `.navbar` */
@@ -42,7 +45,7 @@ Styleguide Trumps.Scopes.Header
   -moz-osx-font-smoothing: grayscale;
 }
 /* To overwrite Portal which loads Bootstrap after header styles */
-:--in-portal .s-header {
+:--for-portal .s-header {
   padding: 0 calc(16px + 20px);
 }
 
@@ -91,7 +94,7 @@ Styleguide Trumps.Scopes.Header
 
 /* FAQ: Each relies on the parent also stretching */
 .s-header,
-:--in-portal .s-header,
+:--for-portal .s-header,
 .s-header .navbar-collapse {
   align-items: stretch;
 }
@@ -148,14 +151,14 @@ Styleguide Trumps.Scopes.Header
 
 @media (--wide-and-above) {
   .s-header .navbar-nav .nav-link,
-  :--in-portal .s-header .navbar-nav .nav-link {
+  :--for-portal .s-header .navbar-nav .nav-link {
     padding-right: 1.25em; /* intent is 15px padding for 12px font */
     padding-left: 1.25em; /* intent is 15px padding for 12px font */
   }
 }
 @media (--wide-and-below) {
   .s-header .navbar-nav .nav-link,
-  :--in-portal .s-header .navbar-nav .nav-link {
+  :--for-portal .s-header .navbar-nav .nav-link {
     padding-right: 0.5em; /* intent is just very narrow (dev design) */
     padding-left: 0.5em; /* intent is just very narrow (dev design) */
   }
@@ -179,6 +182,9 @@ Styleguide Trumps.Scopes.Header
 }
 
 
+
+
+
 /* Search */
 
 /* GH-101: Retain search design until Wes works on it */
@@ -195,6 +201,8 @@ Styleguide Trumps.Scopes.Header
 
   margin-left: 12px;
 }
+
+
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -25,15 +25,6 @@ Styleguide Trumps.Scopes.Header
 /* Container */
 
 .s-header {
-  /* FAQ: Other flex styles come from Bootstrap via `.navbar` */
-  align-items: stretch;
-
-  /* Make horizontal padding match the horizontal content buffer in Portal */
-  /* FAQ: The `calc()` keeps track of disparate source of space values */
-  /*      - 16px is 1rem from Portal (via `#sidebar .nav-content`) */
-  /*      - 20px is from Portal (via `.nav-link`) */
-  padding: 0 calc(16px + 20px);
-
   background-color: env(--header-bkgd-color);
 
   font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
@@ -44,28 +35,51 @@ Styleguide Trumps.Scopes.Header
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-/* To overwrite Portal which loads Bootstrap after header styles */
+/* To give cross-site header padding that respects Portal-only visual balance */
+.s-header,
+/* To overwrite Docs' Bootstrap which is unexpectedly loaded after this */
+/* RFE: Load Docs Bootstrap before CMS CSS (test, revisit relevant hacks) */
+:--for-docs .s-header,
+/* To overwrite Portal's Bootstrap which is mistakenly loaded after this */
+/* RFE: Load Portal Bootstrap before CMS CSS (test, revisit relevant hacks) */
 :--for-portal .s-header {
+  /* To align logo (whole image not just visible pixels) with Portal sidebar */
+  /* FAQ: The calc() retains values from disparate styles in Portal */
+  /* FAQ: The calc() is calculated at build time, so we may be verbose */
+  /*      - 16px is 1rem from Portal `#sidebar .nav-content` */
+  /*      - 20px is from Portal `.nav-link` */
   padding: 0 calc(16px + 20px);
 }
 
-/* On wide viewport, prevent header resize from dynamic content */
-@media (--wide-and-above) {
-  /* CAVEAT: This is only for Portal and Docs which dynamically load content */
-  .s-header {
-    height: 55px;
-  }
+/* To stretch elements as tall as parent (`height: 100%` for flex row items) */
+.s-header,
+/* To overwrite Docs' Bootstrap which is unexpectedly loaded after this */
+/* RFE: Load Docs Bootstrap before CMS CSS (test, revisit relevant hacks) */
+:--for-docs .s-header,
+/* To overwrite Portal's Bootstrap which is mistakenly loaded after this */
+/* RFE: Load Portal Bootstrap before CMS CSS (test, revisit relevant hacks) */
+:--for-portal .s-header,
+/* To propogate styles through extra wrapper (of Bootstrap-driven mobile nav) */
+.s-header .navbar-collapse {
+  align-items: stretch;
 }
 
-
+/* To prevent zero-height element as it is loaded */
+/* FAQ: The zero-height fix is most obvious on Portal/Docs or slow network */
+/* To prevent extra height from FOUC during Portal/Docs AJAX content load */
+/* To set nav height, but not constrain height of opened mobile nav */
+/* FAQ: Set height of descendants, but not of CMS and Portal and mobile navs */
+.s-header .c-logo,
+.s-header .navbar-toggler,
+.s-header tacc-search-bar {
+  height: 55px;
+}
 
 
 
 /* Logo */
 
 .s-header .c-logo {
-  height: 100%;
-
   /* To align position of first CMS nav link with Portal "Dashboard" header */
   /* NOTE: Each portal should set this value based on its image width */
   --offset: 10px;
@@ -87,17 +101,6 @@ Styleguide Trumps.Scopes.Header
 }
 
 
-
-
-
-/* Navigation */
-
-/* FAQ: Each relies on the parent also stretching */
-.s-header,
-:--for-portal .s-header,
-.s-header .navbar-collapse {
-  align-items: stretch;
-}
 
 
 
@@ -151,6 +154,8 @@ Styleguide Trumps.Scopes.Header
 
 @media (--wide-and-above) {
   .s-header .navbar-nav .nav-link,
+  /* To overwrite Portal's Bootstrap which is mistakenly loaded after this */
+  /* RFE: Load Portal Bootstrap before CMS CSS (test, revisit relevant hacks) */
   :--for-portal .s-header .navbar-nav .nav-link {
     padding-right: 1.25em; /* intent is 15px padding for 12px font */
     padding-left: 1.25em; /* intent is 15px padding for 12px font */
@@ -158,6 +163,8 @@ Styleguide Trumps.Scopes.Header
 }
 @media (--wide-and-below) {
   .s-header .navbar-nav .nav-link,
+  /* To overwrite Portal's Bootstrap which is mistakenly loaded after this */
+  /* RFE: Load Portal Bootstrap before CMS CSS (test, revisit relevant hacks) */
   :--for-portal .s-header .navbar-nav .nav-link {
     padding-right: 0.5em; /* intent is just very narrow (dev design) */
     padding-left: 0.5em; /* intent is just very narrow (dev design) */

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -223,7 +223,11 @@ Styleguide Trumps.Scopes.Header
 
 
 
-/* Dropdown Menus */
+/* Dropdowns */
+
+
+
+/* Menu */
 
 .s-header .dropdown-menu {
   padding: 7px 0 0;
@@ -233,22 +237,28 @@ Styleguide Trumps.Scopes.Header
   border: env(--border-width--normal) solid env(--header-accent-color);
   border-radius: unset; /* undo Bootstrap */
 }
+
+
+
+/* Item */
+
 /* FAQ: Selector specificty trumps Bootstrap, so no need for `:hover` (etc.) */
 .s-header .dropdown-item {
   --horz-pad: 11px;
   padding: 5px var(--horz-pad) 6px;
 
-  color: env(--header-text-color);
   border-left: env(--border-width--x-thick) solid transparent;
 
   font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
   font-weight: env(--medium);
 }
+/* To create line between each item */
 .s-header .dropdown-item + .dropdown-item {
   box-shadow:
     0px calc(-1 * (1px + var(--horz-pad))) 0px calc(-1 * var(--horz-pad))
     env(--header-bkgd-color);
 }
+
 .s-header .dropdown-item.active,
 .s-header .dropdown-item:active,
 .s-header .dropdown-item:focus,
@@ -258,6 +268,14 @@ Styleguide Trumps.Scopes.Header
   box-shadow: none;
 }
 
+.s-header .dropdown-item,
+/* To overwrite Bootstrap (see "Portal & Docs Selectors") */
+:--for-portal .s-header .dropdown-item.active,
+:--for-portal .s-header .dropdown-item:active,
+:--for-portal .s-header .dropdown-item:focus,
+:--for-portal .s-header .dropdown-item:hover {
+  color: env(--header-text-color);
+}
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -104,7 +104,7 @@ Styleguide Trumps.Scopes.Header
 
 
 
-/* Links */
+/* Nav Links */
 
 /* RFE: Fix bug on the Internet so we can use these reliably */
 /* SEE: https://github.com/postcss/postcss-custom-selectors/issues/40 */
@@ -186,6 +186,17 @@ Styleguide Trumps.Scopes.Header
 .s-header .dropdown-toggle[aria-expanded="false"]::after {
   @extend %x-arrow--down;
   margin-top: -0.4em;
+}
+
+
+
+
+
+/* Dropdown Menus */
+
+.dropdown-menu {
+  /* To overwrite Bootstrap's `1rem` */
+  font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -15,125 +15,178 @@ Markup: s-header.html.twig
 
 Styleguide Trumps.Scopes.Header
 */
+@import url("_imports/tools/x-arrow.css");
 
-/* WARNING: NO-R/EM: Until Frontera CMS drops Bootstrap 3.7.1 (for old design)…
-            No `em` nor `rem` allowed, because they aren't consitently reliable.
-            - On Frontera CMS, `1rem` = `10px` and `body { font-size: 15px }`
-            - On any other CMS, `1rem` = `16px` (browser default). */
+@custom-selector :--in-cms    body > .o-site__body;
+@custom-selector :--in-portal body > .content;
+@custom-selector :--in-docs   body > #frontera-top-nav-container;
 
 .s-header {
-  font-size: 16px; /* NO-R/EM: Overwrite `bootstrap.3.3.7.css` */
+  /* FAQ: Other flex styles come from Bootstrap via `.navbar` */
+  align-items: stretch;
 
-  /* FAQ: Asssigning this font is only necessary for the User Guide,
-          because it has a different `body` font. Otherwise, this style
-          repeats the CMS and Portal `body` font. But, with this style,
-          the header may be moved to a future page/site without losing font */
-  /* TODO: Find a way to be safe, but not redundant */
-  font-family: var(--global-font-family);
+  /* Make horizontal padding match the horizontal content buffer in Portal */
+  /* FAQ: The `calc()` keeps track of disparate source of space values */
+  /*      - 16px is 1rem from Portal (via `#sidebar .nav-content`) */
+  /*      - 20px is from Portal (via `.nav-link`) */
+  padding: 0 calc(16px + 20px);
+
+  background-color: env(--header-bkgd-color);
+
+  font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+  font-weight: bold;
+  font-family: env(--header-font-family);
+
   /* Copied from Portal (via `body`) */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+/* To overwrite Portal which loads Bootstrap after header styles */
+:--in-portal .s-header {
+  padding: 0 calc(16px + 20px);
+}
 
-  /* To have border not show, ensure value equals that of `--bkgd-color` */
-  border-bottom: 1px solid env(--header-major-border-color);
+/* On wide viewport, prevent header resize from dynamic content */
+@media (--wide-and-above) {
+  /* CAVEAT: This is only for Portal and Docs which dynamically load content */
+  .s-header {
+    height: 55px;
+  }
 }
 
 
-/* Affiliation */
-
-/* SEE: taccsite_cms/static/site_cms/css/src/_imports/branding_logos.css */
 
 
 
 /* Logo */
 
 .s-header .c-logo {
-  /* To align position of first CMS nav link with Portal "Dashboard" header */
-  /* WARNING: If Portal UI changes, then these styles may need to change */
-  min-width: 176px;
-  margin-right: 16px; /* NO-R/EM: 1rem (from Bootstrap via `.navbar-brand`) */
-  padding: 0;
+  height: 100%;
 
+  /* To align position of first CMS nav link with Portal "Dashboard" header */
+  /* NOTE: Each portal should set this value based on its image width */
+  --offset: 10px;
+  margin-right: var(--offset);
+
+  /* FAQ: In case image does not load and browser shows alt text */
   color: env(--header-text-color);
-  /* text-decoration: none; *//* already provided by Bootstrap */
 }
+/* Overwrite Bootstrap */
+.s-header .c-logo.navbar-brand {
+  padding-top: unset;
+  padding-bottom: unset;
+  display: unset;
+}
+
 .s-header .c-logo__image {
-  height: 40px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
+
+
 
 
 
 /* Navigation */
 
-/* On wide viewport, prevent header resize from dynamic content */
-/* CAVEAT: This is only for Portal and Docs which dynamically load content */
-@media only screen and (min-width: 1201px) {
-  .s-header.navbar {
-    height: 50px;
-  }
+/* FAQ: Each relies on the parent also stretching */
+.s-header,
+:--in-portal .s-header,
+.s-header .navbar-collapse {
+  align-items: stretch;
 }
 
-.s-header.navbar {
-  /* Make horizontal padding match the horizontal content buffer in Portal */
-  /* FAQ: The `calc()` keeps track of disparate source of space values */
-  /* `16px` = `1rem` from Portal (via `#sidebar .nav-content`) */
-  /* `20px` from Portal (via `.nav-link`) */
-  --nav-padding-horz: calc(16px + 20px);
-  --nav-padding-vert: 5px;
 
-  background-color: env(--header-bkgd-color);
-  padding: var(--nav-padding-vert) var(--nav-padding-horz);
-}
 
-/* Navigation: Links */
+/* Links */
+
+/* RFE: Fix bug on the Internet so we can use these reliably */
+/* SEE: https://github.com/postcss/postcss-custom-selectors/issues/40 */
+/*
+@custom-selector :--nav-link-hover  .s-header .nav-link:hover;
+@custom-selector :--nav-link-focus  .s-header .nav-link:focus;
+@custom-selector :--nav-link-active .s-header .nav-link:active;
+@custom-selector :--nav-link-current
+  .s-header .nav-item.active .nav-link,
+  .s-header .nav-item.dropdown.show .nav-link;
+*/
 
 .s-header .nav-link {
-  --line-height: 24px;
-  --border-width: 4px;
-  --border-offset: calc(var(--nav-padding-vert) - var(--border-width));
-  --border-color: rgb(213, 181, 124);
+  height: 100%;
 
-  /* The nav vertical padding does not match the link border, so the alignment
-     of the link border with the bottom of the header is off by small amount */
-  position: relative;
-  top: var(--border-offset);
-
-  line-height: var(--line-height);
-
-  /* If link text uses 2 lines, header grows taller (but it must not do so) */
+  display: flex;
+  align-items: center;
+  /* FAQ: If link text uses 2 lines, header grows taller, but it must not */
   white-space: nowrap;
+
+  color: env(--header-text-color);
+}
+.s-header .nav-link:hover,
+.s-header .nav-link:active,
+.s-header .nav-item.active .nav-link,
+.s-header .nav-item.dropdown.show .nav-link {
+  background-color: env(--header-link-bkgd-color);
 }
 .s-header .nav-link:hover,
 .s-header .nav-link:focus,
 .s-header .nav-link:active,
-.s-header .nav-item.active .nav-link {
-  border-width: 0 0 var(--border-width);
-  border-style: solid;
-  border-color: var(--border-color);
-  margin-bottom: calc( var(--border-width) * -1 );
+.s-header .nav-item.active .nav-link,
+.s-header .nav-item.dropdown.show .nav-link {
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid env(--header-accent-color);
 }
-/* HACK: Using an ID selector, because Bootstrap has overspecific selectors */
-#s-header .nav-link,
-/* HACK: Support `span.nav-link` having children `a` and `a.dropdown-toggle-split` */
-#s-header .nav-link > a {
+/* Overwrite Bootstrap */
+.s-header.navbar-dark .navbar-nav .nav-link,
+.s-header.navbar-dark .navbar-nav .nav-link:focus,
+.s-header.navbar-dark .navbar-nav .nav-link:hover {
   color: env(--header-text-color);
-  /* text-decoration: none; *//* already provided by Bootstrap */
+}
+.s-header .nav-link {
+  padding-top: unset;
+  padding-bottom: unset;
 }
 
-/* Navigation: Links: Responsive Design */
-
-/* Tweak Bootstrap `_nav.scss` (which selects via `navbar-expand-` class) */
-.s-header[class*="navbar-expand-"] .navbar-nav .nav-link {
-  padding-top: 8px; /* NO-R/EM: 0.5rem (from Bootstrap) */
-  padding-bottom: 8px; /* NO-R/EM: 0.5rem (from Bootstrap) */
-
-  padding-right: 14px; /* NO-R/EM: .875rem (overwrite Bootstrap) */
-  padding-left: 14px; /* NO-R/EM: .875rem (overwrite Bootstrap) */
+@media (--wide-and-above) {
+  .s-header .navbar-nav .nav-link,
+  :--in-portal .s-header .navbar-nav .nav-link {
+    padding-right: 1.25em; /* intent is 15px padding for 12px font */
+    padding-left: 1.25em; /* intent is 15px padding for 12px font */
+  }
+}
+@media (--wide-and-below) {
+  .s-header .navbar-nav .nav-link,
+  :--in-portal .s-header .navbar-nav .nav-link {
+    padding-right: 0.5em; /* intent is just very narrow (dev design) */
+    padding-left: 0.5em; /* intent is just very narrow (dev design) */
+  }
 }
 
+.s-header .dropdown-toggle::after {
+  @extend %x-arrow;
+
+  --size: 4px;
+  --line: 1px;
+  --color: env(--header-text-color);
+  margin-left: 8px;
+}
+.s-header .dropdown-toggle[aria-expanded="true"]::after {
+  @extend %x-arrow--up;
+  margin-top: 0.6em;
+}
+.s-header .dropdown-toggle[aria-expanded="false"]::after {
+  @extend %x-arrow--down;
+  margin-top: -0.4em;
+}
 
 
 /* Search */
+
+/* GH-101: Retain search design until Wes works on it */
+.s-header .s-search-bar,
+.s-header .s-search-bar::part(input),
+.s-header .s-search-bar::part(button) {
+  font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+}
 
 /* Create a line between search bar and login */
 /* FAQ: The line should only exist if both elements are present */
@@ -149,6 +202,6 @@ Styleguide Trumps.Scopes.Header
 
 /* HACK: Using FontAwesome as placeholder */
 .s-header [class*="fa-"] {
-    width: 27px; /* NO-R/EM: 1.25em (from Portal `.fa`—FP-228 will deprecate it) */
+    width: 27px; /* (from Portal `.fa` 1.25em which FP-636 will deprecate) */
     text-align: center;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -131,8 +131,6 @@ Styleguide Trumps.Scopes.Header
   align-items: center;
   /* FAQ: If link text uses 2 lines, header grows taller, but it must not */
   white-space: nowrap;
-
-  color: env(--header-text-color);
 }
 .s-header .nav-link:hover,
 .s-header .nav-link:active,

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -28,7 +28,7 @@ Styleguide Trumps.Scopes.Header
   background-color: env(--header-bkgd-color);
 
   font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
-  font-weight: bold;
+  font-weight: env(--bold);
   font-family: env(--header-font-family);
 
   /* Copied from Portal (via `body`) */
@@ -143,8 +143,8 @@ Styleguide Trumps.Scopes.Header
 .s-header .nav-link:active,
 .s-header .nav-item.active .nav-link,
 .s-header .nav-item.dropdown.show .nav-link {
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid env(--header-accent-color);
+  border-top: env(--border-width--xx-thick) solid transparent;
+  border-bottom: env(--border-width--xx-thick) solid env(--header-accent-color);
 }
 /* Overwrite Bootstrap */
 .s-header.navbar-dark .navbar-nav .nav-link,
@@ -200,9 +200,38 @@ Styleguide Trumps.Scopes.Header
 /* Dropdown Menus */
 
 .dropdown-menu {
-  /* To overwrite Bootstrap's `1rem` */
-  font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+  padding: 7px 0 0;
+  margin: unset; /* undo Bootstrap */
+
+  background-color: env(--header-link-bkgd-color);
+  border: env(--border-width--normal) solid env(--header-accent-color);
+  border-radius: unset; /* undo Bootstrap */
 }
+/* FAQ: Selector specificty trumps Bootstrap, so no need for `:hover` (etc.) */
+.s-header .dropdown-item {
+  --horz-pad: 11px;
+  padding: 5px var(--horz-pad) 6px;
+
+  color: env(--header-text-color);
+  border-left: env(--border-width--x-thick) solid transparent;
+
+  font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+  font-weight: env(--medium);
+}
+.s-header .dropdown-item + .dropdown-item {
+  box-shadow:
+    0px calc(-1 * (1px + var(--horz-pad))) 0px calc(-1 * var(--horz-pad))
+    env(--header-bkgd-color);
+}
+.s-header .dropdown-item.active,
+.s-header .dropdown-item:active,
+.s-header .dropdown-item:focus,
+.s-header .dropdown-item:hover {
+  border-left-color: env(--header-accent-color);
+  background-color: env(--header-bkgd-color);
+  box-shadow: none;
+}
+
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -11,6 +11,11 @@ Styles for elements within a header that has third-party code:
 - a subset of Bootstrap 3.3.7
   (for CMS body content, can affect navigation)
 
+Portal & Docs Selectors:
+
+- To select old markup by using subsite-specific selectors, some styles target Portal or Docs. This was necessary because markup changed in CMS during GH-101, but Portal and Docs markup was not updated. If Portal and Docs markup matches that of CMS, then these selectors need not be so specific for _this_ purpose.
+- To overwrite Bootstrap by using extra-specific selectors, some styles target Portal or Docs. This was necessary because Bootstrap on both subsites load _after_ these styles (thus took precedence). If we load Bootstrap styles before CMS styles, then these selectors need not be so specific for _this_ purpose.
+
 Markup: s-header.html.twig
 
 Styleguide Trumps.Scopes.Header
@@ -18,13 +23,16 @@ Styleguide Trumps.Scopes.Header
 @import url("_imports/tools/selectors.css");
 @import url("_imports/tools/x-arrow.css");
 
+/* RFE: Make Portal & Docs markup match CMS (see "Portal & Docs Selectors") */
+/* RFE: Load Bootstrap before CMS stylesheets (see "Portal & Docs Selectors") */
 
 
 
 
-/* Container */
 
-.s-header {
+/* Nav Bar */
+
+.s-header.navbar {
   background-color: env(--header-bkgd-color);
 
   font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
@@ -35,14 +43,12 @@ Styleguide Trumps.Scopes.Header
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-/* To give cross-site header padding that respects Portal-only visual balance */
-.s-header,
-/* To overwrite Docs' Bootstrap which is unexpectedly loaded after this */
-/* RFE: Load Docs Bootstrap before CMS CSS (test, revisit relevant hacks) */
-:--for-docs .s-header,
-/* To overwrite Portal's Bootstrap which is mistakenly loaded after this */
-/* RFE: Load Portal Bootstrap before CMS CSS (test, revisit relevant hacks) */
-:--for-portal .s-header {
+
+/* To give cross-site padding that respects Portal-specific visual balance */
+.s-header.navbar,
+/* To overwrite Bootstrap (see "Portal & Docs Selectors") */
+:--for-docs .s-header.navbar,
+:--for-portal .s-header.navbar {
   /* To align logo (whole image not just visible pixels) with Portal sidebar */
   /* FAQ: The calc() retains values from disparate styles in Portal */
   /* FAQ: The calc() is calculated at build time, so we may be verbose */
@@ -51,14 +57,11 @@ Styleguide Trumps.Scopes.Header
   padding: 0 calc(16px + 20px);
 }
 
-/* To stretch elements as tall as parent (`height: 100%` for flex row items) */
-.s-header,
-/* To overwrite Docs' Bootstrap which is unexpectedly loaded after this */
-/* RFE: Load Docs Bootstrap before CMS CSS (test, revisit relevant hacks) */
-:--for-docs .s-header,
-/* To overwrite Portal's Bootstrap which is mistakenly loaded after this */
-/* RFE: Load Portal Bootstrap before CMS CSS (test, revisit relevant hacks) */
-:--for-portal .s-header,
+/* To stretch elements as tall as parent */
+.s-header.navbar,
+/* To overwrite Bootstrap (see "Portal & Docs Selectors") */
+:--for-docs .s-header.navbar,
+:--for-portal .s-header.navbar,
 /* To propogate styles through extra wrapper (of Bootstrap-driven mobile nav) */
 .s-header .navbar-collapse {
   align-items: stretch;
@@ -74,6 +77,27 @@ Styleguide Trumps.Scopes.Header
 .s-header tacc-search-bar {
   height: env(--header-navbar-height);
 }
+
+
+
+
+
+/* Branding */
+
+.s-header.c-branding,
+/* To apply style to old markup (see "Portal & Docs Selectors") */
+/* NOTE: The old markup is dynamically replaced by new markup from CMS */
+:--for-docs .branding-header,
+:--for-portal .branding-header {
+  /* To prevent zero-height element as it is loaded */
+  height: env(--header-brandbar-height);
+
+  color: var(--global-color-primary--xx-light);
+  background-color: var(--global-color-primary--xx-dark);
+  border-bottom: 1px solid var(--global-color-primary--normal);
+}
+
+
 
 
 
@@ -95,7 +119,7 @@ Styleguide Trumps.Scopes.Header
   /* FAQ: In case image does not load and browser shows alt text */
   color: env(--header-text-color);
 }
-/* Overwrite Bootstrap */
+/* To overwrite bootstrap */
 .s-header .c-logo.navbar-brand {
   padding-top: unset;
   padding-bottom: unset;
@@ -146,21 +170,24 @@ Styleguide Trumps.Scopes.Header
   border-top: env(--border-width--xx-thick) solid transparent;
   border-bottom: env(--border-width--xx-thick) solid env(--header-accent-color);
 }
-/* Overwrite Bootstrap */
-.s-header.navbar-dark .navbar-nav .nav-link,
-.s-header.navbar-dark .navbar-nav .nav-link:focus,
-.s-header.navbar-dark .navbar-nav .nav-link:hover {
-  color: env(--header-text-color);
-}
+
+/* To overwrite Bootstrap */
 .s-header .nav-link {
   padding-top: unset;
   padding-bottom: unset;
 }
+/* FAQ: Comment out `.navbar-dark` to obviate "Portal & Docs Selectors" here */
+/* FAQ: On CMS, the `.navbar-dark` is a descendant of `.s-header` */
+.s-header/* .navbar-dark */ .nav-link,
+.s-header/* .navbar-dark */ .nav-link:focus,
+.s-header/* .navbar-dark */ .nav-link:hover {
+  color: env(--header-text-color) !important;
+}
 
+/* To set less space between nav links when screen is narrow */
 @media (--wide-and-above) {
   .s-header .navbar-nav .nav-link,
-  /* To overwrite Portal's Bootstrap which is mistakenly loaded after this */
-  /* RFE: Load Portal Bootstrap before CMS CSS (test, revisit relevant hacks) */
+  /* To overwrite Bootstrap (see "Portal & Docs Selectors") */
   :--for-portal .s-header .navbar-nav .nav-link {
     padding-right: 1.25em; /* intent is 15px padding for 12px font */
     padding-left: 1.25em; /* intent is 15px padding for 12px font */
@@ -168,8 +195,7 @@ Styleguide Trumps.Scopes.Header
 }
 @media (--wide-and-below) {
   .s-header .navbar-nav .nav-link,
-  /* To overwrite Portal's Bootstrap which is mistakenly loaded after this */
-  /* RFE: Load Portal Bootstrap before CMS CSS (test, revisit relevant hacks) */
+  /* To overwrite Bootstrap (see "Portal & Docs Selectors") */
   :--for-portal .s-header .navbar-nav .nav-link {
     padding-right: 0.5em; /* intent is just very narrow (dev design) */
     padding-left: 0.5em; /* intent is just very narrow (dev design) */

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -80,10 +80,17 @@ Styleguide Trumps.Scopes.Header
 /* Logo */
 
 .s-header .c-logo {
-  /* To align position of first CMS nav link with Portal "Dashboard" header */
-  /* NOTE: Each portal should set this value based on its image width */
-  --offset: 10px;
-  margin-right: var(--offset);
+  /* To allow projects to set this value, but let Core implement it */
+  --width: auto;
+  width: var(--width);
+
+  /* To prevent zero-width element as it is loaded */
+  /* To align position of first CMS nav link with Portal section headers */
+  min-width: 190px; /* CAVEAT: Only works for logos narrow enough to fit */
+
+  /* To allow projects to set this value, but let Core implement it */
+  --space-after-logo-before-nav: 0;
+  margin-right: var(--space-after-logo-before-nav); /* overwrites Bootstrap */
 
   /* FAQ: In case image does not load and browser shows alt text */
   color: env(--header-text-color);

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -105,16 +105,15 @@ Styleguide Trumps.Scopes.Header
 
 .s-header .c-logo {
   /* To allow projects to set this value, but let Core implement it */
-  --width: auto;
-  width: var(--width);
+  width: var(--width, auto);
 
   /* To prevent zero-width element as it is loaded */
   /* To align position of first CMS nav link with Portal section headers */
   min-width: 190px; /* CAVEAT: Only works for logos narrow enough to fit */
 
+  /* To overwrite Bootstrap */
   /* To allow projects to set this value, but let Core implement it */
-  --space-after-logo-before-nav: 0;
-  margin-right: var(--space-after-logo-before-nav); /* overwrites Bootstrap */
+  margin-right: var(--space-after-logo-before-nav, 0);
 
   /* FAQ: In case image does not load and browser shows alt text */
   color: env(--header-text-color);

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -28,6 +28,17 @@ Styleguide Trumps.Scopes.Header
 
 
 
+/* Generic */
+
+/* .s-header, *//* FAQ: Already inherited from body */
+/* To match CMS line-height */
+:--for-docs .s-header,
+:--for-portal .s-header {
+  line-height: 1.4;
+}
+
+
+
 
 
 /* Nav Bar */

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -194,23 +194,54 @@ Styleguide Trumps.Scopes.Header
   color: env(--header-text-color) !important;
 }
 
+
+
+/* Responsive Design */
+
+.s-header .navbar-nav .nav-link,
+/* To overwrite Bootstrap (see "Portal & Docs Selectors") */
+:--for-portal .s-header .navbar-nav .nav-link {
+  padding-right: var(--space-between-horz, 0);
+  padding-left: var(--space-between-horz, 0);
+}
+
 /* To set less space between nav links when screen is narrow */
+/* " (sans Portal) */
+@media (--medium-and-above) {
+  /* To have 15px of space for 12px font */
+  .s-header:not(.is-on-portal) .nav-link { --space-between-horz: 1.25em; }
+}
+@media (--medium-and-below) {
+  /* To have "narrower" space (designed by dev) */
+  .s-header:not(.is-on-portal) .nav-link { --space-between-horz: 0.5em; }
+}
+/* " (with Portal) */
 @media (--wide-and-above) {
-  .s-header .navbar-nav .nav-link,
-  /* To overwrite Bootstrap (see "Portal & Docs Selectors") */
-  :--for-portal .s-header .navbar-nav .nav-link {
-    padding-right: 1.25em; /* intent is 15px padding for 12px font */
-    padding-left: 1.25em; /* intent is 15px padding for 12px font */
-  }
+  /* To have 15px of space for 12px font */
+  .s-header.is-on-portal .nav-link,
+  /* To apply style to old markup (see "Portal & Docs Selectors") */
+  /* TODO: Hardcode `is-on-portal` in Portal & Docs markup */
+  :--for-docs .s-header .nav-link,
+  :--for-portal .s-header .nav-link { --space-between-horz: 1.25em; }
 }
 @media (--wide-and-below) {
-  .s-header .navbar-nav .nav-link,
-  /* To overwrite Bootstrap (see "Portal & Docs Selectors") */
-  :--for-portal .s-header .navbar-nav .nav-link {
-    padding-right: 0.5em; /* intent is just very narrow (dev design) */
-    padding-left: 0.5em; /* intent is just very narrow (dev design) */
-  }
+  /* To have "narrower" space (designed by dev) */
+  .s-header.is-on-portal .nav-link,
+  /* To apply style to old markup (see "Portal & Docs Selectors") */
+  /* TODO: Hardcode `is-on-portal` in Portal & Docs markup */
+  :--for-docs .s-header .nav-link,
+  :--for-portal .s-header .nav-link { --space-between-horz: 0.5em; }
 }
+
+
+
+
+
+/* Dropdowns */
+
+
+
+/* Toggle */
 
 .s-header .dropdown-toggle::after {
   @extend %x-arrow;
@@ -228,12 +259,6 @@ Styleguide Trumps.Scopes.Header
   @extend %x-arrow--down;
   margin-top: -0.4em;
 }
-
-
-
-
-
-/* Dropdowns */
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -72,7 +72,7 @@ Styleguide Trumps.Scopes.Header
 .s-header .c-logo,
 .s-header .navbar-toggler,
 .s-header tacc-search-bar {
-  height: 55px;
+  height: env(--header-navbar-height);
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.twig.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.twig.html
@@ -1,7 +1,6 @@
 <!-- FAQ:
 
-This is the markup of the #s-header, as of 2020-03-11,
-from https://frontera-portal.tacc.utexas.edu/. It has:
+This markup has:
 
 - Bootstrap class names
   (also via `./s-portal-nav.html`)
@@ -16,7 +15,7 @@ from https://frontera-portal.tacc.utexas.edu/. It has:
 - illegally-nested markup (`ul > div > li`)
   (only via `./s-portal-nav.html`)
 -->
-<nav id="s-header" class="s-header  navbar navbar-expand-lg navbar-dark">
+<nav class="s-header  navbar navbar-expand-lg navbar-dark">
 
   <a class="navbar-brand" href="/">
     <img

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
@@ -9,16 +9,3 @@ Markup: s-portal-nav.html
 
 Styleguide Trumps.Scopes.PortalNav
 */
-
-/* WARNING: NO-R/EM: Until Frontera CMS drops Bootstrap 3.7.1 (for old design)…
-            No `em` nor `rem` allowed, because they aren't consitently reliable.
-            - On Frontera CMS, `1rem` = `10px` and `body { font-size: 15px }`
-            - On any other CMS, `1rem` = `16px` (browser default). */
-
-.s-portal-nav {
-  /* Override `.navbar` */
-  text-transform: none;
-}
-.s-portal-nav .dropdown-menu {
-  font-size: 16px; /* NO-R/EM: 1rem (from Bootstrap via `.dropdown-menu`) */
-}

--- a/taccsite_cms/static/site_cms/css/src/_themes/constants.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/constants.json
@@ -1,0 +1,15 @@
+{
+  "// METADATA FOR HUMANS": "",
+  "format": "https://github.com/csstools/postcss-preset-env#importfrom",
+  "name": "constants",
+
+  "environment-variables": {
+
+    "// HEADER": "",
+    "--header-font-family": "Roboto, sans-serif",
+    "--header-accent-color": "#877453",
+    "--header-brandbar-height": "40px",
+    "--header-navbar-height": "55px"
+
+  }
+}

--- a/taccsite_cms/static/site_cms/css/src/_themes/constants.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/constants.json
@@ -9,7 +9,20 @@
     "--header-font-family": "Roboto, sans-serif",
     "--header-accent-color": "#877453",
     "--header-brandbar-height": "40px",
-    "--header-navbar-height": "55px"
+    "--header-navbar-height": "55px",
+
+    "// BORDER": "",
+    "--border-width--normal": "1px",
+    "--border-width--thick": "2px",
+    "--border-width--x-thick": "3px",
+    "--border-width--xx-thick": "4px",
+
+    "// FONT": "",
+    "// FONT WEIGHT": "A word-based shortcut for font weights",
+    "--light": 300,
+    "--regular": 400,
+    "--medium": 500,
+    "--bold": 700
 
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_themes/export.js
+++ b/taccsite_cms/static/site_cms/css/src/_themes/export.js
@@ -1,6 +1,7 @@
 /**
  * Export appropriate theme file based on settings value
  */
+const merge = require('merge-lite');
 const rootPath = __dirname + '/../../../../../../';
 const settings = require( rootPath + 'taccsite_cms/settings.json');
 const theme = settings.THEME || 'default';
@@ -26,8 +27,12 @@ function requireOrElse(modulePath, callback) {
   }
 }
 
-const data = requireOrElse(`./theme.${theme}.json`, () => {
+const constants = require(`./constants.json`);
+const themeData = requireOrElse(`./theme.${theme}.json`, () => {
   console.error(`Unable to find '${__dirname}/theme.${theme}.json'`);
 });
+
+/* To prevent a theme from overwriting a constant, merge constants onto theme */
+let data = merge( themeData, constants );
 
 module.exports = data;

--- a/taccsite_cms/static/site_cms/css/src/_themes/theme.default.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/theme.default.json
@@ -6,11 +6,12 @@
   "environment-variables": {
 
     "// HEADER": "",
+    "--header-font-family": "Roboto, sans-serif",
+    "--header-accent-color": "#877453",
     "--header-text-color": "var(--global-color-primary--xx-light)",
     "--header-bkgd-color": "var(--global-color-primary--xx-dark)",
-    "--header-minor-border-color": "var(--global-color-primary--normal)",
-    "// To 'hide' border by setting its color to match background color": "",
-    "--header-major-border-color": "var(--global-color-primary--xx-dark)"
+    "--header-link-bkgd-color": "#313131",
+    "--header-minor-border-color": "var(--global-color-primary--normal)"
 
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_themes/theme.default.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/theme.default.json
@@ -1,13 +1,11 @@
 {
-  "//": "Metadata for humans",
+  "// METADATA FOR HUMANS": "",
   "format": "https://github.com/csstools/postcss-preset-env#importfrom",
   "name": "default",
 
   "environment-variables": {
 
     "// HEADER": "",
-    "--header-font-family": "Roboto, sans-serif",
-    "--header-accent-color": "#877453",
     "--header-text-color": "var(--global-color-primary--xx-light)",
     "--header-bkgd-color": "var(--global-color-primary--xx-dark)",
     "--header-link-bkgd-color": "#313131",

--- a/taccsite_cms/static/site_cms/css/src/_themes/theme.has-dark-logo.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/theme.has-dark-logo.json
@@ -6,10 +6,12 @@
   "environment-variables": {
 
     "// HEADER": "",
-    "--header-text-color": "var(--global-color-primary--x-dark)",
+    "--header-font-family": "Roboto, sans-serif",
+    "--header-accent-color": "#877453",
+    "--header-text-color": "var(--global-color-primary--xx-dark)",
     "--header-bkgd-color": "var(--global-color-primary--x-light)",
-    "--header-minor-border-color": "var(--global-color-primary--normal)",
-    "// To show border between only the light header and content below it": "",
-    "--header-major-border-color": "var(--global-color-primary--normal)"
+    "--header-link-bkgd-color": "#D8D8D8",
+    "--header-minor-border-color": "var(--global-color-primary--normal)"
+
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_themes/theme.has-dark-logo.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/theme.has-dark-logo.json
@@ -1,13 +1,11 @@
 {
-  "//": "Metadata for humans",
+  "// METADATA FOR HUMANS": "",
   "format": "https://github.com/csstools/postcss-preset-env#importfrom",
   "name": "has-dark-logo",
 
   "environment-variables": {
 
     "// HEADER": "",
-    "--header-font-family": "Roboto, sans-serif",
-    "--header-accent-color": "#877453",
     "--header-text-color": "var(--global-color-primary--xx-dark)",
     "--header-bkgd-color": "var(--global-color-primary--x-light)",
     "--header-link-bkgd-color": "#D8D8D8",

--- a/taccsite_cms/static/site_cms/css/src/site.header.css
+++ b/taccsite_cms/static/site_cms/css/src/site.header.css
@@ -7,11 +7,11 @@
 
 /* SETTINGS */
 
-/* CAVEAT: This is already imported in `site.css`, but necessary here to
-           override Portal (which also loads `site.header.css`), so font
-           variables are unfortunately overwritten 1x in CMS, 2x in Portal */
+/* CAVEAT: These are already imported in `site.css`, but necessary here
+           for Portal & Docs, thus font variables are unfortunately overwritten 1x in CMS, 2x in Portal (which has its own settings CSS) */
 /* TODO: Find a way to be modular, but not redundant; perhaps `env()` vars */
 @import url("_imports/settings/font.css");
+@import url("_imports/settings/color.css");
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/site.header.css
+++ b/taccsite_cms/static/site_cms/css/src/site.header.css
@@ -39,3 +39,5 @@
 @import url("_imports/trumps/s-header.css");
 @import url("_imports/trumps/s-portal-nav.css");
 @import url("_imports/trumps/s-cms-nav.css");
+/* Specific to Subsites */
+@import url("_imports/trumps/for-docs.header.css");

--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -7,33 +7,38 @@
 {% for child in children %}
 <li class="nav-item{% if child.selected or child.ancestor %} active{% endif %}{% if child.children %} dropdown{% endif %}">
   {% if child.children %}
-  <span class="nav-link">
-    <a href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">
-      {{ child.get_menu_title|safe }}
-      {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
-    </a>
+  <a
+    href="#"
+    class="nav-link  dropdown-toggle dropdown-toggle-split"
+    data-toggle="dropdown"
+    aria-haspopup="true"
+    aria-expanded="false"
+  >
+    {{ child.get_menu_title|safe }}
+    {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
+    <span class="sr-only">Toggle Dropdown</span>
+  </a>
+  <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown">
+    {% comment %}
+    Bootstrap4 does not support submenus, so levels > 1 can't be handled be the main_menu tag and therfore
+    recursion has been dropped intentionally. Read https://github.com/twbs/bootstrap/pull/6342 for details.
+    {% endcomment %}
+    {% for grandchild in child.children %}
     <a
-      href=""
-      class="dropdown-toggle dropdown-toggle-split"
-      data-toggle="dropdown"
-      aria-haspopup="true"
-      aria-expanded="false">
-      <span class="sr-only">Toggle Dropdown</span>
+      class="dropdown-item{% if grandchild.selected %} active{% endif %}"
+      href="{{ grandchild.attr.redirect_url|default:grandchild.get_absolute_url }}"
+      role="menuitem"
+    >
+      {{ grandchild.get_menu_title|safe }}
+      {% if grandchild.selected %}<span class="sr-only">(current)</span>{% endif %}
     </a>
-    <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown">
-      {% comment %}
-      Bootstrap4 does not support submenus, so levels > 1 can't be handled be the main_menu tag and therfore
-      recursion has been dropped intentionally. Read https://github.com/twbs/bootstrap/pull/6342 for details.
-      {% endcomment %}
-      {% for grandchild in child.children %}
-      <a class="dropdown-item{% if grandchild.selected %} active{% endif %}" href="{{ grandchild.attr.redirect_url|default:grandchild.get_absolute_url }}" role="menuitem">
-        {{ grandchild.get_menu_title|safe }}
-        {% if grandchild.selected %}<span class="sr-only">(current)</span>{% endif %}
-      </a>
-      {% endfor %}
-  </span>
+    {% endfor %}
+  </div>
   {% else %}
-  <a class="nav-link" href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">
+  <a
+    class="nav-link"
+    href="{{ child.attr.redirect_url|default:child.get_absolute_url }}"
+  >
     {{ child.get_menu_title|safe }}
     {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
   </a>

--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -8,7 +8,7 @@
 <li class="nav-item{% if child.selected or child.ancestor %} active{% endif %}{% if child.children %} dropdown{% endif %}">
   {% if child.children %}
   <a
-    href="#"
+    href=""
     class="nav-link  dropdown-toggle dropdown-toggle-split"
     data-toggle="dropdown"
     aria-haspopup="true"

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -2,11 +2,11 @@
 {# SEE: https://confluence.tacc.utexas.edu/x/LoCnCQ #}
 {# FAQ: Extra lines exist to ease CMS/Portal/Guide template comparison #}
 
-<!-- Sponsor Logos -->
+<!-- Branding Bar -->
 {% include "header_branding.html" %}
 
 <!-- Navigation Bar -->
-<nav id="s-header" class="s-header  navbar {% if settings.PORTAL %}navbar-expand-xl{% else %}navbar-expand-lg{% endif %} navbar-dark">
+<nav id="header-navbar" class="s-header  navbar {% if settings.PORTAL %}navbar-expand-xl{% else %}navbar-expand-lg{% endif %} navbar-dark">
   <!-- Portal Logo -->
   {% include "header_logo.html" %}
 

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -6,7 +6,7 @@
 {% include "header_branding.html" %}
 
 <!-- Navigation Bar -->
-<nav id="header-navbar" class="s-header  navbar {% if settings.PORTAL %}navbar-expand-xl{% else %}navbar-expand-lg{% endif %} navbar-dark">
+<nav id="header-navbar" class="s-header  navbar navbar-dark {% if settings.PORTAL %}navbar-expand-lg  is-on-portal{% else %}navbar-expand-md{% endif %}">
   <!-- Portal Logo -->
   {% include "header_logo.html" %}
 

--- a/taccsite_cms/templates/header_branding.html
+++ b/taccsite_cms/templates/header_branding.html
@@ -2,7 +2,7 @@
 {% load staticfiles custom_portal_settings %}
 
 {% with settings.BRANDING as brands %}
-<div id="header-branding" class="c-branding  {{className}}">
+<div id="header-branding" class="s-header  c-branding  {{className}}">
   {# DEBUG: #}{# <code>{{ brands|first }}</code> #}
   {% for brand in brands %}
     {% with name=brand|index:0 filename=brand|index:1 selectors=brand|index:2 targeturl=brand|index:3 targetType=brand|index:4 accessibility=brand|index:5 corstype=brand|index:6 visibility=brand|index:7 %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,11 @@ mdn-data@2.0.4:
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
+merge-lite@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/merge-lite/-/merge-lite-1.0.2.tgz"
+  integrity sha512-28Q9aFRLzLCSp/2MLV49sbilBcCw7pIxq9YfOuX8+g/cMbPgYcAZgI0BLHnsb7ZRgvYOuaEGQPYJk8OWcGHk4A==
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"


### PR DESCRIPTION
# Overview

Redesign the nav dropdowns and the CMS nav.

> The search bar and portal nav button have not been redesigned yet. Their final design _might_ change.

# Changes

Summary:

- Support [custom selectors](https://preset-env.cssdb.org/features#custom-selectors).
- For variable freezing, support [custom environment variables](https://preset-env.cssdb.org/features#environment-variables).
- Install [`merge-lite`](https://www.npmjs.com/package/merge-lite).
- Add `arrow` mixin to CSS.
- Document the kinds of "Trumps" that are in our CSS.
- Add stylesheet `trumps/for-docs.header.css`.
- Rewrite `trumps/s-header.css`.
- Add Theme "constants".
- Fix docs header colors by loading colors in `site.header.css`.

Bug Fixes:

- #55
- #29
- #129

<details><summary>Complete List</summary>

- __New__: Support [custom selectors](https://preset-env.cssdb.org/features#custom-selectors).
    - So we can scope selectors to subsite, and change in one place how we scope.
- __New__: For variable freezing, support [custom environment variables](https://preset-env.cssdb.org/features#environment-variables).
    - Because [`site.tacc-search-bar.css` uses `border.css`](https://github.com/TACC/Core-CMS/blob/task/GH-101-header-redesign--navigation-bar/taccsite_cms/static/site_cms/css/src/freeze_variables/site.tacc-search-bar.css#L12) which [now uses `env()`](https://github.com/TACC/Core-CMS/pull/225/files#diff-4d9754208794dfa86a1a04ddb51ba61cc5537c63ce2be30f19c0f44d523cbca4).¹
- __New__: Install [`merge-lite`](https://www.npmjs.com/package/merge-lite) to support deep merge of objects.
    - So we can [extend themes with constants](https://github.com/TACC/Core-CMS/pull/225/files#diff-d3df923b54d1e3e3fb1d256ac8518d98a25d1d36c73db19830b0d5d6bf6b6090).
    - Because [ES6/ES7 does **not** support deep merge](https://stackoverflow.com/q/27936772/11817077) and lodash is more than we need.
- _Minor_: Add test case for [custom environment variables](https://preset-env.cssdb.org/features#environment-variables).
- _Minor_: Move header-specific branding styles from branding component to header scope.
- _Minor_: Use [fallback values for custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/var()#custom_properties_with_fallbacks_for_use_when_the_property_has_not_been_set).
- _Minor_: Control logo image width and height within component styles._
- _Minor_: Add comment about work involved for conversion of font size to 62.5%._
- _Minor_: Deprecate "global variables" for font weight in favor of custom environment variables._
- __New__: Add `arrow` mixin.
    - So we can create customizable arrows with CSS.
- __Docs__: Describe the kinds of "Trumps" that are in our CSS.
    - Because I never documented "Scopes" and have now added "For (Other Sites)"
- __New__: Add stylesheet `trumps/for-docs.header.css`.
    - So we can add styles to manage Docs-specific side effects of header.
- __New__: Rewrite `trumps/s-header.css`.
    - Because this is where the bulk of the header styles are.
- _Minor_ Remove `s-header` ID (because `s-header` class will be used twice).
- _Minor_: Remove now-useless code from `trumps/s-portal-nav.css`.
- __New__: Add Theme "constants".
    - So we can share immutable values across themes.
- _Minor_: Add new theme property `--header-link-bkgd-color`.
- __Fix__: Load colors in `site.header.css`.
    - So Docs has access to the color variables used in header.
- __Fix__: Do not support CMS menu nav link + dropdown (#129).
    - Because supporting it retains complexity in markup and styles.
- _Minor_: Improve responsiveness of mobile nav (because now-smaller nav text allows this).
- _Minor_: Update `taccsite_custom:frontera-cms` based on these Core changes.

¹ I expect to _completely **replace**_ `freeze_variables` feature with `env()` in whichever GH-101 PR updates the search bar.

</details>

# Testing

## Simple UI Testing

<details><summary>Light/Dark Navbar</summary>

> **Prerequisite**: CMS menu has dropdowns (by having nested links set to display in menu). 

1. Build CSS with CMS setting/secret `_THEME` set to `None`.
1. Confirm dropdown styles match [CMS-Common Components > Navigation Light-mode](https://xd.adobe.com/view/b37b291a-7798-4814-90f3-7ac63c48a3e0-e628/screen/fb70e7c7-f8ad-40a8-ad2d-f211fa36c05f/specs/).
1. Build CSS with CMS setting/secret `_THEME` set to `'has-dark-logo'`.
1. Confirm dropdown styles match [CMS-Common Components > Navigation Dark-mode](https://xd.adobe.com/view/b37b291a-7798-4814-90f3-7ac63c48a3e0-e628/screen/38e3fb7c-0b56-4b76-9648-162d2fa71a97/specs/).

</details>

<details><summary>Responsiveness</summary>

> **Prerequisite**: These steps assume you are testing on a CMS with an attached Portal. Without a Portal, see "Detailed UI Testing" at "Responsiveness".

> **Known Issue**: For Portal and Docs, responsiveness will _not_ have changed unless testing on their branch `task/GH-101-header-redesign`.

While resizing width of window:

- Search field _may_ shrink (but it must always have a border all the way around).
- Space between CMS Nav items _may_ grow or shrink.
- Space between Nav Bar and edge of screen _must **not**_ shrink.
- Given [Frontera](https://frontera-portal.tacc.utexas.edu/) nav link count and text:
    - CMS Nav items _must **not**_ wrap.
    - CMS Nav items text _must **not**_ be cut off.
    - CMS Nav items text _may_ be truncated with an ellipses.
- Logo _must **not**_ shrink.
- Portal nav link (not logged in) _must **not**_ shrink.
- Portal menu toggle (logged in) _must **not**_ shrink.
- Search button _should **not**_ shrink, furthermore:
    - Search button text _must **not**_ wrap.
    - Search button text _should **not**_ be cut off.
    - Search button text _may_ be truncated with an ellipses.

</details>


## Detailed UI Testing

<details><summary><em>Hide/Show Sections</em></summary>

### Responsiveness

<details><summary>CMS (with Portal)</summary>

> **Known Issue**: 
For Portal and Docs, these steps _will **differ**_ on Portal/Docs without their branch `task/GH-101-header-redesign`.
>
> <details><summary>Expected Difference</summary>
> 
> 1. Load site with page wider than 1200px.
> 1. Resize page to narrower than 1200px.
> 1. Confirm mobile nav is triggered.
> </details>

1. Load site with page wider than 1200px.
1. Note distance between CMS nav links.
1. Resize page to narrower than 1200px.
1. Confirm distance between CMS nav links is shorter.
1. Resize page to narrower than 992px.
1. Confirm mobile nav is triggered.

</details>
<details><summary>CMS (stand-alone)</summary>

1. Load site with page wider than 992px.
1. Note distance between CMS nav links.
1. Resize page to narrower than 992px.
1. Confirm distance between CMS nav links is shorter.
1. Resize page to narrower than 768px.
1. Confirm mobile nav is triggered.

</details>

### Logo & CMS Nav Alignment

<details><summary>CMS (with Portal)</summary>

- The CMS Nav is aligned to the _left_.
- The Nav Bar's left and right padding is equal. When comparing, be aware:
    - Portal Nav link has internal padding that is _not_ part of Nav Bar's right padding.
    - Logo image may have internal space that is _not_ part of Nav Bar's left padding.
    - Portal Nav link design is _not_ complete in this PR.
- The Logo image's left side is aligned with Portal sidebar text's left side.
- The CMS Nav first link text's left side is aligned with Portal section header text's left side.

</details>
<details><summary>CMS (stand-alone)</summary>

- The CMS Nav is aligned to the _right_.
- The Nav Bar's left and right padding is equal. When comparing, be aware:
    - CMS Nav link has internal padding that is _not_ part of Nav Bar's right padding.
    - Logo image may have internal space that is _not_ part of Nav Bar's left padding.
- The Logo image's left side is aligned with Portal sidebar text's left side.
- The CMS Nav first link text's left side is aligned with Portal section header text's left side.

</details>

### Light/Dark Navbar

Perform "Simple UI Testing" at "Light/Dark Navbar", but review items on the checklist for each theme.

<details><summary>Checklist</summary>

- navbar height
- logo dimension & spacing:
    - logo height
    - vertical space between logo and top and bottom of navbar¹
- top-level nav link states:
    - (default)
    - `:hover`
    - `:focus`
    - `.active` (on page)²
    - `:active` (mid-click)²
- dropdown menu border
- dropdown menu toggle states:
    - menu closed
    - menu opened
- dropdown menu link states:
    - (default)
    - `:hover`
    - `:focus`
    - `.active` (on page)²
    - `:active` (mid-click)²
- portal nav
    - link when not logged in
    - menu toggle when logged in


¹ The logo image may have its own internal space ([annotated screenshot](https://user-images.githubusercontent.com/62723358/118589346-d64ecb00-b765-11eb-8220-841d0d3ecd02.png), [example logo file](https://cep.tacc.utexas.edu/static/site_cms/img/org_logos/portal.png)).

² Not explicit in design, but should match `:hover` state.
</details>