### PR TITLE
GH-233: Frontera Hero Banner Styles - Quick

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-article-link.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-article-link.css
@@ -19,8 +19,9 @@ Styleguide Tools.ExtendsAndMixins.ArticleLink
   position: absolute;
   height: 100%;
   width: 100%;
-  /* An explicit position (in case container has top padding) */
+  /* FAQ: Explicit position prevents container padding from offsetting link */
   top: 0;
+  left: 0;
 }
 .x-article-link-stretch--gapless,
 %x-article-link-stretch--gapless {

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.css
@@ -159,6 +159,7 @@ Styleguide Trumps.Scopes.ArticlePreview
 }
 .s-article-list--news .s-article-preview ul > li:nth-child(1)::before {
   content: 'Published: ';
+  white-space: pre;
 }
 /* (List) Events */
 .s-article-list--events .s-article-preview ul > li:nth-child(1) {
@@ -171,6 +172,7 @@ Styleguide Trumps.Scopes.ArticlePreview
 }
 .s-article-list--allocations .s-article-preview ul > li:nth-child(1)::before {
   content: 'Submission Deadlines: ';
+  white-space: pre;
 }
 
 /* Children: Metadata: Type */

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.css
@@ -78,8 +78,10 @@ Styleguide Trumps.Scopes.ArticlePreview
   font-size: 1.8rem;
   font-weight: var(--bold);
   line-height: 2.4rem;
-
-  @extend .x-truncate--one-line;
+}
+/* (List) */
+[class*="s-article-list--"] .s-article-preview h3 {
+  @extend %x-truncate--one-line;
 }
 /* (List) Allocations */
 .s-article-list--allocations .s-article-preview h3 {
@@ -103,8 +105,10 @@ Styleguide Trumps.Scopes.ArticlePreview
 
   font-size: 1.6rem;
   line-height: 2.4rem;
-
-  @extend .x-truncate--many-lines;
+}
+/* (List) */
+[class*="s-article-list--"] .s-article-preview p:not(:first-child):not(:last-child) {
+  @extend %x-truncate--many-lines;
   --lines: 3;
 }
 /* (List) Allocations */


### PR DESCRIPTION
# Overview

- To Frontera hero banner, add articles.
- Update relevant Core code to support Frontera hero banner articles.

# Issues

#233

# Changes

- __Fix__: Ensure position of stretched link is top left; ignore container padding.
- _Minor_: Only truncate article previews if they are in a standard article list.
- __Fix__: Ensure expected space actually shows after the prefix for an article preview date.
- __New__: Add Frontera hero banner article styles (and related tweaks).

# Testing

> __Notice__: Tested via changing snippet `GH-35: CSS (Frontera): Templates: Home […]` on https://frontera-portal.tacc.utexas.edu/home-2021-03. The snippet is pasted code from local build. _Testing locally is difficult, because I would need to recreate the page content via CMS actions (cloning CMS content across servers is not yet convenient)._

## Static Design

Check 1200px screen width:
1. Compare design [Adobe XD: Frontera-Redesign-review](https://xd.adobe.com/view/90e6b252-0293-4243-7748-11d94a0763d0-e6d7/specs/) to webpage [Frontera Prod: Home 2021-03](https://frontera-portal.tacc.utexas.edu/home-2021-03).

## Responsive Design

Check all screen widths:
1. If Frontera banner overlay text is cut off, it is done via ellipses truncation.
    - The truncation is at six lines. You can add more text to the overlay to test this.
2. Frontera banner articles fit within overlay.
3. Frontera banner articles drop to one row for each at narrowest screen width like article lists below do.
4. Frontera banner articles have hover state that looks "not bad".