### PR TITLE
Hotfix: Restore variable deleted during GH-98

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
@@ -21,6 +21,7 @@
 
   --global-color-primary--xx-light: #FFFFFF;
   --global-color-primary--x-light: #F4F4F4;
+  --global-color-primary--x-light-rgb: 244, 244, 244;
   --global-color-primary--light: #C6C6C6;
   --global-color-primary--normal: #AFAFAF;
   --global-color-primary--dark: #707070;


### PR DESCRIPTION
# Overview

Restore (another) missing variable (deleted via https://github.com/TACC/Core-CMS/pull/312).

_I just did this in https://github.com/TACC/Core-CMS/pull/314, with a related variable._

# Changes

- Restore variable.

# Screenshots / Testing

**N/A**

_The variable is used in CSS, but no existing page yet renders its result._

# Notes

This variable would be shown with a light section object banner (from Frontera homepage redesign).