### PR TITLE
Hotfix: GH-93: Clearer & Accurate Date Logic

### DIFF
--- a/taccsite_cms/contrib/helpers.py
+++ b/taccsite_cms/contrib/helpers.py
@@ -132,10 +132,12 @@ def which_date_is_nearest_today(date_a, date_b, preferred_time_period):
 
     # Match preferred time
 
-    if today in {date_a, date_b}:
+    if today == date_a:
         is_a = True
-        is_b = True
         a_time_period = 'today'
+
+    elif today == date_b:
+        is_b = True
         b_time_period = 'today'
 
     elif preferred_time_period == 'future':

--- a/taccsite_cms/contrib/taccsite_static_article_preview/templates/static_article_preview.html
+++ b/taccsite_cms/contrib/taccsite_static_article_preview/templates/static_article_preview.html
@@ -39,7 +39,8 @@
   {% if kind == 'news' %}
     <li class="c-article-preview__date  c-date">
       <span class="c-date__label">Published</span>
-      <time class="c-date__value" datetime="{{ instance.publish_date|date:"Y-m-d" }}">
+      <time class="c-date__value"
+            datetime="{{ instance.publish_date|date:"Y-m-d" }}">
         {{ instance.publish_date|date:"F d, Y" }}
       </time>
     </li>
@@ -69,7 +70,8 @@
       {# FAQ: Odd spacing avoids whitespace rendered after text #}
       {% if open_date_time_period == 'future' %}
           Submissions Next Open{% else %}Submissions Open Since{% endif %}</span>
-      <time class="c-date__value" datetime="{{ open_date|date:"Y-m-d" }}">
+      <time class="c-date__value"
+            datetime="{{ open_date|date:"Y-m-d" }}">
         {{ open_date|date:"F d, Y" }}
       </time>
     </li>
@@ -81,7 +83,8 @@
         {# FAQ: Odd spacing avoids whitespace rendered after text #}
         {% if open_date_time_period == 'future' %}
             Submissions Deadline{% else %}Submissions Closed{% endif %}</span>
-      <time class="c-date__value" datetime="{{ close_date|date:"Y-m-d" }}">
+      <time class="c-date__value"
+            datetime="{{ close_date|date:"Y-m-d" }}">
         {{ close_date|date:"F d, Y" }}
       </time>
     </li>


### PR DESCRIPTION
## Overview

__Problem__:
> unsupported operand type(s) for -: 'NoneType' and 'datetime.datetime'

__Solution__:
Fix bad logic that lead to None being assumed to be string and/or date.

## Changes

- __New__: Fix bad date logic.
- _No Op_: Consistent markup (for dates).

## Testing

1. Add an instance of an Allocations Article Preview plugin (with minimum info) to a page.
2. Edit the plugin instance: add valid Start Date, but no End Date.
3. Save change.
4. Page must **not** crash.