### PR TITLE
Quick: Make borders visible between light sections

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -119,7 +119,7 @@ Styleguide Objects.Section
 /* FAQ: Banners should not touch a border of the following section */
 .o-section--style-light:not(.o-section--banner)
 + .o-section--style-light:not(.o-section--banner) {
-  border-top: var(--hr-height) solid var(--global-color-primary--xx-light);
+  border-top: var(--hr-height) solid var(--global-color-primary--normal);
 }
 
 /* Modifers: Style: (Fake) Endless Background */

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
@@ -21,7 +21,7 @@
 
   --global-color-primary--xx-light: #FFFFFF;
   --global-color-primary--x-light: #F4F4F4;
-  --global-color-primary--x-light-rgb: 244, 244, 244;
+    --global-color-primary--x-light-rgb: 244, 244, 244;
   --global-color-primary--light: #C6C6C6;
   --global-color-primary--normal: #AFAFAF;
   --global-color-primary--dark: #707070;


### PR DESCRIPTION
# Overview

Support border between sections, like [Frontera System Specs page](https://xd.adobe.com/view/90e6b252-0293-4243-7748-11d94a0763d0-e6d7/screen/ff0348ff-577d-450a-bef0-5326f3f7c705/specs/).

# Issues

N/A

_The result will be seen when GH-88 is used to build a [Frontera System Specs page](https://xd.adobe.com/view/90e6b252-0293-4243-7748-11d94a0763d0-e6d7/screen/ff0348ff-577d-450a-bef0-5326f3f7c705/specs/)._

# Changes

- __Fix__: Change incorrect border color to closes available (from [standard colors](https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css#L22-L30)) to match Design.
- _Minor_: Fix indentation on a standard color variable.

# Testing

1. On the CMS, create markup like:

    ```
    <div class="o-section o-section--style-light">content above line</div>
    <div class="o-section o-section--style-light">content below line</div>
    ```

2. Check that a light gray border appears between the two lines.

# Screenshots

![GH-88 Usage In Progress - Render](https://user-images.githubusercontent.com/62723358/130513351-59d54332-e183-452a-8bea-4ebe6ea5d4b3.jpeg)

![GH-88 Usage In Progress - Markup](https://user-images.githubusercontent.com/62723358/130513348-80aa2a4a-5da0-4b89-b5c3-222715ce6f30.png)

# Notes

Self-merging because this is a noop future bugfix for code not used yet, but will be used very soon.