### PR TITLE
Quick: Support Snippets & Add 1 Useful Snippet

### DIFF
--- a/taccsite_cms/templates/snippets/README.md
+++ b/taccsite_cms/templates/snippets/README.md
@@ -8,7 +8,7 @@ _This directory can alleviate danger #1 of [Why a Snippet Is Dangerous](#why-a-s
 
 1. The Core CMS __must not__ use any snippets __for production__. _They __should only__ be for testing._
 2. A CMS project __should not__ use any snippets. _They __may only__ be temporarily._
-3. A CMS project snippet __must__ be saved into its respective snippets directory, `/code/taccsite_custom/name-of-project/static`.
+3. A CMS project snippet __must__ be saved into its respective snippets directory, `/code/taccsite_custom/name-of-project/templates/snippets`.
 4. Any snippet file __must__ be kept up to date with its snippet.[^1]
 
 [^1]: For now, maintain snippet source code via internal team process.
@@ -21,9 +21,9 @@ It allows an authorized CMS user to create a snippet of front-end web code (e.g.
 
 ## Why a Snippet Is Dangerous
 
-1. The code is dependent on the (unsynced) database, because it is not under:
+1. (Unless saved) The code is dependent on the (unsynced) database, because it is not under:
     - source/version control
-2. The code is independent of any other code control:
+2. The code may be authored independent of any other code control:
     - security
     - dependency management
     - style guide

--- a/taccsite_cms/templates/snippets/README.md
+++ b/taccsite_cms/templates/snippets/README.md
@@ -1,0 +1,40 @@
+# TACC CMS - Templates - Snippets
+
+__All__, and __only__, snippet code specific to Core __must__ be placed in this directory. This allows us to version and source control snippet code. Failure to do so will result in snippet code loss upon data loss from database.
+
+_This directory can alleviate danger #1 of [Why a Snippet Is Dangerous](#why-a-snippet-is-dangerous)._
+
+## Important
+
+1. The Core CMS __must not__ use any snippets __for production__. _They __should only__ be for testing._
+2. A CMS project __should not__ use any snippets. _They __may only__ be temporarily._
+3. A CMS project snippet __must__ be saved into its respective snippets directory, `/code/taccsite_custom/name-of-project/static`.
+4. Any snippet file __must__ be kept up to date with its snippet.[^1]
+
+[^1]: For now, maintain snippet source code via internal team process.
+
+## What a Snippet Is
+
+A snippet is a __dangerous__ feature from the plugin [`djangocms-snippet`](https://github.com/divio/djangocms-snippet) which is installed in the CMS.
+
+It allows an authorized CMS user to create a snippet of front-end web code (e.g. CSS, HTML, JS) in the database for use anywhere on the website.
+
+## Why a Snippet Is Dangerous
+
+1. The code is dependent on the (unsynced) database, because it is not under:
+    - source/version control
+2. The code is independent of any other code control:
+    - security
+    - dependency management
+    - style guide
+    - organization
+    - linting
+
+## Why a Snippet Is Allowed
+
+1. Support time-sensitive changes to the CMS.[^2]
+2. Support ad-hoc changes by designer who codes.[^2]
+3. Support ad-hoc testing of changes to the code.[^3]
+
+[^2] This is permitted with the expectation that the snippet code is soon appropriately integrated into the repository.
+[^3] See Core snippets for examples.

--- a/taccsite_cms/templates/snippets/spaceless-markup.html
+++ b/taccsite_cms/templates/snippets/spaceless-markup.html
@@ -1,0 +1,2 @@
+{# To remove whitespace between tags of markup for a snippet #}
+{% spaceless %}{{ html }}{% endspaceless %}


### PR DESCRIPTION
# Important

The PR https://github.com/TACC/Core-CMS-Resources/pull/66 depends on this PR.

# Overview / Changes

- Document and regulate snippet support.\*
- Add one useful snippet.†
- Allow use of snippets via committed code.‡

\* Mostly a migration of [TACC/Core-CMS-Resources:`example-cms/snippets`](https://github.com/TACC/Core-CMS-Resources/tree/3627509/example-cms/snippets). \
† Used for testing PR https://github.com/TACC/Core-CMS/pull/300.
‡ Existing snippets may now have their HTML field emptied and their Template field populated.

# Testing / Screenshots

1. If you do not have a CMS environment, then prepare one with [Wiki: Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes).
3. Add new Snippet plugin to test page.
4. Create snippet with:
    - __HTML__: (any markup that has space between tags; [example](https://github.com/TACC/Core-CMS/blob/task/GH-298-add-see-all-component/taccsite_cms/static/site_cms/css/src/_imports/components/c-see-all-link.css#L7-L10))
    - __Template__: `snippets/spaceless-markup.html`
5. Test that the rendered markup does not have whitespace between tags.\*
    
    <details>
    <summary>How to Test</summary>

	1. Inspect element using browser's developer tools.
	2. Right click element in dynamic element inspector.
	3. Choose "Edit as HTML" (or something similar).
	<br />

	_Alternatively, "View Source" of page and search for relevant markup._

    </details>

    ![Test PR #__ via GH-298](https://user-images.githubusercontent.com/62723358/128074750-558c3f91-b8ca-44c3-a3db-d0ea3e7366e2.png)

\* Without the `snippets/spaceless-markup.html`, the markup would have spaces.

# Notes

1. The location `templates/snippets` is supported by https://github.com/django-cms/djangocms-snippet/blob/9303fbf/djangocms_snippet/models.py#L30-L34.
2. The benefit of removing spaces (`snippets/spaceless-markup.html`) is that only whitespace within intended text nodes is rendered. Proof: in the test steps, without the template set, the link will have an extra space character before the text (hover text; see underline extends before "S" character).