### PR TITLE
GH-101: Navigation Bar (Mobile Menus & Toggle)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-branding.css
@@ -38,7 +38,7 @@ Styleguide Components.Branding
 .c-branding__link:last-child .c-branding__image {
   margin-left: var(--column-gap--side);
 }
-@media (--x-narrow-and-below) {
+@media (--nav-compressed) {
   .c-branding {
     --column-gap--side: 10px;
     --column-gap--center: 10px;
@@ -50,12 +50,14 @@ Styleguide Components.Branding
 /* Elements */
 
 .c-branding__link {
+  /* FAQ: Percentage-based math adapts to var(--header-brandbar-height) */
   height: var(--height, 90%);
 }
 .c-branding__separator {
   /* To add border */
-  height: 25px;
-  border-left: solid 1px var(--global-color-primary--xx-light);
+  /* FAQ: Percentage-based math adapts to var(--header-brandbar-height) */
+  height: calc(100% - 35%);
+  border-left: env(--border-width--normal) solid var(--global-color-primary--xx-light);
 
   /* To hide text */
   width: 0;
@@ -63,9 +65,10 @@ Styleguide Components.Branding
 }
 
 /* Specific brands */
-.c-branding__nsf-link    { --height: 35px; }
-.c-branding__tacc-link   { --height: 30px; }
-.c-branding__utexas-link { --height: 26px; }
+/* FAQ: Percentage-based math adapts to var(--header-brandbar-height) */
+.c-branding__nsf-link    { --height: 87.5%; }
+.c-branding__tacc-link   { --height: 75%; }
+.c-branding__utexas-link { --height: 65%; }
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
@@ -16,7 +16,9 @@ Styleguide Trumps.ForOtherSites.Docs
   /* To override `top: 0` (in `theme.css`) */
   /* FAQ: This is an initial value that is re-calculated by a Docs script */
   /* SEE: https://bitbucket.org/taccaci/frontera-tech-docs/src/429f05f/frontera_theme/base.html#lines-69 */
-  top: calc(env(--header-brandbar-height) + env(--header-navbar-height));
+  top: calc(
+    var(--header-brandbar-height) + var(--header-navbar-height)
+  );
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
@@ -14,12 +14,44 @@ Styleguide Trumps.Scopes.Header.Compressed
 
 @media (--nav-compressed) {
 
+  /* Generic */
+
+  :root {
+    --header-brandbar-height: env(--header-brandbar-mobile-height);
+    --header-navbar-height: env(--header-navbar-mobile-height);
+  }
+
+
+
+
+
+  /* Logo */
+
+  #header-logo {
+    /* To prevent wide image from forcing `.navbar-toggler` to be wrapped */
+    /* To match lines with `s-header.compressed.css` */
+    /* FAQ: Matching lines eases comparison with `s-header.compressed.css` */
+    max-width: calc(188px - var(--space-after-logo-before-nav));
+  }
+
+
+
+
+
   /* Nav */
 
 
 
-  /* Container */
+  /* Containers */
 
+  .s-header .navbar-collapse {
+    margin-right: env(--header-navbar-toggle-width);
+
+    background-color: rgba(var(--global-color-primary--x-dark-rgb), 0.6);
+    backdrop-filter: blur(18px) brightness(85%);
+
+    border: env(--border-width--normal) solid var(--global-color-primary--dark);
+  }
   .s-header .navbar-nav {
     /* --nav-link-horz-pad: … *//* set within different media queries */
     --nav-line-color: env(--header-accent-color);
@@ -130,8 +162,6 @@ Styleguide Trumps.Scopes.Header.Compressed
     --nav-link-horz-pad: calc(
       env(--portal-sidebar-padding) + env(--portal-navlink-padding)
     );
-
-    margin-left: calc(-1 * var(--nav-link-horz-pad));
   }
 
   .s-header .s-cms-nav .dropdown-menu {

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -44,9 +44,9 @@ Styleguide Trumps.Scopes.Header
 
 /* Nav Bar */
 
-.s-header.navbar {
-  background-color: env(--header-bkgd-color);
+@custom-selector :--nav-bar-fake-bkgd  .s-header.navbar::after;
 
+.s-header.navbar {
   font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
   font-weight: env(--bold);
   font-family: env(--header-font-family);
@@ -56,15 +56,25 @@ Styleguide Trumps.Scopes.Header
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* To give cross-site padding that respects Portal-specific visual balance */
+/* To color navbar, but allow CMS nav to be transluscent to body content */
+:--nav-bar-fake-bkgd {
+  content: '';
+
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+
+  background-color: env(--header-bkgd-color);
+}
+
+/* To overwrite Bootstrap */
 .s-header.navbar,
 /* To overwrite Bootstrap (see "Portal & Docs Selectors") */
 :--for-docs .s-header.navbar,
 :--for-portal .s-header.navbar {
-  /* To align logo (whole image not just visible pixels) with Portal sidebar */
-  padding: 0 0 0 calc(
-    env(--portal-sidebar-padding) + env(--portal-navlink-padding)
-  );
+  padding: 0;
 }
 
 /* To stretch elements as tall as parent */
@@ -82,10 +92,12 @@ Styleguide Trumps.Scopes.Header
 /* To prevent extra height from FOUC during Portal/Docs AJAX content load */
 /* To set nav height, but not constrain height of opened mobile nav */
 /* FAQ: Set height of descendants, but not of CMS and Portal and mobile navs */
+:--nav-bar-fake-bkgd,
 #header-logo,
 .s-header .navbar-toggler,
 .s-header tacc-search-bar {
-  height: env(--header-navbar-height);
+  /* FAQ: To allow height to change in `…expanded.css` and `…compressed.css` */
+  height: var(--header-navbar-height, env(--header-navbar-normal-height));
 }
 
 
@@ -100,7 +112,7 @@ Styleguide Trumps.Scopes.Header
 :--for-docs .branding-header,
 :--for-portal .branding-header {
   /* To prevent zero-height element as it is loaded */
-  height: env(--header-brandbar-height);
+  height: var(--header-brandbar-height, env(--header-brandbar-normal-height));
 
   color: var(--global-color-primary--xx-light);
   background-color: var(--global-color-primary--xx-dark);
@@ -114,19 +126,22 @@ Styleguide Trumps.Scopes.Header
 /* Logo */
 
 #header-logo {
+  /* To allow projects to change value and responsive design to use value */
+  --space-after-logo-before-nav: 25px;
+
   display: flex;
   align-items: center;
 
-  /* To prevent wide image from forcing `.navbar-toggler` to be wrapped */
-  min-width: calc(215px - 25px);
-
-  /* To prevent zero-width element as it is loaded */
-  /* To align position of first CMS nav link with Portal section headers */
-  min-width: calc(190px - 25px); /* CAVEAT: Only works on narrow-enough logos */
+  /* To allow shrinking beyond content width */
+  min-width: 0;
 
   /* To overwrite Bootstrap */
-  /* To allow projects to set this value, but let Core implement it */
-  margin-right: var(--space-after-logo-before-nav, 25px);
+  margin-right: var(--space-after-logo-before-nav);
+
+  /* To align logo (whole image not just visible pixels) with Portal sidebar */
+  margin-left: calc(
+    env(--portal-sidebar-padding) + env(--portal-navlink-padding)
+  );
 
   /* FAQ: In case image does not load and browser shows alt text */
   color: env(--header-text-color);
@@ -163,6 +178,68 @@ Styleguide Trumps.Scopes.Header
   --nav-line-color: …
   */
 }
+
+
+
+/* Toggle */
+
+@custom-selector :--navbar-button
+  .navbar-toggler;
+@custom-selector :--navbar-button--opened
+  .navbar-toggler[aria-expanded="true"];
+@custom-selector :--navbar-button--closed
+  .navbar-toggler[aria-expanded="false"];
+
+/* Button */
+/* To ensure button remains hidden on expanded navbar */
+/* FAQ: The button as (`.navbar-toggler`) uses `display: none` from Bootstrap */
+.s-header :--navbar-button--opened { display: flex; }
+.s-header :--navbar-button {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  width: env(--header-navbar-toggle-width);
+  margin-right: env(--header-navbar-toggle-width);
+  padding: 0; /* to overwrite Bootstrap */
+
+  color: env(--header-text-color);
+  background-color: env(--header-portal-nav-bkgd-color);
+
+  /* To overwrite Bootstrap */
+  border: none;
+  border-radius: 0;
+}
+
+/* Icon */
+.s-header :--navbar-button::before {
+  font-size: 30px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+}
+/* To overwrite Bootstrap */
+.s-header .navbar-toggler-icon { display: none; }
+/* To apply icon styles without using a class in the markup */
+/* FAQ: For dynamic markup change, Portal & Docs markup must be updated */
+/* SEE: https://getbootstrap.com/docs/4.0/components/collapse/#events */
+.s-header :--navbar-button { @extend [class*=" icon-"]; }
+.s-header :--navbar-button::before { @extend .icon; }
+/* To change icon without using dynamic icon classes */
+.s-header :--navbar-button--opened { @extend .icon-close; }
+.s-header :--navbar-button--closed { @extend .icon-burger; }
+/* To stretch icon to mimic icon in design (which is not available yet) */
+.s-header :--navbar-button--closed::before { transform: scaleX(1.5); }
+
+/* Text */
+.s-header :--navbar-button::after {
+  content: attr(data-icon-label);
+  display: block;
+
+  font-family: Benton Sans, env(--header-font-family);
+  font-size: 10px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+  text-align: center;
+  text-transform: uppercase;
+  font-weight: env(--medium);
+}
+.s-header :--navbar-button--opened::after { display: none; }
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.expanded.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.expanded.css
@@ -14,12 +14,44 @@ Styleguide Trumps.Scopes.Header.Expanded
 
 @media (--nav-expanded) {
 
+  /* Generic */
+
+  :root {
+    --header-brandbar-height: env(--header-brandbar-normal-height);
+    --header-navbar-height: env(--header-navbar-normal-height);
+  }
+
+
+
+
+
+  /* Logo */
+
+  #header-logo {
+    /* To prevent zero-width element as it is loaded */
+    /* To align position of first CMS nav link with Portal section headers */
+    /* CAVEAT: Only works on narrow-enough logos */
+    min-width: calc(190px - var(--space-after-logo-before-nav));
+  }
+
+
+
+
+
   /* Nav */
 
 
 
-  /* Container */
+  /* Containers */
 
+  .s-header .navbar-collapse {
+    /* … */
+
+    /* To match lines with `s-header.compressed.css` */
+    /* FAQ: Matching lines eases comparison with `s-header.compressed.css` */
+
+    /* … */
+  }
   .s-header .navbar-nav {
     /* --nav-link-horz-pad: … *//* set within different media queries */
     --nav-line-color: transparent;

--- a/taccsite_cms/static/site_cms/css/src/_themes/constants.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/constants.json
@@ -12,8 +12,11 @@
     "// HEADER": "",
     "--header-font-family": "Roboto, sans-serif",
     "--header-accent-color": "#877453",
-    "--header-brandbar-height": "40px",
-    "--header-navbar-height": "55px",
+    "--header-brandbar-normal-height": "40px",
+    "--header-brandbar-mobile-height": "33px",
+    "--header-navbar-normal-height": "55px",
+    "--header-navbar-mobile-height": "48px",
+    "--header-navbar-toggle-width": "48px",
 
     "// BORDER": "",
     "--border-width--normal": "1px",

--- a/taccsite_cms/static/site_cms/css/src/site.header.css
+++ b/taccsite_cms/static/site_cms/css/src/site.header.css
@@ -26,9 +26,7 @@
 
 /* Shared with Portal */
 /* FP-526: Consider loading Cortal icons with <link> as delayed asset */
-/* NOTE: This import is duplicated from `icon.css` because `@font-face` is ineffectual in Shadow DOM (where `site.tacc-search-bar.css` is loaded) */
-/* SEE: https://bugs.chromium.org/p/chromium/issues/detail?id=336876 */
-@import url("_imports/trumps/icon.fonts.css");
+@import url("_imports/trumps/icon.css");
 /* FAQ: Because of third-party code and a rush to style the Frontera header
         (which meant maintaining existing markup), scope classes were used for
         - the header

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -13,8 +13,9 @@
   {% include "header_logo.html" %}
 
   <!-- Navbar Accordian Toggle on Small Screens  -->
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExpandTarget" aria-controls="navbarsExpandTarget" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExpandTarget" aria-controls="navbarsExpandTarget" aria-expanded="false" aria-label="Toggle navigation" data-icon-label="Menu">
+    <span class="navbar-toggler-icon">±</span>
+    <span class="sr-only">Menu</span>
   </button>
 
   <!-- Navbar Links -->


### PR DESCRIPTION
# Overview

- Finish styling mobile navbar menu.
- Style mobile navbar menu toggle button.
- Style mobile brand bar.
- Style mobile brandbar and navbar height.

> The search bar and portal menu icons have **not** been re-styled yet.

# Issues

- #101

# Changes

- __New__: Import all icon styles (not just some).
- __New__: Support mobile brandbar.
- __New__: Support mobile vs. desktop navbar & brandbar heights.
- __New__: Support mobile logo.
- __New__: Support mobile navbar collabsible menu.
- __New__: Add new theme constants for navbar & branbar heights.
- __New__: Add navbar menu button text.

# Testing

- Resize screen width.
- Compare the following elements to design when header navigation is mobile versus desktop:
   - brand bar height
   - brand bar separators height
   - brand bar images heights
   - nav bar height
   - nav bar menu background
   - nav bar menu toggle icon & text
   - nav bar menu link alignment