### PR TITLE
Quick: New Test: Custom Media Queries are Constant

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/_tests/postcss-preset-env.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/_tests/postcss-preset-env.css
@@ -26,6 +26,26 @@ Styleguide _Test.PresetEnv
   }
 }
 
+/*! Goal: */
+@media (max-width:60em){._test{background-color:red}}@media (max-width:60em){._test{background-color:blue}}
+
+/*! Test: */
+@custom-media --test-window (min-width: 30em);
+
+@media (--test-window) {
+  ._test {
+    background-color: red;
+  }
+}
+
+@custom-media --test-window (min-width: 60em);
+
+@media (--test-window) {
+  ._test {
+    background-color: blue;
+  }
+}
+
 /*! Media Query Ranges */
 /* SEE: https://preset-env.cssdb.org/features#media-query-ranges */
 
@@ -43,7 +63,6 @@ Styleguide _Test.PresetEnv
 }
 
 /*! Custom Media Queries & Media Query Ranges */
-/* SEE: https://preset-env.cssdb.org/features#custom-media-queries */
 
 /*! Goal: */
 @media (min-width:992px) and (max-width:1199px){._test{background-color:red}}


### PR DESCRIPTION
# Goal

- Test whether custom media queries are constant.
- Prevent need to research this later by providing proof.

# Background

@tacc-wbomar considered variable custom media queries as a solution to a problem in GH-101.¹

<details>
<summary>Footnotes</summary>

¹ The problem was (A) breakpoint-aware markup differed between CMS (updated header) and Portal+Docs (header not updated yet) **and** (B) GH-101 was intend to update the header without _requiring_ (immediate) update to Portal+Docs **where** (A) prevented (B). The solution was to change custom media query definitions at runtime within Portal+Docs selectors.

</details>