### PR TITLE
Quick: Support Variable in x-truncate CSS

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-truncate.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-truncate.css
@@ -34,7 +34,7 @@ Styleguide Tools.ExtendsAndMixins.Truncate
 
 .x-truncate--one-line, /* DEPRECATED */
 %x-truncate--one-line, {
-	text-overflow: ellipsis;
+	text-overflow: var(--text-overflow, ellipsis);
 
 	overflow: hidden;
 	white-space: nowrap;


### PR DESCRIPTION
# Overview

Support a custom property (variable) and a fallback value (the original value) for the value of a rule in the `x-truncate` "tool" stylesheet.

# Changes

- Swap static value for dynamic value with fallback.

# Testing / Screenshots

Ignoring, because:
- This small change was successfully tested during development of [#75](https://github.com/TACC/Core-CMS/issues/75) (still in progress as of 2021-08-03).
- This small change is already proven to be reliable via [some merged Core-Portal PR by me I have trouble finding](https://github.com/TACC/Core-Portal/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Amerged+author%3Atacc-wbomar+).

# Notes

- This feature is documented by MDN: [Using CSS custom properties @ Custom property fallback values](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#custom_property_fallback_values).
- This is needed for #75 and I try to reduce the size of that PR.