### PR TITLE
Hack: GH-101: Use Cortal icons sans markup change

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/for-docs.header.css
@@ -46,3 +46,14 @@ Styleguide Trumps.ForOtherSites.Docs
 :--for-docs .c-branding img {
   max-width: unset;
 }
+
+
+
+/* Overwrite TACC (for Icons in Body) */
+
+/* To compensate for Docs using an `.icon` class different from CMS & Portal */
+:--for-docs .icon {
+  width: unset;
+  height: unset;
+  vertical-align: unset;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -215,7 +215,8 @@ Styleguide Trumps.Scopes.Header
 }
 /* To overwrite Bootstrap */
 .s-header .navbar-toggler-icon { display: none; }
-/* To apply icon styles without using a class in the markup */
+/* To swap Bootstrap icon for Cortal icon */
+/* HACK: To apply icon styles without using a class in the markup */
 /* FAQ: For dynamic markup change, Portal & Docs markup must be updated */
 /* SEE: https://getbootstrap.com/docs/4.0/components/collapse/#events */
 .s-header :--navbar-button { @extend [class*=" icon-"]; }
@@ -421,12 +422,4 @@ Styleguide Trumps.Scopes.Header
 
 .s-header .dropdown-item .nav-icon {
   margin-right: 0.5em;
-}
-
-/* To overwrite Font Awesome & style via Font Awesome */
-/* FP-636: Remove all `.fa` (Font Awesome) icons */
-.s-portal-nav .nav-link .nav-icon[class*="fa"] {
-  font-size: 26px;
-  line-height: unset;
-  vertical-align: unset;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
@@ -10,17 +10,15 @@ Markup: s-portal-nav.html
 Styleguide Trumps.Scopes.PortalNav
 */
 
-/* To distinguish/highlight Portal nav from CMS nav */
+/* To distinguish Portal nav from CMS nav */
+/* To overwrite `.s-header` */
 .s-portal-nav {
   background-color: env(--header-portal-nav-bkgd-color);
 }
-
 .s-portal-nav .nav-link {
   /* To overwrite `.s-header .nav-link:…` etcetera */
   border-bottom-color: transparent !important;
 }
-
-/* To overwrite `.s-header .navbar-nav .nav-link, […]` */
 .s-portal-nav .nav-item .nav-link,
 :--for-portal .s-portal-nav .nav-item .nav-link {
   padding-left: 30px;
@@ -28,3 +26,19 @@ Styleguide Trumps.Scopes.PortalNav
     env(--portal-sidebar-padding) + env(--portal-navlink-padding)
   );
 }
+
+.s-portal-nav .dropdown-toggle .nav-icon {
+  font-size: 26px;
+}
+
+/* To swap Font Awesome icons for Cortal icons */
+/* HACK: To apply icon styles without using a class in the markup */
+/* NOTE: So I can deploy new header and not require edit to Portal nor Docs */
+/* FP-526: Use Cortal Icons for header (then remove these styles) */
+.s-portal-nav [class*="fa"] { @extend [class*=" icon-"]; }
+.s-portal-nav [class*="fa"] { @extend .icon; }
+.s-portal-nav .dropdown-toggle .fa-user-circle { @extend .icon-user; }
+.s-portal-nav .fa-desktop      { @extend .icon-dashboard; }
+.s-portal-nav .fa-tasks        { @extend .icon-approved-boxed; }
+.s-portal-nav .fa-user-circle  { @extend .icon-gear; }
+.s-portal-nav .fa-sign-out-alt { @extend .icon-user; }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.html
@@ -1,42 +1,36 @@
 <!-- FAQ:
 
-This is the markup of the #s-header, as of 2020-08-13,
+This is the markup of the #s-header, as of 2021-05-24,
 from https://frontera-portal.tacc.utexas.edu/. It has:
 
 - Bootstrap class names
 - Bootstrap attributes
-- illegally-nested markup (`ul > div > li`)
-- extra markup (`a > span`)
 -->
 <ul class="s-portal-nav  navbar-nav">
-  <div class="navbar-nav">
-    <li class="nav-item  dropdown">
-      <a class="nav-link  dropdown-toggle"
-        href="#"
-        data-toggle="dropdown"
-        aria-haspopup="true"
-        aria-expanded="false"
-      >
-        <span>Sections</span>
-        <span class="sr-only">Toggle Dropdown</span>
-      </a>
-      <div class="dropdown-menu dropdown-menu-right">
-        <a class="dropdown-item" href="#">
-          <i class="nav-icon"></i> Section 1
-        </a>
-        <a class="dropdown-item" href="#">
-          <i class="nav-icon"></i> Section 2
-        </a>
-        <a class="dropdown-item" href="#">
-          <i class="nav-icon"></i> Section 3
-        </a>
-      </div>
-    </li>
-  </div>
-
-  <li class="nav-item">
-    <a class="nav-link" href="/login/">
-      <i class="nav-icon"></i> Log in
+  <li class="nav-item  dropdown">
+    <a class="nav-link  dropdown-toggle"
+      href="#"
+      data-toggle="dropdown"
+      aria-haspopup="true"
+      aria-expanded="false"
+    >
+      <i class="fas fa-user-circle fa-lg nav-icon"></i>
+      <span>username</span>
+      <span class="sr-only">Toggle Dropdown</span>
     </a>
+    <nav class="dropdown-menu dropdown-menu-right show">
+      <a class="dropdown-item" href="/workbench/dashboard">
+        <i class="fas fa-desktop nav-icon"></i> My Dashboard
+      </a>
+      <a class="dropdown-item" href="/workbench/onboarding/admin">
+        <i class="fas fa-tasks nav-icon"></i> Onboarding Admin
+      </a>
+      <a class="dropdown-item" href="/accounts/profile/">
+        <i class="fas fa-user-circle nav-icon"></i> My Account
+      </a>
+      <a class="dropdown-item" href="/accounts/logout">
+        <i class="fas fa-sign-out-alt nav-icon"></i> Log Out
+      </a>
+    </nav>
   </li>
 </ul>


### PR DESCRIPTION
# Overview

Use Cortal icons for Portal nav.

> The search bar and portal nav have **not** been re-styled yet.

# Issues

- #101

# Changes

- _Minor_: Tweak a comment (related cuz it's also icon hack).
- _Minor_: Migrate Portal nav styles to `s-portal-nav.css`.
- __New__: Add hack to swap FA icons with Cortal icons.
- _Minor_: Update CSS sample `s-portal-nav.html`.

# Testing

1. Load on wide screen (so header navigation uses desktop layout).
1. Ensure icons are new, from Cortal, and not from FontAwesome.
    <details>

    - icons should show and look different than before
    - icons should use Cortal font
    - icons should **not** use Font Awesome font

    </details>
1. Ensure no other styles have changed.
1. Load on small screen (so header navigation uses mobile layout).
1. Ensure Portal nav is usable and has icons.
1. Ensure no other styles have changed.