### PR TITLE
Quick: Support Non-Bootstrap Link & Picture Plugins

### DIFF
--- a/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
+++ b/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
@@ -18,6 +18,7 @@ try:
 
     # SEE: https://github.com/django-cms/djangocms-link/issues/163
     plugin_pool.register_plugin(LinkPlugin)
-# CAVEAT: If plugins exist but import statement is inaccurate... silent failure
+# CAVEAT: If import statement fails for reason other than Bootstrap presence,
+#         then that failure, and the failure of this plugin, is silent
 except ImportError:
     pass

--- a/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
+++ b/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
@@ -1,0 +1,23 @@
+# Reregister unregistered LinkPlugin without uninstalling Bootstrap4LinkPlugin
+# FAQ: A Bootstrap link is undesirable but may be used by migrated legacy sites
+# TODO: Drop try/except & load non-standard plugin set for migrated legacy sites
+# FAQ: If we can import both plugins, then re-register LinkPlugin
+#      (because Bootstrap4Link unregistered LinkPlugin)
+try:
+    from cms.plugin_pool import plugin_pool
+    from djangocms_link.cms_plugins import LinkPlugin
+    from djangocms_bootstrap4.contrib.bootstrap4_link.cms_plugins import Bootstrap4LinkPlugin
+
+    # Restore original fields
+    # SEE: https://github.com/django-cms/djangocms-bootstrap4/blob/2.0.0/djangocms_bootstrap4/contrib/bootstrap4_link/cms_plugins.py#L26-L42
+    # SEE: https://github.com/django-cms/djangocms-link/blob/3.0.0/djangocms_link/cms_plugins.py#L20-L23
+    LinkPlugin.fieldsets[0][1]['fields'] = (
+        'name',
+        ('external_link', 'internal_link'),
+    )
+
+    # SEE: https://github.com/django-cms/djangocms-link/issues/163
+    plugin_pool.register_plugin(LinkPlugin)
+# CAVEAT: If plugins exist but import statement is inaccurate... silent failure
+except ImportError:
+    pass

--- a/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
+++ b/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
@@ -1,4 +1,4 @@
-# Reregister unregistered LinkPlugin without uninstalling Bootstrap4LinkPlugin
+# Reregister unregistered LinkPlugin without uninstalling Bootstrap4's
 # FAQ: A Bootstrap link is undesirable but may be used by migrated legacy sites
 # TODO: Drop try/except & load non-standard plugin set for migrated legacy sites
 # FAQ: If we can import both plugins, then re-register LinkPlugin

--- a/taccsite_cms/contrib/bootstrap4_djangocms_picture/cms_plugins.py
+++ b/taccsite_cms/contrib/bootstrap4_djangocms_picture/cms_plugins.py
@@ -1,0 +1,14 @@
+# Reregister unregistered PicturePlugin without uninstalling Bootstrap4's
+# FAQ: A Bootstrap picture has superfluous options that are not always desirable
+# FAQ: If we can import both plugins, then re-register PicturePlugin
+#      (because Bootstrap4Picture unregistered PicturePlugin)
+try:
+    from cms.plugin_pool import plugin_pool
+    from djangocms_picture.cms_plugins import PicturePlugin
+    from djangocms_bootstrap4.contrib.bootstrap4_picture.cms_plugins import Bootstrap4PicturePlugin
+
+    # SEE: https://github.com/django-cms/djangocms-bootstrap4/blob/master/djangocms_bootstrap4/contrib/bootstrap4_picture/cms_plugins.py#L54
+    plugin_pool.register_plugin(PicturePlugin)
+# CAVEAT: If plugins exist but import statement is inaccurate... silent failure
+except ImportError:
+    pass

--- a/taccsite_cms/contrib/bootstrap4_djangocms_picture/cms_plugins.py
+++ b/taccsite_cms/contrib/bootstrap4_djangocms_picture/cms_plugins.py
@@ -9,6 +9,7 @@ try:
 
     # SEE: https://github.com/django-cms/djangocms-bootstrap4/blob/master/djangocms_bootstrap4/contrib/bootstrap4_picture/cms_plugins.py#L54
     plugin_pool.register_plugin(PicturePlugin)
-# CAVEAT: If plugins exist but import statement is inaccurate... silent failure
+# CAVEAT: If import statement fails for reason other than Bootstrap presence,
+#         then that failure, and the failure of this plugin, is silent
 except ImportError:
     pass

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -238,10 +238,11 @@ INSTALLED_APPS = [
     'taccsite_cms',
     # TODO: Extract TACC CMS UI components into pip-installable plugins
     # FAQ: The djangocms_bootstrap4 library can serve as an example
-    'taccsite_cms.contrib.bootstrap4_djangocms_link',
     'taccsite_cms.contrib.taccsite_sample',
     'taccsite_cms.contrib.taccsite_blockquote',
     'taccsite_cms.contrib.taccsite_offset',
+    # Support djangocms_link and bootstrap4_link simultaneously
+    'taccsite_cms.contrib.bootstrap4_djangocms_link',
 ]
 
 # Convert list of paths to list of dotted module names

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -241,8 +241,9 @@ INSTALLED_APPS = [
     'taccsite_cms.contrib.taccsite_sample',
     'taccsite_cms.contrib.taccsite_blockquote',
     'taccsite_cms.contrib.taccsite_offset',
-    # Support djangocms_link and bootstrap4_link simultaneously
+    # Restore djangocms plugins that bootstrap4 hides
     'taccsite_cms.contrib.bootstrap4_djangocms_link',
+    'taccsite_cms.contrib.bootstrap4_djangocms_picture',
 ]
 
 # Convert list of paths to list of dotted module names

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -238,6 +238,7 @@ INSTALLED_APPS = [
     'taccsite_cms',
     # TODO: Extract TACC CMS UI components into pip-installable plugins
     # FAQ: The djangocms_bootstrap4 library can serve as an example
+    'taccsite_cms.contrib.bootstrap4_djangocms_link',
     'taccsite_cms.contrib.taccsite_sample',
     'taccsite_cms.contrib.taccsite_blockquote',
     'taccsite_cms.contrib.taccsite_offset',


### PR DESCRIPTION
# Overview

Restore support for plugins that `djangocms_bootstrap4` removes (in favor of its own).

_(Because we do not need Bootstrap for every image, link, etcetera.)_

# Changes

- Register new TACC plugin to reregister `LinkPlugin` (if Bootstrap's respective plugin is present).
- Register new TACC plugin to reregister `PicturePluign` (if Bootstrap's respective version is present).

# Screenshots

<details>
<summary>"Generic" ▸ "Image" and "Bootstrap4" ▸ "Picture / Image"</summary>

![PicturePlugin](https://user-images.githubusercontent.com/62723358/123485328-83233000-d5cf-11eb-869a-7d2b0a78973e.png)

</details>

<details>
<summary>"Generic" ▸ "Link" and "Bootstrap4" ▸ "Link / Button"</summary>

(skipped, inconvenient given cross-branch progress on my local environment)

</details>

# Testing

- Ensure that both plugins, "Generic" ▸ "Image" and "Bootstrap4" ▸ "Picture / Image", are available and functional.
- Ensure that both plugins, "Generic" ▸ "Link" and "Bootstrap4" ▸ "Link / Button", are available and functional.