### PR TITLE
GH-101: Mobile Menu (Search & Portal Layout)

### DIFF
--- a/conf/css/.postcssrc.yml
+++ b/conf/css/.postcssrc.yml
@@ -16,6 +16,7 @@ plugins:
     features:
       custom-media-queries: true
       media-query-ranges: true
+      not-pseudo-class: true
       # RFE: Fix bug on the Internet so we can use these reliably
       # SEE: https://github.com/postcss/postcss-custom-selectors/issues/40
       custom-selectors: true

--- a/taccsite_cms/static/site_cms/css/src/_imports/_tests/postcss-preset-env.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/_tests/postcss-preset-env.css
@@ -86,3 +86,11 @@ article :--heading + p {
 :--nav-link-active {
   color: red;
 }
+
+/*! Goal: */
+._test>:not(._test--x):not(._test--y){align-items:center}
+
+/*! Test: */
+._test > *:not(._test--x, ._test--y) {
+  align-items: center;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
@@ -71,7 +71,7 @@ Styleguide Trumps.Scopes.Header.Compressed
   /* Nav Links */
 
   .s-header .nav-link {
-    height: auto;
+    /* height: auto; *//* to mirror props on `s-header.compressed.css` */
 
     /* To overwrite Bootstrap */
     padding-top: 0.8em;
@@ -110,37 +110,25 @@ Styleguide Trumps.Scopes.Header.Compressed
 
 
 
-  /* Menu */
-
-  /* To overwrite Bootstrap */
-  .s-header .dropdown-menu {
-    padding: 0;
-
-    background-color: transparent;
-    border: none;
-
-    font-size: 20px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
-  }
-
-
-
-  /* Item */
-
-  /* FAQ: Selector specificty trumps Bootstrap, so no need for `:hover` (etc.) */
-  .s-header .dropdown-item {
-    /* To overwrite Bootstrap */
-    padding-top: 1em;
-    padding-bottom: 1em;
-  }
-
-
   /* Search */
 
-  /* GH-101: Retain search design until Wes works on it */
+  .s-header .s-search-bar,
+  /* To apply style to old markup (see "Portal & Docs Selectors") */
+  /* TODO: 1. Remove `ml-auto` from Portal & Docs markup
+           2. Remove the ` !important`
+           3. Remove the subsite selectors */
+  :--for-docs .s-header .s-search-bar.ml-auto,
+  :--for-portal .s-header .s-search-bar.ml-auto {
+    /* To line up menu text with logo */
+    margin-left: calc(
+      env(--portal-sidebar-padding) + env(--portal-navlink-padding)
+    ) !important;
+  }
+
   .s-header .s-search-bar,
   .s-header .s-search-bar::part(input),
   .s-header .s-search-bar::part(button) {
-    font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+    font-size: 18px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
   }
 
   /* Create space between search bar and login (only if both elements exist) */
@@ -156,6 +144,11 @@ Styleguide Trumps.Scopes.Header.Compressed
 
   .s-header .s-portal-nav .nav-link .nav-icon {
     margin-right: 0.5em;
+  }
+
+  /* To enlarge all icons */
+  .s-portal-nav .dropdown .nav-icon {
+    font-size: 26px;
   }
 
 }
@@ -217,17 +210,70 @@ Styleguide Trumps.Scopes.Header.Compressed
     z-index: 1000;
   }
 
+  /* To layout elements for mobile navigation */
+  /* FAQ: Mimic column via 100% rows so portal nav & search can be on one row */
+  .s-header .navbar-collapse.show,
+  .s-header .navbar-collapse.collapsing {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .s-header .navbar-collapse > *:not(.s-portal-nav, .s-search-bar) {
+    flex-basis: 100%;
+  }
+  /* To let portal nav & search fit "comfortably" together on thier row */
+  .s-header .s-portal-nav { flex: 0 1 auto }
+  .s-header .s-search-bar { flex: 1 1 auto }
+  /* To let search fill up available space */
+  .s-header tacc-search-bar.s-search-bar::part(form) { width: 100%; }
+  /* To move portal nav & search to top of menu */
+  .s-header .s-portal-nav { order: -1 }
+  .s-header .s-search-bar { order: -2 }
 
 
-  /* Search */
+
+  /* Dropdowns */
 
   /* To overwrite Bootstrap */
-  /* To apply style to old markup (see "Portal & Docs Selectors") */
-  /* TODO: 1. Remove `ml-auto` from Portal & Docs markup
-           2. Remove this style */
-  :--for-docs .s-header .s-search-bar.ml-auto,
-  :--for-portal .s-header .s-search-bar.ml-auto {
-    margin-left: 0 !important;
+  .s-header .dropdown-menu {
+    padding: 0;
+  }
+  .s-header .s-cms-nav .dropdown-menu {
+    background-color: transparent;
+    border: none;
+
+    font-size: 20px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+  }
+  .s-header .s-portal-nav .dropdown-menu {
+    background-color: env(--header-link-bkgd-color);
+    border: none;
+  }
+  /* To overwrite Bootstrap */
+  /* To allow Portal nav menu to still drop down over content on small screen */
+  .s-header .s-portal-nav .dropdown-menu {
+    /* Copied from Bootstrap:
+       ```
+       @media (min-width: 992px) {
+          .navbar-expand-lg .navbar-nav .dropdown-menu
+       }
+       ``` */
+    position: absolute; /* without this, menu pushes down content beneath it */
+  }
+
+  /* To distinguish CMS dropdown from Portal dropdown */
+  .s-header .s-cms-nav .dropdown-item {
+    /* To overwrite Bootstrap */
+    padding-top: 1em;
+    padding-bottom: 1em;
+  }
+  /* To mimic `.s-header .nav-link` */
+  .s-header .s-portal-nav .dropdown-item {
+    /* To overwrite Bootstrap */
+    padding-top: 0.8em;
+    padding-bottom: 0.8em;
+
+    font-size: 2em;
   }
 
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
@@ -166,13 +166,29 @@ Styleguide Trumps.Scopes.Header.Compressed
 
 /* UNIQUE (to Compressed Styles) */
 
+/* Basic Media Range */
+
 @media (--nav-compressed) {
+
+
+
+  /* Nav */
+
   /* To add nav menu padding */
   .s-header .navbar-nav {
     /* To line up menu text with logo */
     --nav-link-horz-pad: calc(
       env(--portal-sidebar-padding) + env(--portal-navlink-padding)
     );
+  }
+
+  /* To overwrite Bootstrap */
+  /* To apply style to old markup (see "Portal & Docs Selectors") */
+  /* TODO: 1. Remove `ml-auto` from Portal & Docs markup
+           2. Remove this style */
+  :--for-docs .s-header .s-cms-nav.ml-auto,
+  :--for-portal .s-header .s-cms-nav.ml-auto {
+    margin-left: 0 !important;
   }
 
   /* To add dropdown menu padding */
@@ -200,4 +216,18 @@ Styleguide Trumps.Scopes.Header.Compressed
     right: 0;
     z-index: 1000;
   }
+
+
+
+  /* Search */
+
+  /* To overwrite Bootstrap */
+  /* To apply style to old markup (see "Portal & Docs Selectors") */
+  /* TODO: 1. Remove `ml-auto` from Portal & Docs markup
+           2. Remove this style */
+  :--for-docs .s-header .s-search-bar.ml-auto,
+  :--for-portal .s-header .s-search-bar.ml-auto {
+    margin-left: 0 !important;
+  }
+
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -201,12 +201,18 @@ Styleguide Trumps.Scopes.Header
   margin-right: env(--header-navbar-toggle-width);
   padding: 0; /* to overwrite Bootstrap */
 
-  color: env(--header-text-color);
   background-color: env(--header-portal-nav-bkgd-color);
 
   /* To overwrite Bootstrap */
   border: none;
   border-radius: 0;
+}
+/* To isolate styles that require more specificity to override Portal */
+.s-header :--navbar-button,
+/* To overwrite Bootstrap (see "Portal & Docs Selectors") */
+:--for-docs .s-header :--navbar-button,
+:--for-portal .s-header :--navbar-button {
+  color: env(--header-text-color);
 }
 
 /* Icon */

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -94,7 +94,7 @@ Styleguide Trumps.Scopes.Header
 /* FAQ: Set height of descendants, but not of CMS and Portal and mobile navs */
 :--nav-bar-fake-bkgd,
 #header-logo,
-.s-header .navbar-toggler,
+.s-header :--navbar-button,
 .s-header tacc-search-bar {
   /* FAQ: To allow height to change in `…expanded.css` and `…compressed.css` */
   height: var(--header-navbar-height, env(--header-navbar-normal-height));

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -353,20 +353,22 @@ Styleguide Trumps.Scopes.Header
 .s-header .dropdown-toggle::after {
   @extend %x-arrow;
 
-  --size: 0.5em;
+  --size: 0.375em;
   --line: 0.1em; /* to get 1px at 12px text and 2px at 24px text */
   --color: env(--header-text-color);
+  --nudge: 0.24em;
 
   margin-left: 0.6em;
   position: relative; /* to allow use of `top` (to vertically align) */
 }
+/* To vertically align with text */
 .s-header .dropdown-toggle[aria-expanded="true"]::after {
   @extend %x-arrow--up;
-  top: 0.35em; /* to vertically align with text */
+  top: var(--nudge);
 }
 .s-header .dropdown-toggle[aria-expanded="false"]::after {
   @extend %x-arrow--down;
-  top: -0.35em; /* to vertically align with text */
+  bottom: var(--nudge);
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -1,7 +1,9 @@
 /*
 Header
 
-Styles for elements within a header that has third-party code:
+Styles for elements within a header.
+
+Warning: There are complex overwrites for 3rd-party and subsite code:
 
 - FontAwesome icons
   (for Portal navigation)
@@ -10,6 +12,8 @@ Styles for elements within a header that has third-party code:
   (for Portal navigation)
 - a subset of Bootstrap 3.3.7
   (for CMS body content, can affect navigation)
+- Docs
+- Portal
 
 Portal & Docs Selectors:
 
@@ -95,7 +99,7 @@ Styleguide Trumps.Scopes.Header
 :--nav-bar-fake-bkgd,
 #header-logo,
 .s-header :--navbar-button,
-.s-header tacc-search-bar {
+.s-header .s-search-bar {
   /* FAQ: To allow height to change in `…expanded.css` and `…compressed.css` */
   height: var(--header-navbar-height, env(--header-navbar-normal-height));
 }
@@ -177,6 +181,11 @@ Styleguide Trumps.Scopes.Header
   --nav-link-horz-pad: …
   --nav-line-color: …
   */
+}
+
+/* To distinguish Portal nav from CMS nav */
+.s-portal-nav {
+  background-color: env(--header-portal-nav-bkgd-color);
 }
 
 
@@ -301,6 +310,11 @@ Styleguide Trumps.Scopes.Header
   padding-right: var(--nav-link-horz-pad, 0);
   padding-left: var(--nav-link-horz-pad, 0);
 }
+.s-header .s-portal-nav .nav-link,
+/* To overwrite Bootstrap (see "Portal & Docs Selectors") */
+:--for-portal .s-portal-nav .nav-link {
+  padding-left: 30px;
+}
 
 /* To create line between each item */
 .s-header .nav-item + .nav-item .nav-link {
@@ -359,17 +373,20 @@ Styleguide Trumps.Scopes.Header
 
 /* Menu */
 
+/* To overwrite Bootstrap */
+/* FAQ: Bootstrap has styles we do not want a value for, so `unset` */
 .s-header .dropdown-menu {
-  margin: unset; /* undo Bootstrap */
+  margin: unset;
 
-  border-radius: unset; /* undo Bootstrap */
+  border-radius: unset;
+
+  font-size: unset;
 }
 
 
 
 /* Item */
 
-/* FAQ: Selector specificty trumps Bootstrap, so no need for `:hover` (etc.) */
 .s-header .dropdown-item {
   padding-left: var(--menu-link-horz-pad);
   padding-right: var(--menu-link-horz-pad);
@@ -403,21 +420,6 @@ Styleguide Trumps.Scopes.Header
 :--for-portal .s-header .dropdown-item:focus,
 :--for-portal .s-header .dropdown-item:hover {
   color: env(--header-text-color);
-}
-
-
-/* Search */
-
-/* GH-101: Retain search design until Wes works on it */
-.s-header .s-search-bar,
-.s-header .s-search-bar::part(input),
-.s-header .s-search-bar::part(button) {
-  font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
-}
-
-/* Create space between search bar and login (only if both elements exist) */
-.s-header .s-search-bar ~ .s-portal-nav {
-  margin-left: 12px;
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -254,6 +254,11 @@ Styleguide Trumps.Scopes.Header
   font-weight: env(--medium);
 }
 .s-header :--navbar-button--opened::after { display: none; }
+/* To apply style to old markup (see "Portal & Docs Selectors") */
+/* FAQ: This selector does not use `:--for-portal` but has similar purpose */
+.s-header :--navbar-button:not([data-icon-label])::after {
+  content: 'Menu';
+}
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.expanded.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.expanded.css
@@ -166,6 +166,11 @@ Styleguide Trumps.Scopes.Header.Expanded
 
 /* UNIQUE (to Expanded Styles) */
 
+
+
+
+/* Complex Media Range */
+
 /* To reduce space between nav links when space is limited */
 @media (--wide-and-below) and (--nav-expanded) {
   /* To have "narrower" space (designed by dev) */
@@ -192,4 +197,30 @@ Styleguide Trumps.Scopes.Header.Expanded
   /* TODO: Hardcode `is-on-portal` in Portal & Docs markup */
   :--for-docs .s-header .navbar-nav,
   :--for-portal .s-header .navbar-nav { --nav-link-horz-pad: 1.25em; }
+}
+
+
+
+/* Basic Media Range */
+
+@media (--nav-expanded) {
+
+
+
+  /* Nav */
+
+  /* To move CMS nav to the right if there is no Portal */
+  .s-header:not(.is-on-portal) .s-cms-nav {
+    margin-left: auto;
+  }
+
+
+
+  /* Search */
+
+  /* To add flexible space between CMS nav and search bar */
+  .s-header .s-search-bar {
+    margin-left: auto;
+  }
+
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.expanded.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.expanded.css
@@ -45,12 +45,12 @@ Styleguide Trumps.Scopes.Header.Expanded
   /* Containers */
 
   .s-header .navbar-collapse {
-    /* … */
+
 
     /* To match lines with `s-header.compressed.css` */
     /* FAQ: Matching lines eases comparison with `s-header.compressed.css` */
 
-    /* … */
+
   }
   .s-header .navbar-nav {
     /* --nav-link-horz-pad: … *//* set within different media queries */
@@ -110,37 +110,25 @@ Styleguide Trumps.Scopes.Header.Expanded
 
 
 
-  /* Menu */
-
-  /* To overwrite Bootstrap */
-  .s-header .dropdown-menu {
-    padding: 7px 0 0;
-
-    background-color: env(--header-link-bkgd-color);
-    border: env(--border-width--normal) solid env(--header-accent-color);
-
-    font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
-  }
-
-
-
-  /* Item */
-
-  /* FAQ: Selector specificty trumps Bootstrap, so no need for `:hover` (etc.) */
-  .s-header .dropdown-item {
-    /* To overwrite Bootstrap */
-    padding-top: 0.5em;
-    padding-bottom: 0.5em;
-  }
-
-
   /* Search */
 
-  /* GH-101: Retain search design until Wes works on it */
+  /* To add flexible space between CMS nav and search bar */
+  .s-header .s-search-bar {
+    /* To match lines with `s-header.compressed.css` */
+    /* FAQ: Matching lines eases comparison with `s-header.compressed.css` */
+
+
+
+
+    margin-left: auto;
+
+
+  }
+
   .s-header .s-search-bar,
   .s-header .s-search-bar::part(input),
   .s-header .s-search-bar::part(button) {
-    font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+    font-size: 14px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
   }
 
   /* Create space between search bar and login (only if both elements exist) */
@@ -156,6 +144,11 @@ Styleguide Trumps.Scopes.Header.Expanded
 
   .s-header .s-portal-nav .nav-link .nav-icon {
     margin-right: 0.5em;
+  }
+
+  /* To enlarge toggle icon */
+  .s-portal-nav .dropdown-toggle .nav-icon {
+    font-size: 26px;
   }
 
 }
@@ -216,11 +209,22 @@ Styleguide Trumps.Scopes.Header.Expanded
 
 
 
-  /* Search */
+  /* Dropdowns */
 
-  /* To add flexible space between CMS nav and search bar */
-  .s-header .s-search-bar {
-    margin-left: auto;
+  /* To overwrite Bootstrap */
+  .s-header .dropdown-menu {
+    padding: 7px 0 0;
+
+    background-color: env(--header-link-bkgd-color);
+    border: env(--border-width--normal) solid env(--header-accent-color);
+
+    font-size: 12px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
+  }
+
+  /* To overwrite Bootstrap */
+  .s-header .dropdown-item {
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
   }
 
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
@@ -1,7 +1,7 @@
 /*
 Portal Navigation
 
-Styles for elements within Portal navigation that has third-party code:
+Styles for elements specific to Portal navigation in isolation:
 
 - Bootstrap 4.3.1
 
@@ -10,26 +10,11 @@ Markup: s-portal-nav.html
 Styleguide Trumps.Scopes.PortalNav
 */
 
-/* To distinguish Portal nav from CMS nav */
-/* To overwrite `.s-header` */
-.s-portal-nav {
-  background-color: env(--header-portal-nav-bkgd-color);
-}
-.s-portal-nav .nav-link {
-  /* To overwrite `.s-header .nav-link:…` etcetera */
-  border-bottom-color: transparent !important;
-}
-.s-portal-nav .nav-item .nav-link,
-:--for-portal .s-portal-nav .nav-item .nav-link {
-  padding-left: 30px;
-  padding-right: calc(
-    env(--portal-sidebar-padding) + env(--portal-navlink-padding)
-  );
-}
 
-.s-portal-nav .dropdown-toggle .nav-icon {
-  font-size: 26px;
-}
+
+
+
+/* Icons */
 
 /* To swap Font Awesome icons for Cortal icons */
 /* HACK: To apply icon styles without using a class in the markup */

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
@@ -25,5 +25,11 @@ Styleguide Trumps.Scopes.PortalNav
 .s-portal-nav .dropdown-toggle .fa-user-circle { @extend .icon-user; }
 .s-portal-nav .fa-desktop      { @extend .icon-dashboard; }
 .s-portal-nav .fa-tasks        { @extend .icon-approved-boxed; }
-.s-portal-nav .fa-user-circle  { @extend .icon-gear; }
-.s-portal-nav .fa-sign-out-alt { @extend .icon-user; }
+.s-portal-nav .fa-user-circle  { @extend .icon-user; }
+.s-portal-nav .fa-sign-out-alt { @extend .icon-exit; }
+
+/* To align log out icon closer to visual midpoint of other icons */
+.s-portal-nav .icon-exit,
+.s-portal-nav .fa-sign-out-alt {
+  transform: translateX(2px);
+}

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -20,17 +20,14 @@
 
   <!-- Navbar Links -->
   <div class="collapse navbar-collapse" id="navbarsExpandTarget">
-    {# GL-6: Remove need for different `className` values #}
-    {% if settings.PORTAL %}
-      {# FAQ: If template were included with `only`, then it would NOT render `show_menu` #}
-      {% include "nav_cms.html" with className="navbar-nav" %}
+    {# FAQ: We pass `navbar-nav` because it is coupled to `navbar-…` here #}
+    {# FAQ: If template included with `only`, it would NOT render `show_menu` #}
+    {% include "nav_cms.html" with className="navbar-nav" %}
 
+    {% if settings.PORTAL %}
       {# NOTE: As of 2020-12, search is only available with a Portal #}
-      {% include "nav_search.html" with className="form-inline  ml-auto" only %}
+      {% include "nav_search.html" with className="form-inline" only %}
       {% include "nav_portal.html" with className="navbar-nav" settings=settings only %}
-    {% else %}
-      {# FAQ: If template were included with `only`, then it would NOT render `show_menu` #}
-      {% include "nav_cms.html" with className="navbar-nav  ml-auto" %}
     {% endif %}
   </div>
 </nav>


### PR DESCRIPTION
# Overview

- Finish styling mobile navbar menu.
- Style mobile navbar menu toggle button.
- Style mobile brand bar.
- Style mobile brandbar and navbar height.

> The search bar, icons, and portal nav have **not** been re-styled yet.

# Issues

- #101

# Changes

- __New__: Use CSS for margin instead of `ml-auto`
    - _Minor_: Make header code DRY (now that CMS nav imports are identical).
- _Minor_: Use custom selector for consistency
- __Fix__: Fix navbar toggle color
- __New__: New mobile menu layout for search bar and portal nav
    - _Minor_: Support `:not` with multiple elements.
    - _Minor_: Edit existing relevant CSS to be consistent and accurately organized.
- __Fix__: Reduce oversized dropdown toggle ("chevron")
- __New__: Swap "Log Out" & "My Account" icons

# Testing

1. Resize screen width.
1. Compare the following elements to design when header navigation is mobile versus desktop:
   - portal nav icons
   - portal nav style
   - portal nav position
   - search bar position
   - dropdown toggle size

# Notes

1. <details>
    <summary>On mobile nav, the dropdown toggle ("chevron") is not thick enough.</summary>

    I am forgoing complexity in code, because there should be a Cortal icon for this shape.

    </details>