### PR TITLE
Task/gh 101 header redesign  portal nav

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -61,11 +61,9 @@ Styleguide Trumps.Scopes.Header
 :--for-docs .s-header.navbar,
 :--for-portal .s-header.navbar {
   /* To align logo (whole image not just visible pixels) with Portal sidebar */
-  /* FAQ: The calc() retains values from disparate styles in Portal */
-  /* FAQ: The calc() is calculated at build time, so we may be verbose */
-  /*      - 16px is 1rem from Portal `#sidebar .nav-content` */
-  /*      - 20px is from Portal `.nav-link` */
-  padding: 0 calc(16px + 20px);
+  padding: 0 0 0 calc(
+    env(--portal-sidebar-padding) + env(--portal-navlink-padding)
+  );
 }
 
 /* To stretch elements as tall as parent */
@@ -115,16 +113,13 @@ Styleguide Trumps.Scopes.Header
 /* Logo */
 
 .s-header .c-logo {
-  /* To allow projects to set this value, but let Core implement it */
-  width: var(--width, auto);
-
   /* To prevent zero-width element as it is loaded */
   /* To align position of first CMS nav link with Portal section headers */
-  min-width: 190px; /* CAVEAT: Only works for logos narrow enough to fit */
+  min-width: calc(190px - 25px); /* CAVEAT: Only works on narrow-enough logos */
 
   /* To overwrite Bootstrap */
   /* To allow projects to set this value, but let Core implement it */
-  margin-right: var(--space-after-logo-before-nav, 0);
+  margin-right: var(--space-after-logo-before-nav, 25px);
 
   /* FAQ: In case image does not load and browser shows alt text */
   color: env(--header-text-color);
@@ -198,6 +193,7 @@ Styleguide Trumps.Scopes.Header
 
 /* Responsive Design */
 
+/* FAQ: The overspecific `.navbar-nav` selector allows overwrite of Bootstrap */
 .s-header .navbar-nav .nav-link,
 /* To overwrite Bootstrap (see "Portal & Docs Selectors") */
 :--for-portal .s-header .navbar-nav .nav-link {
@@ -325,11 +321,8 @@ Styleguide Trumps.Scopes.Header
   font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
 }
 
-/* Create a line between search bar and login */
-/* FAQ: The line should only exist if both elements are present */
+/* Create space between search bar and login (only if both elements exist) */
 .s-header .s-search-bar ~ .s-portal-nav {
-  border-left: 1px solid env(--header-minor-border-color);
-
   margin-left: 12px;
 }
 
@@ -339,8 +332,20 @@ Styleguide Trumps.Scopes.Header
 
 /* Icons */
 
-/* HACK: Using FontAwesome as placeholder */
-.s-header [class*="fa-"] {
-    width: 27px; /* (from Portal `.fa` 1.25em which FP-636 will deprecate) */
-    text-align: center;
+.s-header .nav-icon {
+  margin-right: 1em;
+}
+.s-header .nav-link .nav-icon {
+  margin-right: 0.5em;
+}
+.s-header .dropdown-item .nav-icon {
+  margin-right: 0.5em;
+}
+/* To overwrite Font Awesome & style via Font Awesome */
+/* FP-636: Remove all `.fa` (Font Awesome) icons */
+/* FAQ: The `.nav-link` ensures dropdown icons are unaffected */
+.s-header .nav-link .nav-icon[class*="fa"] {
+  font-size: 26px;
+  line-height: unset;
+  vertical-align: unset;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
@@ -9,3 +9,22 @@ Markup: s-portal-nav.html
 
 Styleguide Trumps.Scopes.PortalNav
 */
+
+/* To distinguish/highlight Portal nav from CMS nav */
+.s-portal-nav {
+  background-color: env(--header-portal-nav-bkgd-color);
+}
+
+.s-portal-nav .nav-link {
+  /* To overwrite `.s-header .nav-link:…` etcetera */
+  border-bottom-color: transparent !important;
+}
+
+/* To overwrite `.s-header .navbar-nav .nav-link, […]` */
+.s-portal-nav .nav-item .nav-link,
+:--for-portal .s-portal-nav .nav-item .nav-link {
+  padding-left: 30px;
+  padding-right: calc(
+    env(--portal-sidebar-padding) + env(--portal-navlink-padding)
+  );
+}

--- a/taccsite_cms/static/site_cms/css/src/_themes/constants.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/constants.json
@@ -5,6 +5,10 @@
 
   "environment-variables": {
 
+    "// PORTAL": "",
+    "--portal-sidebar-padding": "16px",
+    "--portal-navlink-padding": "20px",
+
     "// HEADER": "",
     "--header-font-family": "Roboto, sans-serif",
     "--header-accent-color": "#877453",

--- a/taccsite_cms/static/site_cms/css/src/_themes/theme.default.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/theme.default.json
@@ -8,8 +8,10 @@
     "// HEADER": "",
     "--header-text-color": "var(--global-color-primary--xx-light)",
     "--header-bkgd-color": "var(--global-color-primary--xx-dark)",
+    "// --header-link-bkgd-color": "unique, not registered in global colors",
     "--header-link-bkgd-color": "#313131",
-    "--header-minor-border-color": "var(--global-color-primary--normal)"
+    "--header-minor-border-color": "var(--global-color-primary--normal)",
+    "--header-portal-nav-bkgd-color": "var(--global-color-primary--x-dark)"
 
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_themes/theme.has-dark-logo.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/theme.has-dark-logo.json
@@ -8,8 +8,10 @@
     "// HEADER": "",
     "--header-text-color": "var(--global-color-primary--xx-dark)",
     "--header-bkgd-color": "var(--global-color-primary--x-light)",
+    "// --header-link-bkgd-color": "registered in global vars as an alt. color",
     "--header-link-bkgd-color": "#D8D8D8",
-    "--header-minor-border-color": "var(--global-color-primary--normal)"
+    "--header-minor-border-color": "var(--global-color-primary--normal)",
+    "--header-portal-nav-bkgd-color": "var(--global-color-primary--light)"
 
   }
 }


### PR DESCRIPTION
# Overview

Redesign the portal nav link / menu toggle.

# Issue

GH-101

# Changes

- Use new portal `env()` vars for nav padding.
- No custom logo width (related to portal nav via navbar padding).
- Remove border between search and portal nav.
- Add Portal nav styles.
- Add new portal `env()` vars for nav padding.
- Comment on header link background color `env()` var value.
- Add new header `env()` var for portal nav background color.
- Revert/Remove commented Frontera code.

# Screenshots

Skipped.

# Testing

## Logged In

1. Build CSS with CMS setting/secret `_THEME` set to `None`.
1. Confirm Portal nav link style matches [CMS-Common Components > Navigation Light-mode](https://xd.adobe.com/view/b37b291a-7798-4814-90f3-7ac63c48a3e0-e628/screen/fb70e7c7-f8ad-40a8-ad2d-f211fa36c05f/specs/).
1. Build CSS with CMS setting/secret `_THEME` set to `'has-dark-logo'`.
1. Confirm Portal nav link style matches [CMS-Common Components > Navigation Dark-mode](https://xd.adobe.com/view/b37b291a-7798-4814-90f3-7ac63c48a3e0-e628/screen/38e3fb7c-0b56-4b76-9648-162d2fa71a97/specs/).

## Logged Out

1. Build CSS with CMS setting/secret `_THEME` set to `None`.
1. Confirm Portal menu toggle style matches [CMS-Common Components > Navigation Light-mode](https://xd.adobe.com/view/b37b291a-7798-4814-90f3-7ac63c48a3e0-e628/screen/fb70e7c7-f8ad-40a8-ad2d-f211fa36c05f/specs/).
1. Build CSS with CMS setting/secret `_THEME` set to `'has-dark-logo'`.
1. Confirm Portal menu toggle style matches [CMS-Common Components > Navigation Dark-mode](https://xd.adobe.com/view/b37b291a-7798-4814-90f3-7ac63c48a3e0-e628/screen/38e3fb7c-0b56-4b76-9648-162d2fa71a97/specs/).

# Notes

### Known Issues

1. __Mobile Nav.__ The Portal nav link / menu toggle looks bad in header mobile nav. Expect fix in separate PR.