### PR TITLE
Hotfix: GH-233: Frontera hero article hover bugs

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-article-link.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-article-link.css
@@ -19,9 +19,13 @@ Styleguide Tools.ExtendsAndMixins.ArticleLink
   position: absolute;
   height: 100%;
   width: 100%;
-  /* FAQ: Explicit position prevents container padding from offsetting link */
+  /* To prevent container padding from offsetting an `outline` */
   top: 0;
   left: 0;
+
+  /* To prevent `outline` from being inexplicably offset in Firefox */
+  /* SEE: http://johndoesdesign.com/blog/2012/css/firefox-and-its-css-focus-outline-bug/ */
+  overflow: hidden;
 }
 .x-article-link-stretch--gapless,
 %x-article-link-stretch--gapless {


### PR DESCRIPTION
# Overview

Frontera: Fix bugs with outline on hover over articles in banner.

# Changes

- Prevent `outline` extending too far left when hovering on article in banner on wide screen.
- Two other `outline` fixes in Frontera-specific code.

# Testing

- Check hover outline at all screen sizes on Firefox and Safari.