### PR TITLE
Hotfix: Restore variable deleted during GH-98

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
@@ -25,6 +25,7 @@
   --global-color-primary--normal: #AFAFAF;
   --global-color-primary--dark: #707070;
   --global-color-primary--x-dark: #484848;
+    --global-color-primary--x-dark-rgb: 72, 72, 72;
   --global-color-primary--xx-dark: #222222;
 
   /* Distinct Hues */


### PR DESCRIPTION
# Overview

Restore missing variable (deleted via https://github.com/TACC/Core-CMS/pull/312).

# Changes

- Restore variable.

# Screenshots

Before
![Hotfix X-Dark RGB - Before](https://user-images.githubusercontent.com/62723358/129636124-2349f4f8-f442-46cd-b26c-d97a92b33dfd.png)

After
![Hotfix X-Dark RGB - After](https://user-images.githubusercontent.com/62723358/129636119-c6e0992c-79c7-4581-be8b-430e710638b9.png)

# Testing

Difficult to test because homepage is not quickly reproducible locally, but I have it.

# Notes

This variable is used by section object banner (from Frontera homepage redesign).