### PR TITLE
GH-101: Portal Nav (Load with Transition / Animation)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -186,9 +186,8 @@ Styleguide Trumps.Scopes.Header
   --nav-line-color: …
   */
 }
-
 /* To distinguish Portal nav from CMS nav */
-.s-portal-nav {
+.s-header .s-portal-nav {
   background-color: env(--header-portal-nav-bkgd-color);
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
@@ -14,6 +14,34 @@ Styleguide Trumps.Scopes.PortalNav
 
 
 
+/* Container */
+
+/* To have Portal Nav gently push—not abruptly shove—elements to make room */
+/* FAQ: Load Portal Nav with zero width, then transition to normal width */
+.s-portal-nav {
+  flex-shrink: 0;
+
+  transition: max-width 0.5s ease-out;
+  max-width: 0;
+}
+.s-portal-nav.js-content--is-loaded /* from `nav_portal.html` */ {
+  /* To let width grow, use explicit value, and not constrain width */
+  /* FAQ: No support for transition to `width: auto` nor `max-width: 100%` */
+  /* SEE: https://css-tricks.com/using-css-transitions-auto-dimensions/ */
+  /* FAQ: Value is normal width of logged in nav with 8-char (max) username */
+  /* CAVEAT: Change of space or dimension of portal nav items affects value */
+  max-width: 212px;
+}
+/* To ensure content that is off screen does not cause scrollbar for <body> */
+/* FAQ: The specific conditional hide ensures dropdown menu is not hidden */
+.s-portal-nav .dropdown:not(.show) {
+  overflow: hidden;
+}
+
+
+
+
+
 /* Icons */
 
 /* To swap Font Awesome icons for Cortal icons */

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -17,26 +17,3 @@
     container.classList.add('js-content--is-loaded');
   });
 </script>
-<style>
-  /* To have Portal Nav gently push—not abruptly shove—elements to make room */
-  /* FAQ: Load Portal Nav with zero width, then transition to normal width */
-  .s-portal-nav {
-    flex-shrink: 0;
-
-    transition: max-width 0.5s ease-out;
-    max-width: 0;
-  }
-  .s-portal-nav.js-content--is-loaded {
-    /* To let width grow, use explicit value, and not constrain width */
-    /* FAQ: No support for transition to `width: auto` nor `max-width: 100%` */
-    /* SEE: https://css-tricks.com/using-css-transitions-auto-dimensions/ */
-    /* FAQ: Value is normal width of logged in nav with 8-char (max) username */
-    /* CAVEAT: Change of space or dimension of portal nav items affects value */
-    max-width: 212px;
-  }
-  /* To ensure content that is off screen does not cause scrollbar for <body> */
-  /* FAQ: The specific conditional hide ensures dropdown menu is not hidden */
-  .s-portal-nav .dropdown:not(.show) {
-    overflow: hidden;
-  }
-</style>

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -18,6 +18,8 @@
   });
 </script>
 <style>
+  /* To have Portal Nav gently push—not abruptly shove—elements to make room */
+  /* FAQ: Load Portal Nav with zero width, then transition to normal width */
   .s-portal-nav {
     flex-shrink: 0;
 
@@ -25,10 +27,15 @@
     max-width: 0;
   }
   .s-portal-nav.js-content--is-loaded {
+    /* To let width grow, use explicit value, and not constrain width */
+    /* FAQ: No support for transition to `width: auto` nor `max-width: 100%` */
+    /* SEE: https://css-tricks.com/using-css-transitions-auto-dimensions/ */
     /* FAQ: Value is normal width of logged in nav with 8-char (max) username */
     /* CAVEAT: Change of space or dimension of portal nav items affects value */
     max-width: 212px;
   }
+  /* To ensure content that is off screen does not cause scrollbar for <body> */
+  /* FAQ: The specific conditional hide ensures dropdown menu is not hidden */
   .s-portal-nav .dropdown:not(.show) {
     overflow: hidden;
   }

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -13,5 +13,23 @@
 
   const container = document.getElementById('portal-nav');
 
-  importHTML.insertFromURL('/core/markup/nav', container);
+  importHTML.insertFromURL('/core/markup/nav', container).then(container => {
+    container.classList.add('js-content--is-loaded');
+  });
 </script>
+<style>
+  .s-portal-nav {
+    flex-shrink: 0;
+
+    transition: max-width 0.5s ease-out;
+    max-width: 0;
+  }
+  .s-portal-nav.js-content--is-loaded {
+    /* FAQ: Value is normal width of logged in nav with 8-char (max) username */
+    /* CAVEAT: Change of space or dimension of portal nav items affects value */
+    max-width: 212px;
+  }
+  .s-portal-nav .dropdown:not(.show) {
+    overflow: hidden;
+  }
+</style>


### PR DESCRIPTION
# Overview

Load portal nav with no width, then transition it to "natural" width.

> The login icon has not ben restyled yet. The location of portal nav in mobile has not moved, yet.

# Issues

- #101

# Changes

- _Minor_: Add missing specificity to a Portal Nav selector.
- __New__: Make Portal Nav _gently push_—**not** abruptly shove—Search Bar aside after it loads.

# Testing

1. Load CMS.
2. Ensure Portal Nav gently pushed search to the left.
3. Load Docs.
4. Ensure Portal Nav gently pushed search to the left.
5. Load Portal.
6. Ensure Portal Nav loads before search i.e. search is not pushed anywhere.

# Notes

## Known Issue

1. Does not work on Docs unless Docs has (commits from) branch `task/GH-101-header-redesign`.
2. (pre-existing defect) The width of Portal Nav on CMS & Docs differs from Portal (may be related to font size of whitespace).