### PR TITLE
FP-1099: Allow Search Index to be Disabled

### DIFF
--- a/taccsite_cms/default_secrets.py
+++ b/taccsite_cms/default_secrets.py
@@ -157,6 +157,13 @@ _FEATURES = {
     # SEE: https://confluence.tacc.utexas.edu/x/EwDeCg
     # SEE: https://confluence.tacc.utexas.edu/x/FAA9Cw
     "blog": False,
+
+    # Search
+    # - `True`  (Portal:  enable search, CMS:  enable indexing)
+    # - (falsy) (Portal:  enable search, CMS: disable indexing)
+    # - `False` (Portal: disable search, CMS: disable indexing)
+    # FP-1099: Search can be disabled as a workaround to suspected indexing bug
+    "search": None,
 }
 
 ########################

--- a/taccsite_cms/default_secrets.py
+++ b/taccsite_cms/default_secrets.py
@@ -159,10 +159,10 @@ _FEATURES = {
     "blog": False,
 
     # Search
-    # - `True`  (Portal:  enable search, CMS:  enable indexing)
-    # - (falsy) (Portal:  enable search, CMS: disable indexing)
-    # - `False` (Portal: disable search, CMS: disable indexing)
-    # FP-1099: Search can be disabled as a workaround to suspected indexing bug
+    # - `True`  (Portal:       allow search,          Any CMS: allow index)
+    # - (falsy) (Portal & CMS: allow search & index,  SAD CMS: never index)
+    # - `False` (Portal:       no search bar,         Any CMS: never index)
+    # FP-1099: Search can be disabled as a workaround to suspected index bug
     "search": None,
 }
 

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -232,8 +232,6 @@ INSTALLED_APPS = [
     'djangocms_bootstrap4.contrib.bootstrap4_picture',
     'djangocms_bootstrap4.contrib.bootstrap4_tabs',
     'djangocms_bootstrap4.contrib.bootstrap4_utilities',
-    'haystack',
-    'aldryn_apphooks_config',
     # For faster testing, disable migrations during database creation
     # SEE: https://stackoverflow.com/a/37150997
     'test_without_migrations',
@@ -377,8 +375,8 @@ if CONSOLE_LOG_ENABLED:
     for feature in FEATURES:
         print(feature + ": ", FEATURES[feature])
 
-if current_secrets._FEATURES['blog']:
-    # Install required apps
+# Support Blog/News & Social Media Metadata
+if FEATURES['blog']:
     INSTALLED_APPS += [
         # Blog/News
         # 'filer',              # Already added
@@ -394,7 +392,7 @@ if current_secrets._FEATURES['blog']:
         'djangocms_page_meta',
     ]
 
-    # Metadata: Configure
+    # Configure metadata
     META_SITE_PROTOCOL = 'http'
     META_USE_SITES = True
     META_USE_OG_PROPERTIES = True
@@ -402,18 +400,45 @@ if current_secrets._FEATURES['blog']:
     META_USE_GOOGLEPLUS_PROPERTIES = True # django-meta 1.x+
     # META_USE_SCHEMAORG_PROPERTIES=True  # django-meta 2.x+
 
-    # Blog/News: Set custom paths for templates
+    # Set custom paths for templates
     BLOG_PLUGIN_TEMPLATE_FOLDERS = (
         ('plugins/default', 'Default template'),    # i.e. `templates/djangocms_blog/plugins/default/`
         ('plugins/default-clone', 'Clone of default template'),  # i.e. `templates/djangocms_blog/plugins/default-clone/`
     )
 
-    # Blog/News: Change default values for the auto-setup of one `BlogConfig`
+    # Change default values for the auto-setup of one `BlogConfig`
     # SEE: https://github.com/nephila/djangocms-blog/issues/629
     BLOG_AUTO_SETUP = True
     BLOG_AUTO_HOME_TITLE ='Home'
     BLOG_AUTO_BLOG_TITLE = 'News'
     BLOG_AUTO_APP_TITLE = 'News'
+
+# Support Portal search or CMS indexing
+if 'search' in FEATURES and (
+    FEATURES['search']
+    # FAQ: Portals can search by default, but may not set `FEATURES['search']`
+    or (PORTAL and FEATURES['search'] != False)
+):
+    INSTALLED_APPS += [
+        'haystack',
+        'aldryn_apphooks_config',
+    ]
+
+    # Elasticsearch Indexing
+    HAYSTACK_ROUTERS = ['aldryn_search.router.LanguageRouter',]
+    HAYSTACK_SIGNAL_PROCESSOR = 'taccsite_cms.signal_processor.RealtimeSignalProcessor'
+    ALDRYN_SEARCH_DEFAULT_LANGUAGE = 'en'
+    ALDRYN_SEARCH_REGISTER_APPHOOK = True
+    HAYSTACK_CONNECTIONS = {
+        'default': {
+            'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+            'URL': current_secrets._ES_HOSTS,
+            'INDEX_NAME': current_secrets._ES_INDEX_PREFIX.format('cms'),
+            'KWARGS': {'http_auth': current_secrets._ES_AUTH }
+        }
+    }
+
+    ES_DOMAIN = current_secrets._ES_DOMAIN
 
 
 DJANGOCMS_PICTURE_NESTING = True
@@ -464,23 +489,6 @@ GOOGLE_ANALYTICS_PRELOAD = current_secrets._GOOGLE_ANALYTICS_PRELOAD
 # SETTINGS VARIABLE EXPORTS.
 # Use a custom namespace (using default settings.VARIABLE configuration)
 SETTINGS_EXPORT_VARIABLE_NAME = 'settings'
-
-# Elasticsearch Indexing
-HAYSTACK_ROUTERS = ['aldryn_search.router.LanguageRouter',]
-# FP-1099: Wesley is disabling this to prove it is a trigger for a bug
-# HAYSTACK_SIGNAL_PROCESSOR = 'taccsite_cms.signal_processor.RealtimeSignalProcessor'
-ALDRYN_SEARCH_DEFAULT_LANGUAGE = 'en'
-ALDRYN_SEARCH_REGISTER_APPHOOK = True
-HAYSTACK_CONNECTIONS = {
-    'default': {
-        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
-        'URL': current_secrets._ES_HOSTS,
-        'INDEX_NAME': current_secrets._ES_INDEX_PREFIX.format('cms'),
-        'KWARGS': {'http_auth': current_secrets._ES_AUTH }
-    }
-}
-
-ES_DOMAIN = current_secrets._ES_DOMAIN
 
 # Exported settings.
 SETTINGS_EXPORT = [

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -467,7 +467,8 @@ SETTINGS_EXPORT_VARIABLE_NAME = 'settings'
 
 # Elasticsearch Indexing
 HAYSTACK_ROUTERS = ['aldryn_search.router.LanguageRouter',]
-HAYSTACK_SIGNAL_PROCESSOR = 'taccsite_cms.signal_processor.RealtimeSignalProcessor'
+# FP-1099: Wesley is disabling this to prove it is a trigger for a bug
+# HAYSTACK_SIGNAL_PROCESSOR = 'taccsite_cms.signal_processor.RealtimeSignalProcessor'
 ALDRYN_SEARCH_DEFAULT_LANGUAGE = 'en'
 ALDRYN_SEARCH_REGISTER_APPHOOK = True
 HAYSTACK_CONNECTIONS = {

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -23,7 +23,7 @@
       {% include "nav_cms.html" with className="navbar-nav" %}
 
       {# NOTE: As of 2020-12, search is only available with a Portal #}
-      {% include "nav_search.html" with className="form-inline  ml-auto" only %}
+      {% if settings.FEATURES.search != False %}{% include "nav_search.html" with className="form-inline  ml-auto" only %}{% endif %}
       {% include "nav_portal.html" with className="navbar-nav" settings=settings only %}
     {% else %}
       {# FAQ: If template were included with `only`, then it would NOT render `show_menu` #}


### PR DESCRIPTION
# Overview

- By default, disable search index for SAD CMS (because it does not support search).
- Allow disabling of search for Portal sites (because it can cause 504 on CMS publish).

# Issues

This is a workaround for [FP-1099](https://jira.tacc.utexas.edu/browse/FP-1099) which was solved.

This now could be its own feature to avoid indexing sites that do not need indexing.

# Changes

## Major

- __New__: Add `FEATURE['search']`
- __New__: Isolate search settings behind `FEATURE['search']` toggle
- __New__: Only render search bar for Portals with `FEATURE['search']` set to anything _except_ `False`.

| if `FEATURE['search']` is | then Portal will | then Portal CMS will | then SAD CMS will |
| --- | --- | --- | --- |
| `True`† | __allow__ _search_ | __allow__ _index_ | __allow__ _search_ & __allow__ _index_ |
| `(falsy)`* | __allow__ _search_ | __allow__ _index_ | __no__ _search_ bar & __never__ _index_ |
| `False`† | __no__ _search_ bar | __never__ _index_ | __no__ _search_ bar & __never__ _index_ |

<details>
<summary>Footnotes</summary>

\* This is helpful if a CMS has not updated its secrets value, but receives this support.

† Any Portal must update its secrets to set this value, in order to retain indexing.

</details>

## Minor

- _Minor_: Comments for `FEATURE['blog']`

# Testing

<details>
<summary>Test all combinations of values for <code>FEATURE['search']</code> and <code>PORTAL</code>…</summary>

1. Set `FEATURE['search']` to `True`.
   Set `PORTAL` to `True`.
   Test:
    - search bar is rendered
    - CMS is indexed\*
2. Set `FEATURE['search']` to `True`.
   Set `PORTAL` to `False`.
   Test:
    - search bar is __not__ rendered
    - CMS is indexed\*
3. Set `FEATURE['search']` to `None`.
   Set `PORTAL` to `True`.
   Test:
    - search bar is rendered
    - CMS is indexed\*
4. Set `FEATURE['search']` to `None`.
   Set `PORTAL` to `False`.
   Test:
    - search bar is __not__ rendered
    - CMS is __not__ indexed\*
5. Set `FEATURE['search']` to `True`.
   Set `PORTAL` to `True`.
   Test:
    - search bar is rendered
    - CMS is indexed\*
6. Set `FEATURE['search']` to `True`.
   Set `PORTAL` to `False`.
   Test:
    - search bar is __not__ rendered
    - CMS is indexed\*

\* CMS index occurs on page publish, un-publish, and delete.

</details>