### PR TITLE
Quick: Fix wrong global font size 2.4 → 2.6

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/font.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/font.css
@@ -47,7 +47,7 @@ Styleguide Settings.CustomProperties.Font
   --global-font-size--small: 1.4rem;
   --global-font-size--medium: 1.6rem;
   --global-font-size--large: 2.0rem;
-  --global-font-size--x-large: 2.4rem;
+  --global-font-size--x-large: 2.6rem;
   --global-font-size--xx-large: 3.2rem;
   --global-font-size--xxx-large: 4.1rem;
 


### PR DESCRIPTION
# Overview

Fix font size that was saved wrong in https://github.com/TACC/Core-CMS/pull/312.

# Notes

In the [reference document](https://confluence.tacc.utexas.edu/x/nh4FDg), I typed `26px` (good, from Designer) but did not update the `rem` value below from `2.4rem` (old) to `2.6rem` (new). __Bad Wes.__

_P.S. I have checked calculation (see "Math Applied" in doc) to confirm the value is 26 (not 24)._