### PR TITLE
GH-101: Portal Nav Mobile - Layout Change

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/media-queries.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/media-queries.css
@@ -58,3 +58,9 @@ Styleguide Tools.CustomMediaQueries.Breakpoints
    - `...-sm` → `--x-narrow-and-...` */
 @custom-media --nav-compressed (width < 992px);
 @custom-media --nav-expanded (width >= 992px);
+
+/* Arbitrary widths below and above `--nav-compressed` and `--nav-expanded` */
+@custom-media --nav-narrow-and-below (width < 768px);
+@custom-media --nav-narrow-and-above (width >= 768px);
+@custom-media --nav-wide-and-below (width < 1200px);
+@custom-media --nav-wide-and-above (width >= 1200px);

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-mobile-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-mobile-button.css
@@ -61,7 +61,6 @@ Styleguide Tools.ExtendsAndMixins.MobileButton
   /* FAQ: The flex properties require `display` of `grid` or `inline-grid` */
   /* display: grid; *//* set this externally */
 
-  display: grid;
   grid-auto-flow: column;
   grid-template-rows: auto;
   justify-items: center;

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-mobile-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-mobile-button.css
@@ -3,16 +3,54 @@ Mobile Button (or Link)
 
 Styles to lay out button icon, text, and toggle in a compressed area.
 
-%x-mobile-button--toggle-on-side - Support toggle positioned on side of button
+`x-mobile-button--has-toggle`
+```
+┌────────────┬───┐
+│            │   │
+│            │   │
+│    Icon    │   │
+├────────────┤ ▼ │
+│    Text    │   │
+│            │   │
+└────────────┴───┘
+```
+
+`x-mobile-button--no-toggle`
+```
+┌────────────────┐
+│                │
+│                │
+│      Icon      │
+├────────────────┤
+│      Text      │
+│                │
+└────────────────┘
+```
+
+`x-mobile-button--only-icon`
+```
+┌────────────────┐
+│                │
+│                │
+│                │
+│      Icon      │
+│                │
+│                │
+└────────────────┘
+```
+
+%x-mobile-button--has-toggle - Position toggle (assumed) on side of button
+%x-mobile-button--no-toggle  - Do not position toggle (would fall to bottom)
+%x-mobile-button--only-icon  - Position icon (no other el's) in center of button
 
 Styleguide Tools.ExtendsAndMixins.MobileButton
 */
 
-/* WARNING: A button must have `display: (inline-)flex` set externally */
-/* FAQ: Why not set `display: flex` here?
+/* WARNING: A button must have `display: (inline-)grid` set externally */
+/* FAQ: Why not set `display: grid` here?
         - It may break a button conditionally dependent on `display: none`.
-        - It would be overridden if button needs `display: inline-flex`.
-        - It makes user aware of the complexity of `display` and `flex`.
+        - It would be overridden if button needs `display: inline-grid`.
+        - It makes user aware of the complexity of `display` and `grid`.
 */
 
 
@@ -20,19 +58,28 @@ Styleguide Tools.ExtendsAndMixins.MobileButton
 /* Base */
 
 %x-mobile-button {
-  /* FAQ: The flex properties require `display` of `flex` or `inline-flex` */
-  /* display: flex; *//* set this externally */
+  /* FAQ: The flex properties require `display` of `grid` or `inline-grid` */
+  /* display: grid; *//* set this externally */
 
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: auto;
+  justify-items: center;
 }
 
 
 
 /* Elements */
 
+%x-mobile-button__icon {
+  grid-area: icon;
+}
+
 %x-mobile-button__text {
+  grid-area: text;
+
+  align-self: start;
+
   font-family: var(--global-font-family--sans);
   font-size: 10px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
   text-align: center;
@@ -40,15 +87,41 @@ Styleguide Tools.ExtendsAndMixins.MobileButton
   font-weight: env(--medium);
 }
 
+%x-mobile-button__toggle {
+  grid-area: toggle;
+
+  align-self: center;
+}
 
 
 /* Modifiers */
 
-%x-mobile-button--toggle-on-side {
+%x-mobile-button--has-toggle,
+%x-mobile-button--no-toggle {
+  /* To make icon and text appear vertically centered as a group */
+  grid-template-rows: auto 16px; /* a tad taller than text line height */
+
+  align-items: end;
+}
+
+%x-mobile-button--has-toggle {
   @extend %x-mobile-button;
 
-  /* FAQ: A height is required to force toggle to wrap */
-  /* height: 60px; *//* set this externally */
+  grid-template-areas:
+    "icon toggle"
+    "text toggle";
+}
+%x-mobile-button--no-toggle {
+  @extend %x-mobile-button;
 
-  flex-wrap: wrap;
+  grid-template-areas:
+    "icon"
+    "text";
+}
+%x-mobile-button--only-icon {
+  @extend %x-mobile-button;
+
+  align-items: center; /* To vertically center icon */
+  grid-template-areas:
+    "icon";
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
@@ -10,7 +10,6 @@ Styleguide Trumps.Scopes.Header.Compressed
 
 
 
-
 /* COMPARABLE (to Expanded Styles) */
 
 @media (--nav-compressed) {
@@ -46,7 +45,7 @@ Styleguide Trumps.Scopes.Header.Compressed
   /* Containers */
 
   .s-header .navbar-collapse {
-    margin-right: env(--header-navbar-toggle-width);
+    margin-right: env(--header-navbar-right-pad);
 
     background-color: rgba(var(--global-color-primary--x-dark-rgb), 0.6);
     backdrop-filter: blur(18px) brightness(85%);
@@ -80,6 +79,9 @@ Styleguide Trumps.Scopes.Header.Compressed
 
     font-size: 2em;
   }
+  /* To match lines with `s-header.compressed.css` */
+  /* FAQ: Matching lines eases comparison with `s-header.compressed.css` */
+  /* .s-header .s-portal-nav .nav-link { } */
 
   /* NOTE: Design may want hover .s-header active background color with alpha */
   /* SEE: `./s-header.css` */
@@ -112,17 +114,14 @@ Styleguide Trumps.Scopes.Header.Compressed
 
   /* Search */
 
-  .s-header .s-search-bar,
-  /* To apply style to old markup (see "Portal & Docs Selectors") */
-  /* TODO: 1. Remove `ml-auto` from Portal & Docs markup
-           2. Remove the ` !important`
-           3. Remove the subsite selectors */
-  :--for-docs .s-header .s-search-bar.ml-auto,
-  :--for-portal .s-header .s-search-bar.ml-auto {
-    /* To line up menu text with logo */
-    margin-left: calc(
-      env(--portal-sidebar-padding) + env(--portal-navlink-padding)
-    ) !important;
+  /* To add constant space between CMS nav and search bar */
+  .s-header .s-search-bar {
+    /* To line up menu content with logo */
+    margin-left: env(--header-navbar-left-pad);
+  }
+  /* To shove portal nav into same row as search bar */
+  .s-header .s-portal-nav {
+    margin-top: calc(-1 * env(--header-navbar-mobile-height));
   }
 
   .s-header .s-search-bar,
@@ -131,18 +130,14 @@ Styleguide Trumps.Scopes.Header.Compressed
     font-size: 18px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
   }
 
-  /* Create space between search bar and login (only if both elements exist) */
-  .s-header .s-search-bar ~ .s-portal-nav {
-    margin-left: 2px;
-  }
-
 
 
 
 
   /* Icons */
 
-  .s-header .s-cms-nav .nav-icon {
+  .s-header .s-cms-nav .nav-icon,
+  .s-header .s-portal-nav .dropdown-item .nav-icon {
     margin-right: 0.5em;
   }
 
@@ -159,6 +154,8 @@ Styleguide Trumps.Scopes.Header.Compressed
 
 /* UNIQUE (to Compressed Styles) */
 
+
+
 /* Basic Media Range */
 
 @media (--nav-compressed) {
@@ -169,10 +166,8 @@ Styleguide Trumps.Scopes.Header.Compressed
 
   /* To add nav menu padding */
   .s-header .navbar-nav {
-    /* To line up menu text with logo */
-    --nav-link-horz-pad: calc(
-      env(--portal-sidebar-padding) + env(--portal-navlink-padding)
-    );
+    /* To line up menu content with logo */
+    --nav-link-horz-pad: env(--header-navbar-left-pad);
   }
 
   /* To overwrite Bootstrap */
@@ -187,11 +182,31 @@ Styleguide Trumps.Scopes.Header.Compressed
   /* To add dropdown menu padding */
   .s-header .s-cms-nav .dropdown-menu {
     /* To match nav menu padding (because spacing in design is so similar) */
-    --menu-link-horz-pad: calc(
-      env(--portal-sidebar-padding) + env(--portal-navlink-padding)
-    );
+    margin-left: var(--menu-link-horz-pad, env(--header-navbar-left-pad));
+  }
 
-    margin-left: var(--menu-link-horz-pad);
+  /* To set height of "top row" (search bar & portal nav) of mobile nav */
+  /* FAQ: Setting height of search bar is not respected as navbar collapses */
+  /* FAQ: Setting height of portal nav would hide portal nav dropdown menu */
+  .s-header tacc-search-bar.s-search-bar::part(form),
+  .s-header .s-portal-nav .nav-link {
+    height: var(--header-navbar-height);
+  }
+  .s-header .s-portal-nav .nav-link {
+    margin-left: auto; /* to align right compared to dropdown menu */
+  }
+
+  /* To make background for "top row" (search bar & portal nav) of mobile nav */
+  /* HACK: Create background with a pseudo element that matches "row" height */
+  .s-header .s-portal-nav .dropdown::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    z-index: -1;
+    background-color: env(--header-bkgd-color);
   }
 
   /* HACK: To transform the navbar into a dropdown */
@@ -215,41 +230,15 @@ Styleguide Trumps.Scopes.Header.Compressed
   .s-header .navbar-collapse.show,
   .s-header .navbar-collapse.collapsing {
     display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: center;
+    flex-direction: column;
   }
-  .s-header .navbar-collapse > *:not(.s-portal-nav, .s-search-bar) {
-    flex-basis: 100%;
-  }
-  /* To let portal nav & search fit "comfortably" together on thier row */
-  .s-header .s-portal-nav { flex: 0 1 auto }
-  .s-header .s-search-bar { flex: 1 1 auto }
-  /* To let search fill up available space */
+  /* To make content of search bar fill up available space */
   .s-header tacc-search-bar.s-search-bar::part(form) { width: 100%; }
   /* To move portal nav & search to top of menu */
-  .s-header .s-portal-nav { order: -1 }
-  .s-header .s-search-bar { order: -2 }
+  /* FAQ: The `z-index` ensures portal nav allows click through to search */
+  .s-header .s-portal-nav { order: -1; z-index: 1 }
+  .s-header .s-search-bar { order: -2; z-index: 2 }
 
-  /* To style "Log In" and "username" like navbar toggle button */
-  .s-header .s-portal-nav .nav-link {
-    @extend %x-mobile-button--has-toggle;
-    display: grid;
-
-    /* width: env(--header-navbar-toggle-width); */
-
-    height: var(--header-navbar-height);
-    padding: 0; /* to overwrite Bootstrap */
-  }
-  .s-header .s-portal-nav .nav-link .nav-icon {
-    @extend %x-mobile-button__icon;
-  }
-  .s-header .s-portal-nav .nav-link .nav-text {
-    @extend %x-mobile-button__text;
-  }
-  .s-header .s-portal-nav .nav-link::after {
-    @extend %x-mobile-button__toggle;
-  }
 
 
   /* Dropdowns */
@@ -257,38 +246,19 @@ Styleguide Trumps.Scopes.Header.Compressed
   /* To overwrite Bootstrap */
   .s-header .dropdown-menu {
     padding: 0;
+
+    font-size: 20px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
   }
   .s-header .s-cms-nav .dropdown-menu {
     background-color: transparent;
     border: none;
-
-    font-size: 20px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
   }
   .s-header .s-portal-nav .dropdown-menu {
     background-color: env(--header-link-bkgd-color);
     border: none;
-  }
-  /* To overwrite Bootstrap */
-  /* To allow Portal nav menu to still drop down over content on small screen */
-  .s-header .s-portal-nav .dropdown-menu {
-    /* Copied from Bootstrap:
-       ```
-       @media (min-width: ...px) {
-          .navbar-expand-…… .navbar-nav .dropdown-menu
-       }
-       ``` */
-    position: absolute; /* without this, menu pushes down content beneath it */
-  }
-  /* To compensate for CMS's Bootstrap version older than Portal & Docs */
-  :--for-cms .dropdown-menu-right {
-    /* Copied from Bootstrap:
-       ```
-       @media (min-width: ...px) {
-          .navbar-expand-…… .navbar-nav .dropdown-menu-right
-       }
-       ``` */
-    right: 0;
-    left: auto;
+
+    width: max-content;
+    margin-left: auto;
   }
 
   /* To distinguish CMS dropdown from Portal dropdown */
@@ -302,8 +272,6 @@ Styleguide Trumps.Scopes.Header.Compressed
     /* To overwrite Bootstrap */
     padding-top: 0.8em;
     padding-bottom: 0.8em;
-
-    font-size: 2em;
   }
 
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.compressed.css
@@ -65,7 +65,7 @@ Styleguide Trumps.Scopes.Header.Compressed
   /* Button */
   /* To ensure button remains hidden on expanded navbar, isolate this style */
   /* FAQ: The button as `.navbar-toggler` uses `display: none` from Bootstrap */
-  .s-header :--navbar-button { display: flex; }
+  .s-header :--navbar-button { display: grid; }
 
 
 
@@ -233,17 +233,22 @@ Styleguide Trumps.Scopes.Header.Compressed
 
   /* To style "Log In" and "username" like navbar toggle button */
   .s-header .s-portal-nav .nav-link {
-    @extend %x-mobile-button--toggle-on-side;
-    display: flex;
+    @extend %x-mobile-button--has-toggle;
+    display: grid;
 
-    /* To ensure dropdown toggle wraps by limiting available content height */
-    height: 56px;
-    padding-top: 5px; /* to overwrite Boostrap */
-    padding-bottom: 5px; /* to overwrite Boostrap */
+    /* width: env(--header-navbar-toggle-width); */
+
+    height: var(--header-navbar-height);
+    padding: 0; /* to overwrite Bootstrap */
   }
-  /* FAQ: The extra `.nav-link` specificity avoids styling dropdown link text */
+  .s-header .s-portal-nav .nav-link .nav-icon {
+    @extend %x-mobile-button__icon;
+  }
   .s-header .s-portal-nav .nav-link .nav-text {
     @extend %x-mobile-button__text;
+  }
+  .s-header .s-portal-nav .nav-link::after {
+    @extend %x-mobile-button__toggle;
   }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -147,10 +147,8 @@ Styleguide Trumps.Scopes.Header
   /* To overwrite Bootstrap */
   margin-right: var(--space-after-logo-before-nav);
 
-  /* To align logo (whole image not just visible pixels) with Portal sidebar */
-  margin-left: calc(
-    env(--portal-sidebar-padding) + env(--portal-navlink-padding)
-  );
+  /* To align logo (whole image not just visible pixels) with Portal content */
+  margin-left: env(--header-navbar-left-pad);
 
   /* FAQ: In case image does not load and browser shows alt text */
   color: env(--header-text-color);
@@ -187,10 +185,6 @@ Styleguide Trumps.Scopes.Header
   --nav-line-color: …
   */
 }
-/* To distinguish Portal nav from CMS nav */
-.s-header .s-portal-nav {
-  background-color: env(--header-portal-nav-bkgd-color);
-}
 
 
 
@@ -208,7 +202,7 @@ Styleguide Trumps.Scopes.Header
   /* display: grid; *//* SEE `s-header.compressed.css` */
 
   width: env(--header-navbar-toggle-width);
-  margin-right: env(--header-navbar-toggle-width);
+  margin-right: env(--header-navbar-right-pad);
   padding: 0; /* to overwrite Bootstrap */
 
   background-color: env(--header-portal-nav-bkgd-color);
@@ -287,6 +281,10 @@ Styleguide Trumps.Scopes.Header
   display: flex;
   align-items: center;
 }
+.s-header .s-portal .nav-link {
+  /* To horizontally center align icon, text, and toggle as a group */
+  justify-content: center;
+}
 
 /* To truncate link text */
 .s-header .nav-item { min-width: 0; }
@@ -319,14 +317,74 @@ Styleguide Trumps.Scopes.Header
   padding-right: var(--nav-link-horz-pad, 0);
   padding-left: var(--nav-link-horz-pad, 0);
 }
-.s-header .s-portal-nav .nav-link,
-/* To overwrite Bootstrap (see "Portal & Docs Selectors") */
-:--for-portal .s-portal-nav .nav-link {
-  padding-left: 30px;
-  /* To match space betwwen logo and left side of window */
-  --nav-link-horz-pad: calc(
-    env(--portal-sidebar-padding) + env(--portal-navlink-padding)
-  );
+
+/* To match design of expanded navbar Portal Nav but take liberty with when */
+@media (--nav-expanded), /* match design */
+       (--nav-narrow-and-above) and (--nav-compressed) /* dev liberty */ {
+
+  .s-header .s-portal-nav .nav-link,
+  /* To overwrite Bootstrap (see "Portal & Docs Selectors") */
+  :--for-portal .s-portal-nav .nav-link {
+    padding-left: 30px;
+    /* To match space betwwen logo and left side of window */
+    --nav-link-horz-pad: env(--header-navbar-left-pad);
+  }
+  .s-header .s-portal-nav .nav-link .nav-icon {
+    margin-right: 0.5em;
+  }
+
+}
+/* To match design of collapsed navbar Portal Nav but take liberty with when */
+@media (--nav-narrow-and-above) and (--nav-compressed) /* dev liberty */ {
+
+
+  /* To make space for portal nav in which to shove portal nav */
+  .s-header .s-search-bar {
+    --space-after-search-before-nav: calc(
+      env(--portal-navlink-normal-max-width) + 2px
+    );
+  }
+  .s-header .s-portal-nav .nav-link {
+    /* To prevent width expansion upon dropdown menu open */
+    width: env(--portal-navlink-normal-max-width);
+  }
+
+}
+@media (--nav-narrow-and-below) {
+
+  /* To make space for portal nav in which to shove portal nav */
+  .s-header .s-search-bar {
+    --space-after-search-before-nav: calc(
+      env(--portal-navlink-mobile-max-width) + 2px
+    );
+  }
+  .s-header .s-portal-nav .nav-link {
+    /* To prevent width expansion upon dropdown menu open */
+    width: env(--portal-navlink-mobile-max-width);
+  }
+
+  /* To style "Log In" and "username" like navbar toggle button */
+  .s-header .s-portal-nav .nav-link {
+    @extend %x-mobile-button--has-toggle;
+    display: grid;
+
+    min-width: calc(2 * env(--header-navbar-toggle-width)); /* dev liberty */
+    margin-right: 0; /* to overwrite (--nav-expanded) `.s-header .nav-icon` */
+
+    padding-top: 0; /* to overwrite Bootstrap */
+    padding-bottom: 0; /* to overwrite Bootstrap */
+    --nav-link-horz-pad: 1em;
+  }
+  .s-header .s-portal-nav .nav-link .nav-icon {
+    @extend %x-mobile-button__icon;
+  }
+  .s-header .s-portal-nav .nav-link .nav-text {
+    @extend %x-mobile-button__text;
+  }
+  .s-header .s-portal-nav .nav-link::after {
+    @extend %x-mobile-button__toggle;
+  }
+
 }
 
 /* To create line between each item */
@@ -435,4 +493,19 @@ Styleguide Trumps.Scopes.Header
 :--for-portal .s-header .dropdown-item:focus,
 :--for-portal .s-header .dropdown-item:hover {
   color: env(--header-text-color);
+}
+
+
+
+
+
+/* Search */
+
+/* Create space between search bar and login (only if both elements exist) */
+.s-header.is-on-portal .s-search-bar,
+/* To apply style to old markup (see "Portal & Docs Selectors") */
+/* TODO: Hardcode `is-on-portal` in Portal & Docs markup */
+:--for-docs .s-header .s-search-bar,
+:--for-portal .s-header .s-search-bar {
+  margin-right: var(--space-after-search-before-nav, 0);
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.css
@@ -205,8 +205,7 @@ Styleguide Trumps.Scopes.Header
 
 /* Button */
 .s-header :--navbar-button {
-  @extend %x-mobile-button--toggle-on-side;
-  /* display: flex; *//* SEE `s-header.compressed.css` */
+  /* display: grid; *//* SEE `s-header.compressed.css` */
 
   width: env(--header-navbar-toggle-width);
   margin-right: env(--header-navbar-toggle-width);
@@ -218,6 +217,8 @@ Styleguide Trumps.Scopes.Header
   border: none;
   border-radius: 0;
 }
+.s-header :--navbar-button--opened { @extend %x-mobile-button--only-icon; }
+.s-header :--navbar-button--closed { @extend %x-mobile-button--no-toggle; }
 /* To isolate styles that require more specificity to override Portal */
 .s-header :--navbar-button,
 /* To overwrite Bootstrap (see "Portal & Docs Selectors") */
@@ -254,6 +255,9 @@ Styleguide Trumps.Scopes.Header
   @extend %x-mobile-button__text;
 
   content: attr(data-icon-label);
+}
+.s-header .navbar-toggler-icon {
+  @extend %x-mobile-button__icon;
 }
 .s-header :--navbar-button--opened::after { display: none; }
 /* To apply style to old markup (see "Portal & Docs Selectors") */

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.expanded.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-header.expanded.css
@@ -79,6 +79,9 @@ Styleguide Trumps.Scopes.Header.Expanded
 
     /* font-size: 1em; *//* to mirror props on `s-header.compressed.css` */
   }
+  .s-header .s-portal-nav .nav-link {
+    background-color: env(--header-portal-nav-bkgd-color);
+  }
 
   /* NOTE: Design may want hover .s-header active background color with alpha */
   /* SEE: `./s-header.css` */
@@ -113,26 +116,23 @@ Styleguide Trumps.Scopes.Header.Expanded
 
   /* To add flexible space between CMS nav and search bar */
   .s-header .s-search-bar {
+    --space-after-search-before-nav: 12px;
+
     /* To match lines with `s-header.compressed.css` */
     /* FAQ: Matching lines eases comparison with `s-header.compressed.css` */
 
-
-
-
+    /* To insert flexible space */
     margin-left: auto;
-
-
   }
+
+  /* To match lines with `s-header.compressed.css` */
+  /* FAQ: Matching lines eases comparison with `s-header.compressed.css` */
+
 
   .s-header .s-search-bar,
   .s-header .s-search-bar::part(input),
   .s-header .s-search-bar::part(button) {
     font-size: 14px; /* WARNING: Do not use `rem` until `html { 62.5%; }` */
-  }
-
-  /* Create space between search bar and login (only if both elements exist) */
-  .s-header .s-search-bar ~ .s-portal-nav {
-    margin-left: 12px;
   }
 
 
@@ -141,7 +141,8 @@ Styleguide Trumps.Scopes.Header.Expanded
 
   /* Icons */
 
-  .s-header .nav-icon {
+  .s-header .s-cms-nav .nav-icon,
+  .s-header .s-portal-nav .nav-icon {
     margin-right: 0.5em;
   }
 
@@ -157,7 +158,6 @@ Styleguide Trumps.Scopes.Header.Expanded
 
 
 /* UNIQUE (to Expanded Styles) */
-
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-portal-nav.css
@@ -16,28 +16,33 @@ Styleguide Trumps.Scopes.PortalNav
 
 /* Container */
 
-/* To have Portal Nav gently push—not abruptly shove—elements to make room */
-/* FAQ: Load Portal Nav with zero width, then transition to normal width */
-/* FAQ: Portal loads Portal Nav statically, so no need to ever hide it */
-.s-portal-nav[data-status] {
-  flex-shrink: 0;
+@media (--nav-expanded) {
 
-  transition: max-width 0.5s ease-out;
-  max-width: 0;
-}
-.s-portal-nav:not([data-status]) /* To assume load for unsupported markup */,
-.s-portal-nav[data-status="loaded"] {
-  /* To let width grow, use explicit value, and not constrain width */
-  /* FAQ: No support for transition to `width: auto` nor `max-width: 100%` */
-  /* SEE: https://css-tricks.com/using-css-transitions-auto-dimensions/ */
-  /* FAQ: Value is normal width of logged in nav with 8-char (max) username */
-  /* CAVEAT: Change of space or dimension of portal nav items affects value */
-  max-width: 212px !important; /* override `:--for-cms` and `:--for-docs` */
-}
-/* To ensure content that is off screen does not cause scrollbar for <body> */
-/* FAQ: The specific conditional hide ensures dropdown menu is not hidden */
-.s-portal-nav .dropdown:not(.show) {
-  overflow: hidden;
+  /* To have Portal Nav gently push—not abruptly shove—elements to make room */
+  /* FAQ: Load Portal Nav with zero width, then transition to normal width */
+  /* FAQ: Portal loads Portal Nav statically, so no need to ever hide it */
+  .s-portal-nav[data-status] {
+    flex-shrink: 0;
+
+    transition: max-width 0.5s ease-out;
+    max-width: 0;
+  }
+  .s-portal-nav:not([data-status]) /* To assume load for unsupported markup */,
+  .s-portal-nav[data-status="loaded"] {
+    /* To let width grow, use explicit value, and not constrain width */
+    /* FAQ: No support for transition to `width: auto` nor `max-width: 100%` */
+    /* SEE: https://css-tricks.com/using-css-transitions-auto-dimensions/ */
+    /* FAQ: Value is normal width of logged in nav with 8-char (max) username */
+    /* CAVEAT: Change of space or dimension of portal nav items affects value */
+    /* FAQ: The `!important` overrides `:--for-cms` and `:--for-docs` */
+    max-width: 212px !important;
+  }
+  /* To ensure content that is off screen does not cause scrollbar for <body> */
+  /* FAQ: The specific conditional hide ensures dropdown menu is not hidden */
+  .s-portal-nav .dropdown:not(.show) {
+    overflow: hidden;
+  }
+
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_themes/constants.json
+++ b/taccsite_cms/static/site_cms/css/src/_themes/constants.json
@@ -6,8 +6,10 @@
   "environment-variables": {
 
     "// PORTAL": "",
-    "--portal-sidebar-padding": "16px",
-    "--portal-navlink-padding": "20px",
+    "--portal-sidebar-pad": "16px",
+    "--portal-navlink-pad": "20px",
+    "--portal-navlink-normal-max-width": "206px",
+    "--portal-navlink-mobile-max-width": "112px",
 
     "// HEADER": "",
     "--header-font-family": "Roboto, sans-serif",
@@ -17,6 +19,10 @@
     "--header-navbar-normal-height": "55px",
     "--header-navbar-mobile-height": "48px",
     "--header-navbar-toggle-width": "48px",
+    "--header-navbar-right-pad": "48px",
+    "// --header-navbar-left-pad: 16px": "--portal-sidebar-pad",
+    "// --header-navbar-left-pad: 20px": "--portal-navlink-pad",
+    "--header-navbar-left-pad": "calc(16px + 20px)",
 
     "// BORDER": "",
     "--border-width--normal": "1px",


### PR DESCRIPTION
# Overview

Change portal nav layout to be "pushdown" menu instead of "dropdown" menu.¹

> The location of portal nav in mobile was not moved as was planned for this PR.

¹ See "Known Issues" 1.

# Issues

- #101

# Changes

- __New__: Convert "mobile button" layout from flex to grid.
    - Update "mobile button" instances accordingly.
- __New__: Add more nav media queries.
- _Minor_: Use new constants.
- __New__: Shove Portal Nav up into Search Bar row (do not properly share 1 row).
- __Fix__: Ensure icon spacing is accurate given different nav states.
- __Fix__: Add background for Portal Nav & Search Bar "row".
- __New__: Make all mobile dropdown menu items have same font size.
- __New__: Retain wide portal nav for one breakpoint within collapsed navbar.
- __New__: Limit Portal Nav load transition to when navbar is expanded.
- __New__: Add new constants.

# Testing

1. Resize window to be narrow (≤767px).
2. Follow checklist for CMS, Docs, and Portal:
    - Portal Nav icon, when logged _in_ **and** when logged _out_, is narrow.
    - Portal Nav toggle/link is aligned to the right.
    - Portal Nav toggle/link is one one row with only the search bar.¹
    - Portal Nav menu (requires log in) pushes down CMS Nav menu.
1. Resize window to be narrow (≤991px).
2. Follow checklist for CMS, Docs, and Portal:
    - Portal Nav icon, when logged _in_ **and** when logged _out_, is wide.
    - Portal Nav toggle/link is aligned to the right.
    - Portal Nav toggle/link is one one row with only the search bar.¹
    - Portal Nav menu (requires log in) pushes down CMS Nav menu.
1. Resize window to be narrow (>992px).
2. Follow checklist for CMS, Docs, and Portal:
    - Portal Nav icon, when logged _in_ **and** when logged _out_, is wide.
    - Portal Nav toggle/link is aligned to the right.
    - Portal Nav toggle/link is one one row with the logo, CMS nav, and search bar.
    - Portal Nav menu (requires log in) drops down over content beneath header.

¹ See "Known Issues" 1.
² Can not test logged out Portal Nav on Portal.

# Notes

## Known Issues

1. <details><summary>Portal nav location is not as <em>verbally</em> described by designer.</summary>

    The result matches the static design, and invents solutions for what the design does not define.

    The designer has verbally described the desired (undrawn) behavior for the mobile portal nav. It should be at the right of the navbar toggle, and always (when visible¹) a similar size to the navbar toggle (when visible¹).

    But this change only changes mobile portal nav menu from a "dropdown" menu to a "pushhdown" menu and experiments with wide and narrow mobile portal nav toggle/link designs. The change here is simpler, tests the ability to move the portal nav outside its position in the markup, and tests nav-specific breakpoints narrow and wider than just when the navbar collapses/expands.

    ¹ The mobile portal nav and the navbar toggle are not visible on wide screens.

    </details>