### PR TITLE
GH-298: Add "See All" Link Component

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-see-all-link.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-see-all-link.css
@@ -1,0 +1,52 @@
+/*
+See All Link
+
+A link to all content to which a subset of content before it belongs.
+
+Markup:
+<a class="c-see-all-link" href="#">
+  <i class="c-see-all-link__icon  icon icon-push-right"></i>
+  <span class="c-see-all-link__text">See All</span>
+</a>
+
+Styleguide Components.SeeAllLink
+*/
+@import url("_imports/tools/x-truncate.css");
+
+
+
+/* Base i.e. Container */
+
+.c-see-all-link {
+  display: inline-block;
+
+  padding-top: 1.0em;
+  padding-right: 1.0em;
+  padding-bottom: 1.0em;
+  margin-bottom: -1.0em; /* to "undo" space added from `padding-bottom` */
+
+  @extend %x-truncate--one-line;
+  max-width: 100%; /* SEE: https://stackoverflow.com/a/44521595 */
+
+  font-size: 1.2rem;
+  font-weight: var(--bold);
+}
+
+
+
+/* Children */
+
+.c-see-all-link__icon {
+  margin-right: 0.75em;
+
+  font-size: 1.167em; /* to get size 14px from 12px base */
+  vertical-align: text-bottom;
+
+  /* To hide the `text-decoration: underline` of the anchor */
+  /* SEE: https://stackoverflow.com/a/15688237/11817077 */
+  display: inline-block;
+}
+
+.c-see-all-link__text {
+  font-size: 1em;
+}

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -26,6 +26,7 @@
 
 /* COMPONENTS */
 @import url("_imports/components/c-footer.css");
+@import url("_imports/components/c-see-all-link.css");
 @import url("_imports/components/django.cms.css");
 @import url("_imports/components/django.cms.blog.css");
 @import url("_imports/components/django.cms.post.css");


### PR DESCRIPTION
# Overview

Create CSS component for any "See all" / "See more" links.



# Issues

- GH-298



# Changes

- Create new CSS component stylesheet.
- Import new stylesheet into Core `site.css`.



# Testing

1. If you do not have a CMS environment, then prepare one with [Wiki: Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes).
2. Checkout branch `task/GH-298-add-see-all-component--quick/support-and-add-snippets`.
3. Add new snippet to test page.
4. Create Snippet plugin with:
    - __HTML__: ["Markup" from `c-see-all-link.css`](https://github.com/TACC/Core-CMS/blob/task/GH-298-add-see-all-component/taccsite_cms/static/site_cms/css/src/_imports/components/c-see-all-link.css#L7-L10)
    - __Template__: `snippets/spaceless-markup.html`
5. Test that the following is rendered:
    - With page template "Fullwidth" (`fullwidth.html`)\*:
      ![GH-298 Render - Core](https://user-images.githubusercontent.com/62723358/128064292-cf6ab498-9f9b-4254-b8a4-40989591a297.png)
    - With Frontera "Fullwidth" template (`frontera-cms/templates/fullwidth.html`)\*†:
      ![GH-298 Render - Frontera](https://user-images.githubusercontent.com/62723358/128064465-02f7d19a-d445-43bc-b62e-e2aade744a8a.png)

\* The color of the link is irrelevant, because link colors have not been standardized.

† The different size of text is expected. Frontera is the first project to use 10px root font (albeit not in a standardized manner). There is an [upcoming standard for font size](https://confluence.tacc.utexas.edu/x/nh4FDg).



# Screenshots

| Core | Frontera |
| --- | --- |
| ![GH-298 Plugin - Core](https://user-images.githubusercontent.com/62723358/128065188-ea49d557-eb74-4cf6-8e7c-cc228c01a44f.png) | ![GH-298 Plugin - Frontera](https://user-images.githubusercontent.com/62723358/128065190-9b1d60cf-7e15-4371-99c7-efb729bfe37d.png) |



# Notes

- The styles come from [`c-article-list.css`](https://github.com/TACC/Core-CMS/blob/2bdf7e7/taccsite_cms/static/site_cms/css/src/_imports/components/c-article-list.css) (which is applied to [`article_list.html`](https://github.com/TACC/Core-CMS/blob/2bdf7e7/taccsite_cms/contrib/taccsite_static_article_list/templates/article_list.html)). After this PR is merged, a new ticket should be created to update article list to use this component. — note added on 2021-08-09; new ticket #309