### PR TITLE
GH-253: Initial Pattern Library Template & Styles

### DIFF
--- a/taccsite_cms/default_secrets.py
+++ b/taccsite_cms/default_secrets.py
@@ -81,7 +81,11 @@ _CMS_TEMPLATES = (
     # ('guides/getting_started.html', 'Guide: Getting Started'),
     # ('guides/data_transfer.html', 'Guide: Data Transfer'),
     # ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
-    # ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
+    # ('guides/portal_technology.html', 'Guide: Portal Technology Stack'),
+
+    # For now, only Core portal should enable this template
+    # FAQ: We know not yet how to auto-replicate pages and plugins across sites
+    # ('style_guide.html', 'Style Guide'),
 )
 
 ########################

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-style-guide.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-style-guide.css
@@ -1,0 +1,39 @@
+/*
+Style Guide
+
+A style guide. This is intended for:
+- a design system
+- a writing style guide
+- a developer style guide
+
+Styleguide Trumps.Scopes.StyleGuide
+*/
+
+.s-style-guide {
+  margin-top: var(--global-space--large);
+  margin-bottom: var(--global-space--x-large);
+}
+
+
+
+
+
+/* ELEMENTS */
+
+
+
+/* ELEMENTS: Content Sectioning */
+
+.s-style-guide section {
+  clear: both;
+}
+.s-style-guide section:not(section section) {
+  border-top: var(--global-border--x-thick);
+  padding-top: var(--global-space--x-large);
+  margin-top: var(--global-space--x-large);
+}
+.s-style-guide section section {
+  border-top: var(--global-border--normal);
+  padding-top: var(--global-space--normal);
+  margin-top: var(--global-space--normal);
+}

--- a/taccsite_cms/static/site_cms/css/src/template.style-guide.css
+++ b/taccsite_cms/static/site_cms/css/src/template.style-guide.css
@@ -1,0 +1,8 @@
+/* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
+
+/* Organize via ITCSS */
+/* SEE: https://confluence.tacc.utexas.edu/x/IAA9Cw */
+
+/* TRUMPS */
+
+@import url("_imports/trumps/s-style-guide.css");

--- a/taccsite_cms/templates/style_guide.html
+++ b/taccsite_cms/templates/style_guide.html
@@ -2,9 +2,9 @@
 {% load cms_tags staticfiles %}
 
 {% block assets_custom %}
-	{{ block.super }}
+  {{ block.super }}
 
-	<link
+  <link
     rel="stylesheet"
     href="{% static 'site_cms/css/build/template.style-guide.css' %}"
   >

--- a/taccsite_cms/templates/style_guide.html
+++ b/taccsite_cms/templates/style_guide.html
@@ -1,0 +1,19 @@
+{% extends "fullwidth.html" %}
+{% load cms_tags staticfiles %}
+
+{% block assets_custom %}
+	{{ block.super }}
+
+	<link
+    rel="stylesheet"
+    href="{% static 'site_cms/css/build/template.style-guide.css' %}"
+  >
+{% endblock assets_custom %}
+
+{% block content %}
+<div class="container  s-document  s-style-guide">
+  {% block guide %}
+    {% placeholder "content" %}
+  {% endblock guide %}
+</div>
+{% endblock content %}


### PR DESCRIPTION
# Overview

Create a basic template and stylesheet for any kind of style guide. Use cases:
- __Pattern Library__*
- Design System
- Writing Style Guide
- Coding Style Guide

\* This is the first use case.

# Issues

* #253

# Changes

* __New__: Add `style-guide` template to secrets.
* __New__: Add `style-guide` stylesheets.
* __New__: Add `style-guide` template.

# Testing

1. Add new entry to `_CMS_TEMPLATES` secrets.
2. Create a page with template "Style Guide".
3. Add "Text" plugin to page and confirm:
    - large space above text
    - larger space below text
4. Add several nested "Style" plugins to page, each using a `<section>` tag, and confirm:
    - top-level `<section>`s have thick border and large space between them
    - low-level `<section>`s have thin border and small space between them

# Notes

## Known Issues

### Ugly & Not Replicable

This solution is:
- manually populated
- developer-facing _— because it has no final design_
- manually propagated

_This will be solved when I know how (see #153)._

Why are you submitting this?
1. I need something to locally showcase plugins during screen-share demos.
2. These files may be used by (future) automatic page population (see #146).