### PR TITLE
Hotfix: GH-101: Match Portal+Docs Nav Breakpoint

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/media-queries.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/media-queries.css
@@ -56,11 +56,11 @@ Styleguide Tools.CustomMediaQueries.Breakpoints
    - `...-lg` → `--medium-and-...`
    - `...-md` → `--narrow-and-...`
    - `...-sm` → `--x-narrow-and-...` */
-@custom-media --nav-compressed (width < 992px);
-@custom-media --nav-expanded (width >= 992px);
+@custom-media --nav-compressed (width < 1200px);
+@custom-media --nav-expanded (width >= 1200px);
 
 /* Arbitrary widths below and above `--nav-compressed` and `--nav-expanded` */
-@custom-media --nav-narrow-and-below (width < 768px);
-@custom-media --nav-narrow-and-above (width >= 768px);
-@custom-media --nav-wide-and-below (width < 1200px);
-@custom-media --nav-wide-and-above (width >= 1200px);
+@custom-media --nav-narrow-and-below (width < 576px);
+@custom-media --nav-narrow-and-above (width >= 576px);
+@custom-media --nav-wide-and-below (width < 1400px);
+@custom-media --nav-wide-and-above (width >= 1400px);

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -8,7 +8,7 @@
 <!-- Navigation Bar -->
 {# NOTE: `navbar-expand-*` maps to a `media-queries.css`'s `--nav-*` value #}
 {# CAVEAT: The mobile nav CSS can NOT support conditional `navbar-expand-*` #}
-<nav id="header-navbar" class="s-header  navbar navbar-dark navbar-expand-lg  {% if settings.PORTAL %}is-on-portal{% endif %}">
+<nav id="header-navbar" class="s-header  navbar navbar-dark navbar-expand-xl  {% if settings.PORTAL %}is-on-portal{% endif %}">
   <!-- Portal Logo -->
   {% include "header_logo.html" %}
 


### PR DESCRIPTION
# Overview

Make CMS match Portal & Docs navbar collapse breakpoint.

> __Caveat__: This makes a _stand-alone CMS_ navbar collapse for a wider screen than it did before (and than is necessary). _For CMS's that have a Portal, there is no change._

</details>

# Changes

- __New__/__Fix__: Use `navbar-expand-lg` (for now) to match Portal & Docs.

# Testing

- Load Docs, CMS, and Portal.
- Ensure all three have the same navbar styling and collapsing at these breakpoints:
   - ≥ 1200px
   - 576px – 1200px
   - < 576px 

# Notes

- Ideally CSS can change media queries to match diff markup per subsite.
- But there is __not__ a feasible CSS way to do this.
- And the effort for a way it can be done (nesting rules) is too great.
- So great an effort I might as well update Portal & Docs markup.