### PR TITLE
Quick: Clean Up Plugins to Match GH-93 Plugins

### DIFF
--- a/taccsite_cms/contrib/taccsite_blockquote/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_blockquote/cms_plugins.py
@@ -1,5 +1,3 @@
-# SEE: https://github.com/django-cms/djangocms-bootstrap4/blob/2.0.0/djangocms_bootstrap4/contrib/bootstrap4_content/cms_plugins.py#L41
-
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from django.utils.translation import gettext_lazy as _

--- a/taccsite_cms/contrib/taccsite_blockquote/models.py
+++ b/taccsite_cms/contrib/taccsite_blockquote/models.py
@@ -1,5 +1,3 @@
-# SEE: https://github.com/django-cms/djangocms-bootstrap4/blob/2.0.0/djangocms_bootstrap4/contrib/bootstrap4_content/models.py
-
 from cms.models.pluginmodel import CMSPlugin
 from django.utils.translation import gettext_lazy as _
 
@@ -21,7 +19,7 @@ class TaccsiteBlockquote(CMSPlugin):
     )
 
     origin = models.CharField(
-        help_text='The origin of the quote (i.e. citation, attribution) (e.g. author, source). This value is ignored if "Advanced origin" fields have data.',
+        help_text=_('The origin of the quote (i.e. citation, attribution) (e.g. author, source). This value is ignored if "Advanced origin" fields have data.'),
         blank=True,
         max_length=100,
     )

--- a/taccsite_cms/contrib/taccsite_offset/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_offset/cms_plugins.py
@@ -1,5 +1,3 @@
-# SEE: https://github.com/django-cms/djangocms-bootstrap4/blob/2.0.0/djangocms_bootstrap4/contrib/bootstrap4_content/cms_plugins.py#L41
-
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 

--- a/taccsite_cms/contrib/taccsite_offset/models.py
+++ b/taccsite_cms/contrib/taccsite_offset/models.py
@@ -1,11 +1,11 @@
-# SEE: https://github.com/django-cms/djangocms-bootstrap4/blob/2.0.0/djangocms_bootstrap4/contrib/bootstrap4_content/models.py
-
 from cms.models.pluginmodel import CMSPlugin
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from djangocms_attributes_field import fields
+
+
 
 # Constants
 
@@ -14,6 +14,8 @@ DIRECTION_CHOICES = (
     # ('center', _('Center')), # GH-66: Support centered offset content
     ('right', _('Right')),
 )
+
+
 
 # Helpers
 
@@ -27,6 +29,8 @@ def get_direction_classname(offset):
     }
 
     return switcher.get(offset, '')
+
+
 
 # Models
 

--- a/taccsite_cms/contrib/taccsite_sample/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_sample/cms_plugins.py
@@ -6,7 +6,7 @@ from django.utils.encoding import force_text
 from .models import TaccsiteSample
 
 from .constants import DEFAULT_USER_NAME as default_name
-from .utils import has_proper_name
+from .helpers import has_proper_name
 
 # SEE: http://docs.django-cms.org/en/release-3.7.x/reference/plugins.html
 @plugin_pool.register_plugin
@@ -32,7 +32,9 @@ class TaccsiteSamplePlugin(CMSPluginBase):
     # FAQ: Sets tooltip of preview of this plugin within a Text plugin
     def icon_alt(self, instance):
         super_value = force_text(super().icon_alt(instance))
-        return f'Hello, […] ({super_value})'
+        return _('Hello, […] (%(original_string_text)s)') % {
+            'original_string_text': super_value
+        }
     # NOTE: Our previews (see `icon_alt`) are rich and have no icon...
     # TODO: Confirm whether these are ever necessary
     # def icon_src(self, instance)

--- a/taccsite_cms/contrib/taccsite_sample/helpers.py
+++ b/taccsite_cms/contrib/taccsite_sample/helpers.py
@@ -1,8 +1,3 @@
-"""
-.. module:: taccsite_sample.utils
-   :synopsis: Utilities to process user name.
-"""
-
 def has_proper_name(user=None):
     """Whether user has enough data with which to form a proper name.
 

--- a/taccsite_cms/contrib/taccsite_sample/helpers.py
+++ b/taccsite_cms/contrib/taccsite_sample/helpers.py
@@ -1,7 +1,7 @@
 def has_proper_name(user=None):
     """Whether user has enough data with which to form a proper name.
 
-    :param user: Django user object
+    :param django.contrib.auth.models.User: Django user object
 
     :returns: True, False, or None (if unknown)
     :rtype: bool | None
@@ -22,7 +22,7 @@ def has_proper_name(user=None):
 def get_proper_name(user=None):
     """Get proper name of an authenticated user.
 
-    :param user: Django user object (authenticated)
+    :param django.contrib.auth.models.User: Django user object (authenticated)
 
     :returns: Proper name of user
     :rtype: str | None

--- a/taccsite_cms/contrib/taccsite_sample/models.py
+++ b/taccsite_cms/contrib/taccsite_sample/models.py
@@ -3,16 +3,9 @@ from cms.models.pluginmodel import CMSPlugin
 from django.db import models
 
 from .constants import DEFAULT_USER_NAME as default_name
-from .utils import has_proper_name, get_proper_name
+from .helpers import has_proper_name, get_proper_name
 
 class TaccsiteSample(CMSPlugin):
-    # Overwrites
-
-    def get_short_description(self):
-        return 'Hello, […]'
-
-    # Fields
-
     """
     Components > "Sample (Greet User)" Model
     https://url.to/docs/components/sample/
@@ -20,7 +13,7 @@ class TaccsiteSample(CMSPlugin):
     guest_name = models.CharField(
         max_length=50,
         default=default_name,
-        help_text=f'If user is logged in they are greeted by their name. If not logged in, they are greeted as this value. If this value is blank, they are greeted as "{default_name}".',
+        help_text=('If user is logged in they are greeted by their name. If not logged in, they are greeted as this value. If this value is blank, they are greeted as "%(default_name)s".') % {'default_name': default_name},
         # To change the widget, a new Form class is required
         # FAQ: Wesley B searched for hours to find this important information
         # SEE: http://disq.us/p/210zgp2
@@ -29,15 +22,18 @@ class TaccsiteSample(CMSPlugin):
         blank=True
     )
 
+    def get_short_description(self):
+        return 'Hello, […]'
+
     # Custom
 
     def get_name(self, user=None):
         """Get name by which to greet the user.
 
-        :param user: Django user object
+        :param django.contrib.auth.models.User: Django user object
 
-        :rtype: str
         :returns: Name of authenticated user or the name for any guest
+        :rtype: str
         """
         if has_proper_name(user):
             name = get_proper_name(user)

--- a/taccsite_cms/contrib/taccsite_sample/tests.py
+++ b/taccsite_cms/contrib/taccsite_sample/tests.py
@@ -25,6 +25,7 @@ class TaccsiteSampleTests(TestCase):
     # Helpers
 
     def _create_auth_user(self, username='test', first_name='', last_name=''):
+        """Create authenticated user"""
         self.auth_user = User.objects.create_user(
             username=username,
             first_name=first_name,
@@ -36,11 +37,13 @@ class TaccsiteSampleTests(TestCase):
         self.context['request'].user = self.auth_user
 
     def _create_anon_user(self, guest_name='Guest'):
+        """Create unauthenticated user"""
         self.auth_user = AnonymousUser()
         self.context = { 'request': self.factory.get('/test/user') }
         self.context['request'].user = self.anon_user
 
     def _populate_plugin_model(self, guest_name=None):
+        """Update plugin model to have necessary data"""
         data = {'guest_name': guest_name} if bool(guest_name) else {}
         self.plugin = add_plugin(
             self.placeholder,


### PR DESCRIPTION
# Overview

Update old plugins to have formatting and naming consistent with incoming GH-93 plugins.

# Changes

- new lines
- organizational comments
- rename `utils.py` to `helpers.py`
- remove what would become redundant `documentation`
- use internationalization formatting for user-facing strings with variables
- improve & add docblocks