### PR TITLE
GH-75: Data List - Styles / Component

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.css
@@ -58,13 +58,17 @@ table.c-data-list {
   }
 }
 
-/* To add colon */
+/* To add colon (non-tables) */
 .c-data-list__key:not(th)::after {
   content: ':';
   display: inline;
   padding-right: 0.25em;
 }
 
+/* To add space (instead of colon) (tables) */
+th.c-data-list__key {
+  padding-right: 0.25em;
+}
 
 
 
@@ -191,11 +195,7 @@ table.c-data-list--is-horz th.c-data-list__key {
 /* FAQ: Truncate when doing is unlikely to almost entirely obscure text */
 
 /* Non-table wide horz. layout is for areas expected to have enough space */
-.c-data-list--is-horz.c-data-list--is-wide:not(table) .c-data-list__value,
-/* Non-table narr. vert. layout has enough space cuz values are beneath keys */
-.c-data-list--is-vert.c-data-list--is-narrow:not(table) .c-data-list__value,
-/* Table vert. layout does NOT have enough space but text would escape table */
-table.c-data-list--is-vert .c-data-list__value {
+.c-data-list--should-truncate-values .c-data-list__value {
   @extend %x-truncate--one-line;
 }
 
@@ -207,7 +207,8 @@ table.c-data-list--is-vert .c-data-list__value {
 
 .c-data-list--is-horz:not(table) { align-items: baseline; }
 
-/* CAVEAT: This causes th and td cell borders to be offset */
+/* CAVEAT: On Firefox (for "Benton Sans"), `align-items` is ineffectual */
+/* CAVEAT: This causes <th> and <td> cell borders to be offset */
 table.c-data-list--is-horz tr { align-items: baseline; }
 
 table.c-data-list--is-vert th.c-data-list__key,

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.css
@@ -1,0 +1,100 @@
+/*
+Data List
+
+A list of pairs of values, where the titles/names of the values are aligned with each other and the values themselves are aligned with each other.
+
+__Notice__:
+- User _should_ add arrangement and spacing modifiers. See Caveat #1.
+- The _recommended_ markup is a definition list (`<dl>`) or a table (`<table>`).
+
+__Caveat__:
+1. With no modifiers added, the result is an incomplete vertical arrangement.
+2. No provided repsonsive design solutions; users must apply their own.
+3. Limited support for (table) `<table>` markup and `.c-data-list--is-horz`.
+
+.c-data-list--is-horz - (arrangement) A horizontal list
+.c-data-list--is-vert - (arrangement) A vertical list
+.c-data-list--is-narrow - (spacing) A list that has limited horizontal space
+.c-data-list--is-wide - (spacing) A list that has ample horizontal space
+
+Markup: c-data-list.html
+
+Styleguide Components.DataList
+*/
+@import url("_imports/tools/x-truncate.css");
+
+
+
+/* Base i.e. Container */
+
+.c-data-list--is-horz,
+.c-data-list--is-horz dd {
+  margin-bottom: 0; /* overwrite Bootstrap's `_reboot.scss` */
+}
+
+
+
+/* Elements i.e. Children */
+
+.c-data-list__key {
+  --text-overflow: ':';
+  @extend %x-truncate--one-line;
+}
+.c-data-list__key::after {
+  content: ':';
+  display: inline;
+  padding-right: 0.25em;
+}
+.c-data-list--is-horz
+> .c-data-list__value {
+  white-space: nowrap;
+}
+
+
+
+/* Modifiers i.e. Types */
+
+.c-data-list--is-horz {
+  display: flex;
+  flex-direction: row;
+}
+.c-data-list--is-horz
+> .c-data-list__key ~ .c-data-list__key::before {
+  content: '|';
+  display: inline-block;
+}
+
+.c-data-list--is-horz.c-data-list--is-narrow
+> .c-data-list__key ~ .c-data-list__key::before {
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
+.c-data-list--is-horz.c-data-list--is-wide
+> .c-data-list__key ~ .c-data-list__key::before {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+/* Overwrite Bootstrap `_reboot.scss` */
+.c-data-list--is-vert
+> .c-data-list__value {
+  margin-left: 0;
+}
+.c-data-list--is-vert.c-data-list--is-narrow
+> .c-data-list__value {
+  padding-left: 0;
+}
+.c-data-list--is-vert.c-data-list--is-wide
+> .c-data-list__value {
+  padding-left: 2.5em; /* font-size 10px gives 40px (Firefox default margin) */
+}
+
+/* Truncate specific edge cases */
+.c-data-list--is-horz.c-data-list--is-wide
+> .c-data-list__value {
+  @extend %x-truncate--one-line;
+}
+.c-data-list--is-vert.c-data-list--is-narrow
+> .c-data-list__value {
+  @extend %x-truncate--one-line;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.css
@@ -141,7 +141,7 @@ table.c-data-list--is-vert {
   margin-left: 0;
 }
 
-/* To space out key and value */
+/* To space out key and value (tables) */
 .c-data-list--is-vert:not(table).c-data-list--is-narrow > .c-data-list__value,
 table.c-data-list--is-vert.c-data-list--is-narrow td.c-data-list__value {
   padding-left: 0;
@@ -161,7 +161,7 @@ table.c-data-list--is-vert.c-data-list--is-wide td.c-data-list__value {
 
 /* Element Borders */
 
-/* To remove most table borders */
+/* To remove most borders (tables) */
 table.c-data-list--is-vert th.c-data-list__key,
 td.c-data-list__value {
   border-left: 0;
@@ -173,7 +173,7 @@ table.c-data-list--is-horz td.c-data-list__value {
   border-bottom: 0;
 }
 
-/* To keep real border between key and value */
+/* To keep real border between key and value (tables) */
 /* CAVEAT: Certain fonts may limit border height (see "Font Alignment") */
 table.c-data-list--is-horz tr:first-child th.c-data-list__key {
   border-left: 0;
@@ -182,7 +182,7 @@ table.c-data-list--is-horz th.c-data-list__key {
   border-right: 0;
 }
 
-/* To add fake border between key and value */
+/* To add fake border between key and value (non-tables) */
 .c-data-list--is-horz:not(table)
   > .c-data-list__key ~ .c-data-list__key::before {
   content: '|';
@@ -194,7 +194,6 @@ table.c-data-list--is-horz th.c-data-list__key {
 /* Truncate Values */
 /* FAQ: Truncate when doing is unlikely to almost entirely obscure text */
 
-/* Non-table wide horz. layout is for areas expected to have enough space */
 .c-data-list--should-truncate-values .c-data-list__value {
   @extend %x-truncate--one-line;
 }
@@ -205,11 +204,13 @@ table.c-data-list--is-horz th.c-data-list__key {
 /* NOTE: If font has different internal baseline per weight, use these */
 /* FAQ: "Benton Sans" needs this solution (as of 2021-07) */
 
+/* NOTE: This assumes key and value are flex items, not inline display */
 .c-data-list--is-horz:not(table) { align-items: baseline; }
 
 /* CAVEAT: On Firefox (for "Benton Sans"), `align-items` is ineffectual */
 /* CAVEAT: This causes <th> and <td> cell borders to be offset */
 table.c-data-list--is-horz tr { align-items: baseline; }
 
+/* NOTE: This assumes key and value are inline display, not flex items */
 table.c-data-list--is-vert th.c-data-list__key,
 table.c-data-list--is-vert td.c-data-list__value { vertical-align: baseline; }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.css
@@ -3,14 +3,22 @@ Data List
 
 A list of pairs of values, where the titles/names of the values are aligned with each other and the values themselves are aligned with each other.
 
-__Notice__:
-- User _should_ add arrangement and spacing modifiers. See Caveat #1.
-- The _recommended_ markup is a definition list (`<dl>`) or a table (`<table>`).
+Features:
+- Layout can be horizontal or vertical, wide or narrow.
+- Narrow layouts have minimal spacing. Wide layouts have extra spacing.
+- All layouts truncate keys. Some layouts truncate values.
+- Table keys do not have colons. Other keys do have colons.
 
-__Caveat__:
-1. With no modifiers added, the result is an incomplete vertical arrangement.
+Notices:
+- User _should_ add arrangement and spacing modifiers. See Caveats #1.
+- The _recommended_ markup is a description list (`<dl>`) or a `<table>`.
+
+Caveats:
+1. With no modifiers added, the result is feature-limited vertical arrangement.
 2. No provided repsonsive design solutions; users must apply their own.
-3. Limited support for (table) `<table>` markup and `.c-data-list--is-horz`.
+3. Inflexible support for `<table>`s (flex and truncation in table is fragile).
+    - No protection from nesting caveats (whether is-wide or is-narrow takes precedence when one is nested inside the other).
+    - Specific (yet semantic) markup is required to benefit from all features.
 
 .c-data-list--is-horz - (arrangement) A horizontal list
 .c-data-list--is-vert - (arrangement) A vertical list
@@ -25,76 +33,182 @@ Styleguide Components.DataList
 
 
 
+
+
 /* Base i.e. Container */
 
-.c-data-list--is-horz,
-.c-data-list--is-horz dd {
-  margin-bottom: 0; /* overwrite Bootstrap's `_reboot.scss` */
+table.c-data-list {
+  border-left: 0;
+  border-right: 0;
 }
+
+
 
 
 
 /* Elements i.e. Children */
 
+/* To truncate text */
 .c-data-list__key {
-  --text-overflow: ':';
   @extend %x-truncate--one-line;
 }
-.c-data-list__key::after {
+@supports(text-overflow: ':') {
+  .c-data-list__key:not(th) {
+    --text-overflow: ':';
+  }
+}
+
+/* To add colon */
+.c-data-list__key:not(th)::after {
   content: ':';
   display: inline;
   padding-right: 0.25em;
 }
-.c-data-list--is-horz
-> .c-data-list__value {
-  white-space: nowrap;
-}
+
+
 
 
 
 /* Modifiers i.e. Types */
+/* FAQ: The `:not(table)` selectors avoid nesting caveats by using `>` */
+
+
+
+/* Horizontal */
 
 .c-data-list--is-horz {
   display: flex;
   flex-direction: row;
 }
-.c-data-list--is-horz
-> .c-data-list__key ~ .c-data-list__key::before {
+dl.c-data-list--is-horz,
+.c-data-list--is-horz dd.c-data-list__value {
+  margin-bottom: 0; /* overwrite Bootstrap's `_reboot.scss` */
+}
+
+/* To propogate flexbox layout so cells are flex items */
+table.c-data-list--is-horz tr,
+table.c-data-list--is-horz tbody {
+  min-width: 0;
+
+  display: flex;
+  flex-direction: row;
+}
+
+/* To space out key and value (non-tables) */
+.c-data-list--is-horz:not(table).c-data-list--is-narrow
+  > .c-data-list__key ~ .c-data-list__key::before {
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
+.c-data-list--is-horz:not(table).c-data-list--is-wide
+  > .c-data-list__key ~ .c-data-list__key::before {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+/* To space out key and value (tables) */
+table.c-data-list--is-horz.c-data-list--is-narrow
+  tr:not(:first-child) th.c-data-list__key {
+  padding-left: 0.5em;
+}
+table.c-data-list--is-horz.c-data-list--is-narrow
+  td.c-data-list__value {
+  margin-right: 0.5em; /* use margin because text would show through padding */
+}
+table.c-data-list--is-horz.c-data-list--is-wide
+  tr:not(:first-child) th.c-data-list__key {
+  padding-left: 1em;
+}
+table.c-data-list--is-horz.c-data-list--is-wide
+  td.c-data-list__value {
+  margin-right: 1em; /* use margin because text would show through padding */
+}
+
+
+
+/* Vertical */
+
+table.c-data-list--is-vert {
+  width: 100%;
+  table-layout: fixed;
+}
+
+/* To overwrite Bootstrap `_reboot.scss` */
+.c-data-list--is-vert:not(table) > .c-data-list__value {
+  margin-left: 0;
+}
+
+/* To space out key and value */
+.c-data-list--is-vert:not(table).c-data-list--is-narrow > .c-data-list__value,
+table.c-data-list--is-vert.c-data-list--is-narrow td.c-data-list__value {
+  padding-left: 0;
+}
+.c-data-list--is-vert:not(table).c-data-list--is-wide > .c-data-list__value,
+table.c-data-list--is-vert.c-data-list--is-wide td.c-data-list__value {
+  padding-left: 2.5em; /* font-size 10px gives 40px (Firefox default margin) */
+}
+
+
+
+
+
+/* Edge Cases */
+
+
+
+/* Element Borders */
+
+/* To remove most table borders */
+table.c-data-list--is-vert th.c-data-list__key,
+td.c-data-list__value {
+  border-left: 0;
+  border-right: 0;
+}
+table.c-data-list--is-horz th.c-data-list__key,
+table.c-data-list--is-horz td.c-data-list__value {
+  border-top: 0;
+  border-bottom: 0;
+}
+
+/* To keep real border between key and value */
+/* CAVEAT: Certain fonts may limit border height (see "Font Alignment") */
+table.c-data-list--is-horz tr:first-child th.c-data-list__key {
+  border-left: 0;
+}
+table.c-data-list--is-horz th.c-data-list__key {
+  border-right: 0;
+}
+
+/* To add fake border between key and value */
+.c-data-list--is-horz:not(table)
+  > .c-data-list__key ~ .c-data-list__key::before {
   content: '|';
   display: inline-block;
 }
 
-.c-data-list--is-horz.c-data-list--is-narrow
-> .c-data-list__key ~ .c-data-list__key::before {
-  padding-left: 0.5em;
-  padding-right: 0.5em;
-}
-.c-data-list--is-horz.c-data-list--is-wide
-> .c-data-list__key ~ .c-data-list__key::before {
-  padding-left: 1em;
-  padding-right: 1em;
-}
 
-/* Overwrite Bootstrap `_reboot.scss` */
-.c-data-list--is-vert
-> .c-data-list__value {
-  margin-left: 0;
-}
-.c-data-list--is-vert.c-data-list--is-narrow
-> .c-data-list__value {
-  padding-left: 0;
-}
-.c-data-list--is-vert.c-data-list--is-wide
-> .c-data-list__value {
-  padding-left: 2.5em; /* font-size 10px gives 40px (Firefox default margin) */
-}
 
-/* Truncate specific edge cases */
-.c-data-list--is-horz.c-data-list--is-wide
-> .c-data-list__value {
+/* Truncate Values */
+/* FAQ: Truncate when doing is unlikely to almost entirely obscure text */
+
+/* Non-table wide horz. layout is for areas expected to have enough space */
+.c-data-list--is-horz.c-data-list--is-wide:not(table) .c-data-list__value,
+/* Non-table narr. vert. layout has enough space cuz values are beneath keys */
+.c-data-list--is-vert.c-data-list--is-narrow:not(table) .c-data-list__value,
+/* Table vert. layout does NOT have enough space but text would escape table */
+table.c-data-list--is-vert .c-data-list__value {
   @extend %x-truncate--one-line;
 }
-.c-data-list--is-vert.c-data-list--is-narrow
-> .c-data-list__value {
-  @extend %x-truncate--one-line;
-}
+
+
+
+/* Font Alignment */
+/* NOTE: If font has different internal baseline per weight, use these */
+/* FAQ: "Benton Sans" needs this solution (as of 2021-07) */
+
+.c-data-list--is-horz:not(table) { align-items: baseline; }
+
+/* CAVEAT: This causes th and td cell borders to be offset */
+table.c-data-list--is-horz tr { align-items: baseline; }
+
+table.c-data-list--is-vert th.c-data-list__key,
+table.c-data-list--is-vert td.c-data-list__value { vertical-align: baseline; }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.html
@@ -1,0 +1,141 @@
+<!-- D. Lists -->
+<article>
+  <h4>Horizontal &amp; Wide</h4>
+  <dl class="c-data-list
+            c-data-list--is-horz
+            c-data-list--is-wide">
+    <dt class="c-data-list__key">Given Name</dt>
+    <dd class="c-data-list__value">King</dd>
+    <dt class="c-data-list__key">Surname</dt>
+    <dd class="c-data-list__value">Kong</dd>
+    <dt class="c-data-list__key">Favorite Fruit</dt>
+    <dd class="c-data-list__value">Banana</dd>
+  </dl>
+</article>
+<article>
+  <h4>Horizontal &amp; Narrow</h4>
+  <dl class="c-data-list
+            c-data-list--is-horz
+            c-data-list--is-narrow">
+    <dt class="c-data-list__key">Given Name</dt>
+    <dd class="c-data-list__value">King</dd>
+    <dt class="c-data-list__key">Surname</dt>
+    <dd class="c-data-list__value">Kong</dd>
+    <dt class="c-data-list__key">Favorite Fruit</dt>
+    <dd class="c-data-list__value">Banana</dd>
+  </dl>
+</article>
+<article>
+  <h4>Vertical &amp; Wide</h4>
+  <dl class="c-data-list
+            c-data-list--is-vert
+            c-data-list--is-wide">
+    <dt class="c-data-list__key">Given Name</dt>
+    <dd class="c-data-list__value">King</dd>
+    <dt class="c-data-list__key">Surname</dt>
+    <dd class="c-data-list__value">Kong</dd>
+    <dt class="c-data-list__key">Favorite Fruit</dt>
+    <dd class="c-data-list__value">Banana</dd>
+  </dl>
+</article>
+<article>
+  <h4>Horizontal &amp; Narrow</h4>
+  <dl class="c-data-list
+            c-data-list--is-vert
+            c-data-list--is-narrow">
+    <dt class="c-data-list__key">Given Name</dt>
+    <dd class="c-data-list__value">King</dd>
+    <dt class="c-data-list__key">Surname</dt>
+    <dd class="c-data-list__value">Kong</dd>
+    <dt class="c-data-list__key">Favorite Fruit</dt>
+    <dd class="c-data-list__value">Banana</dd>
+  </dl>
+</article>
+
+
+
+<!-- Tables -->
+<article>
+  <h4>Horizontal &amp; Wide</h4>
+  <table>
+    <tbody class="c-data-list
+                  c-data-list--is-horz
+                  c-data-list--is-wide">
+      <tr>
+        <th class="c-data-list__key">Given Name</th>
+        <td class="c-data-list__value">King</td>
+      </tr>
+      <tr>
+        <th class="c-data-list__key">Surname</th>
+        <td class="c-data-list__value">Kong</td>
+      </tr>
+      <tr>
+        <th class="c-data-list__key">Favorite Fruit</th>
+        <td class="c-data-list__value">Banana</td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+<article>
+  <h4>Horizontal &amp; Narrow</h4>
+  <table>
+    <tbody class="c-data-list
+                  c-data-list--is-horz
+                  c-data-list--is-narrow">
+      <tr>
+        <th class="c-data-list__key">Given Name</th>
+        <td class="c-data-list__value">King</td>
+      </tr>
+      <tr>
+        <th class="c-data-list__key">Surname</th>
+        <td class="c-data-list__value">Kong</td>
+      </tr>
+      <tr>
+        <th class="c-data-list__key">Favorite Fruit</th>
+        <td class="c-data-list__value">Banana</td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+<article>
+  <h4>Vertical &amp; Wide</h4>
+  <table>
+    <tbody class="c-data-list
+                  c-data-list--is-vert
+                  c-data-list--is-wide">
+      <tr>
+        <th class="c-data-list__key">Given Name</th>
+        <td class="c-data-list__value">King</td>
+      </tr>
+      <tr>
+        <th class="c-data-list__key">Surname</th>
+        <td class="c-data-list__value">Kong</td>
+      </tr>
+      <tr>
+        <th class="c-data-list__key">Favorite Fruit</th>
+        <td class="c-data-list__value">Banana</td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+<article>
+  <h4>Vertical &amp; Narrow</h4>
+  <table>
+    <tbody class="c-data-list
+                  c-data-list--is-vert
+                  c-data-list--is-narrow">
+      <tr>
+        <th class="c-data-list__key">Given Name</th>
+        <td class="c-data-list__value">King</td>
+      </tr>
+      <tr>
+        <th class="c-data-list__key">Surname</th>
+        <td class="c-data-list__value">Kong</td>
+      </tr>
+      <tr>
+        <th class="c-data-list__key">Favorite Fruit</th>
+        <td class="c-data-list__value">Banana</td>
+      </tr>
+    </tbody>
+  </table>
+</article>

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.html
@@ -2,8 +2,8 @@
 <article>
   <h4>Horizontal &amp; Wide</h4>
   <dl class="c-data-list
-            c-data-list--is-horz
-            c-data-list--is-wide">
+             c-data-list--is-horz
+             c-data-list--is-wide">
     <dt class="c-data-list__key">Given Name</dt>
     <dd class="c-data-list__value">King</dd>
     <dt class="c-data-list__key">Surname</dt>
@@ -15,8 +15,8 @@
 <article>
   <h4>Horizontal &amp; Narrow</h4>
   <dl class="c-data-list
-            c-data-list--is-horz
-            c-data-list--is-narrow">
+             c-data-list--is-horz
+             c-data-list--is-narrow">
     <dt class="c-data-list__key">Given Name</dt>
     <dd class="c-data-list__value">King</dd>
     <dt class="c-data-list__key">Surname</dt>
@@ -28,8 +28,8 @@
 <article>
   <h4>Vertical &amp; Wide</h4>
   <dl class="c-data-list
-            c-data-list--is-vert
-            c-data-list--is-wide">
+             c-data-list--is-vert
+             c-data-list--is-wide">
     <dt class="c-data-list__key">Given Name</dt>
     <dd class="c-data-list__value">King</dd>
     <dt class="c-data-list__key">Surname</dt>
@@ -41,8 +41,8 @@
 <article>
   <h4>Horizontal &amp; Narrow</h4>
   <dl class="c-data-list
-            c-data-list--is-vert
-            c-data-list--is-narrow">
+             c-data-list--is-vert
+             c-data-list--is-narrow">
     <dt class="c-data-list__key">Given Name</dt>
     <dd class="c-data-list__value">King</dd>
     <dt class="c-data-list__key">Surname</dt>
@@ -57,10 +57,10 @@
 <!-- Tables -->
 <article>
   <h4>Horizontal &amp; Wide</h4>
-  <table>
-    <tbody class="c-data-list
-                  c-data-list--is-horz
-                  c-data-list--is-wide">
+  <table class="c-data-list
+                c-data-list--is-horz
+                c-data-list--is-wide">
+    <tbody>
       <tr>
         <th class="c-data-list__key">Given Name</th>
         <td class="c-data-list__value">King</td>
@@ -78,10 +78,10 @@
 </article>
 <article>
   <h4>Horizontal &amp; Narrow</h4>
-  <table>
-    <tbody class="c-data-list
-                  c-data-list--is-horz
-                  c-data-list--is-narrow">
+  <table class="c-data-list
+                c-data-list--is-horz
+                c-data-list--is-narrow">
+    <tbody>
       <tr>
         <th class="c-data-list__key">Given Name</th>
         <td class="c-data-list__value">King</td>
@@ -99,10 +99,10 @@
 </article>
 <article>
   <h4>Vertical &amp; Wide</h4>
-  <table>
-    <tbody class="c-data-list
-                  c-data-list--is-vert
-                  c-data-list--is-wide">
+  <table class="c-data-list
+                c-data-list--is-vert
+                c-data-list--is-wide">
+    <tbody>
       <tr>
         <th class="c-data-list__key">Given Name</th>
         <td class="c-data-list__value">King</td>
@@ -120,10 +120,10 @@
 </article>
 <article>
   <h4>Vertical &amp; Narrow</h4>
-  <table>
-    <tbody class="c-data-list
-                  c-data-list--is-vert
-                  c-data-list--is-narrow">
+  <table class="c-data-list
+                c-data-list--is-vert
+                c-data-list--is-narrow">
+    <tbody>
       <tr>
         <th class="c-data-list__key">Given Name</th>
         <td class="c-data-list__value">King</td>

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.html
@@ -1,10 +1,11 @@
 <!-- D. Lists -->
 <article>
-  <h4>Horizontal &amp; Wide</h4>
+  <h4>Horizontal &amp; Wide &amp; Truncate Values</h4>
   <dl class="c-data-list
              c-data-list--is-horz
-             c-data-list--is-wide">
-    <dt class="c-data-list__key">Given Name</dt>
+             c-data-list--is-wide
+             c-data-list--should-truncate-values">
+    <dt class="c-data-list__key">Name</dt>
     <dd class="c-data-list__value">King</dd>
     <dt class="c-data-list__key">Surname</dt>
     <dd class="c-data-list__value">Kong</dd>
@@ -17,7 +18,7 @@
   <dl class="c-data-list
              c-data-list--is-horz
              c-data-list--is-narrow">
-    <dt class="c-data-list__key">Given Name</dt>
+    <dt class="c-data-list__key">Name</dt>
     <dd class="c-data-list__value">King</dd>
     <dt class="c-data-list__key">Surname</dt>
     <dd class="c-data-list__value">Kong</dd>
@@ -30,7 +31,7 @@
   <dl class="c-data-list
              c-data-list--is-vert
              c-data-list--is-wide">
-    <dt class="c-data-list__key">Given Name</dt>
+    <dt class="c-data-list__key">Name</dt>
     <dd class="c-data-list__value">King</dd>
     <dt class="c-data-list__key">Surname</dt>
     <dd class="c-data-list__value">Kong</dd>
@@ -39,11 +40,12 @@
   </dl>
 </article>
 <article>
-  <h4>Horizontal &amp; Narrow</h4>
+  <h4>Vertical &amp; Narrow &amp; Truncate Values</h4>
   <dl class="c-data-list
              c-data-list--is-vert
-             c-data-list--is-narrow">
-    <dt class="c-data-list__key">Given Name</dt>
+             c-data-list--is-narrow
+             c-data-list--should-truncate-values">
+    <dt class="c-data-list__key">Name</dt>
     <dd class="c-data-list__value">King</dd>
     <dt class="c-data-list__key">Surname</dt>
     <dd class="c-data-list__value">Kong</dd>
@@ -62,7 +64,7 @@
                 c-data-list--is-wide">
     <tbody>
       <tr>
-        <th class="c-data-list__key">Given Name</th>
+        <th class="c-data-list__key">Name</th>
         <td class="c-data-list__value">King</td>
       </tr>
       <tr>
@@ -83,7 +85,7 @@
                 c-data-list--is-narrow">
     <tbody>
       <tr>
-        <th class="c-data-list__key">Given Name</th>
+        <th class="c-data-list__key">Name</th>
         <td class="c-data-list__value">King</td>
       </tr>
       <tr>
@@ -98,13 +100,14 @@
   </table>
 </article>
 <article>
-  <h4>Vertical &amp; Wide</h4>
+  <h4>Vertical &amp; Wide &amp; Truncate Values</h4>
   <table class="c-data-list
                 c-data-list--is-vert
-                c-data-list--is-wide">
+                c-data-list--is-wide
+                c-data-list--should-truncate-values">
     <tbody>
       <tr>
-        <th class="c-data-list__key">Given Name</th>
+        <th class="c-data-list__key">Name</th>
         <td class="c-data-list__value">King</td>
       </tr>
       <tr>
@@ -119,13 +122,14 @@
   </table>
 </article>
 <article>
-  <h4>Vertical &amp; Narrow</h4>
+  <h4>Vertical &amp; Narrow &amp; Truncate Values</h4>
   <table class="c-data-list
                 c-data-list--is-vert
-                c-data-list--is-narrow">
+                c-data-list--is-narrow
+                c-data-list--should-truncate-values">
     <tbody>
       <tr>
-        <th class="c-data-list__key">Given Name</th>
+        <th class="c-data-list__key">Name</th>
         <td class="c-data-list__value">King</td>
       </tr>
       <tr>

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -27,6 +27,7 @@
 /* COMPONENTS */
 /* GH-302: HELP: How should all of these become individually built files? */
 /* GH-302: FAQ: Individually built stylesheets could be loaded explicitely. */
+@import url("_imports/components/c-data-list.css");
 @import url("_imports/components/c-footer.css");
 @import url("_imports/components/django.cms.css");
 @import url("_imports/components/django.cms.blog.css");


### PR DESCRIPTION
# Overview

Create CSS component for "Data List" (borrow and improve [similar Portal component](https://github.com/TACC/Core-Portal/pull/116)).



# Issues

Just the component (re-usable styles) for GH-75.



# Changes

- Create new CSS component stylesheet.
- Import new stylesheet into Core `site.css`.



# Testing

> **Alternative**: To test with a plugin instead of a snippet—or test #308 at the same time—then checkout branch `task/GH-75-styles--GH-75-plugin` instead.

1. If you do not have a CMS environment, then prepare one with [Wiki: Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes).
2. Checkout this branch.
3. Add new snippet to test page.
4. Create Snippet plugin with:
    - __HTML__: ["Markup" from `c-data-list.html`](https://github.com/TACC/Core-CMS/blob/task/GH-75-styles/taccsite_cms/static/site_cms/css/src/_imports/components/c-data-list.html)
5. Test that the following is rendered:
    - With page template "Fullwidth" (`fullwidth.html`), see
      <details>
      <summary>several lists and tables with different layouts (toggle for screenshot)</summary>

      ![GH-75 - Test via Snippet](https://user-images.githubusercontent.com/62723358/128207308-d8b36d77-ec9d-42c7-825b-21e8c89b59a7.png)

      </details>


# Screenshots

## Truncation Requirements Not Met By Layout

> __Notice__: The orange and blue box descriptions are **mismatched**. Just notice that "Truncate Values" headings are the **only** sections that allow truncation of values.

| Subject | Firefox | Chromium |
| ---| --- | --- |
| D. Lists | ![GH-75 - D Lists - Firefox](https://user-images.githubusercontent.com/62723358/128207709-53546931-cf50-44c7-a1e9-6a664241b11f.png) | ![GH-75 - D Lists - Chromium](https://user-images.githubusercontent.com/62723358/128207745-81fb9a82-44ff-4a41-afbc-8a4920e4d581.png) |
| Tables | ![GH-75 - Tables - Firefox](https://user-images.githubusercontent.com/62723358/128207356-1c6d4e69-282d-4d61-b0db-cb30e0104be5.png) | ![GH-75 - Tables - Chromium](https://user-images.githubusercontent.com/62723358/128207453-d15b1b5e-0bd3-4f40-860c-535f97d3a5ab.png) |

## Truncation Requirements (Artificially) Met by Layout
I __both__ narrowed screen __and__ increased `html` `font-size` to 500% and 800% to achieve this layout.
| Subject | Firefox | Chromium | Notes |
| ---| --- | --- | --- |
| Horizontal | ![GH-75 - D Lists (Horz) - Narrow - Firefox](https://user-images.githubusercontent.com/62723358/128211075-34db26de-9c49-4fa1-9ea3-7b52ca239500.png) | ![GH-75 - D Lists (Horz) - Narrow - Chromium](https://user-images.githubusercontent.com/62723358/128211111-f68479b1-f110-411d-b5b1-74839926fd27.jpeg) | These are edge cases¹, so everything need not be legible. <hr /> The vert. layouts don't need truncation at this screen width and font size. <hr /> Firefox supports truncation via character (":"); Chromium does not. |
| Vertical | ![GH-75 - D Lists (Vert) - Narrow - Firefox](https://user-images.githubusercontent.com/62723358/128213501-fb1a8995-7b0a-4021-b300-c22ec86b798b.png) | ![GH-75 - D Lists (Vert) - Narrow - Chromium](https://user-images.githubusercontent.com/62723358/128213525-919b8eb2-9839-48a2-a3a5-ca5c390d271f.jpeg) | Text "_____" was appended to force truncation. <hr /> Firefox supports truncation via character (":"); Chromium does not. |

¹ Truncation for horizontal layout is an edge case because: (a) this layout should be used only when enough space is available; (b) when space is not available, responsive design (styles outside this component) should change the surrounding layout so space _is_ available.