### PR TITLE
bug/FP-1099: Only rebuild index on `Page` type for `publish` or `unpublish` events

### DIFF
--- a/taccsite_cms/signal_processor.py
+++ b/taccsite_cms/signal_processor.py
@@ -2,6 +2,7 @@ from haystack.signals import BaseSignalProcessor
 from django.db import models
 from django.core.management import call_command
 from cms import signals
+from cms.models.pagemodel import Page
 
 
 class RealtimeSignalProcessor(BaseSignalProcessor):
@@ -28,4 +29,5 @@ class RealtimeSignalProcessor(BaseSignalProcessor):
         models.signals.post_delete.disconnect(self.handle_save)
 
     def handle_save(self, **kwargs):
-        call_command('rebuild_index', '--noinput')
+        if type(kwargs.get('instance')) is Page:
+            call_command('rebuild_index', '--noinput')


### PR DESCRIPTION
### Overview
As it was, the cms elasticsearch index would rebuild for every publish and unpublish event sent from the cms. This means a new rebuild event for every cms model or snippet on a page. This task pares down the `rebuild_index` event for only signals derived from the `cms.models.pagemodel.Page` model, resulting in only one `rebuild_index` event for a given page publication or unpublication.

### Jira Task
- https://jira.tacc.utexas.edu/browse/FP-1099

### Testing
1. Edit a page with more than one type of object in it, i.e. many text boxes, alerts, etc.
2. Publish the page, and in the logs ensure the following text only appears once.
```
core_cms         | Removing all documents from your index because you said so.
core_cms_elasticsearch | {"type": "server", "timestamp": "XXXX", "level": "INFO", "component": "o.e.c.m.MetaDataDeleteIndexService", "cluster.name": "es-dev", "node.name": "es01", "message": "[cms-dev-cms/XXXX] deleting index", "cluster.uuid": "XXXX", "node.id": "XXXX"  }
core_cms         | All documents removed.
core_cms         | Indexing 1 titles
...
```