### PR TITLE
Quick: GH-253: Tweak Style Guide CSS

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-style-guide.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-style-guide.css
@@ -24,16 +24,18 @@ Styleguide Trumps.Scopes.StyleGuide
 
 /* ELEMENTS: Content Sectioning */
 
-.s-style-guide section {
-  clear: both;
+/* Mirrors `s-document` "ELEMENTS: Content Sectioning" */
+
+.s-style-guide h2 {
+  margin: var(--global-space--large) 0 var(--global-space--normal);
 }
-.s-style-guide section:not(section section) {
-  border-top: var(--global-border--x-thick);
-  padding-top: var(--global-space--x-large);
-  margin-top: var(--global-space--x-large);
+
+.s-style-guide h3 {
+  margin-bottom: var(--global-space--normal);
 }
-.s-style-guide section section {
-  border-top: var(--global-border--normal);
-  padding-top: var(--global-space--normal);
-  margin-top: var(--global-space--normal);
-}
+
+/* Extra space above lesser headings */
+.s-style-guide h3 { margin-top: 1em; }
+.s-style-guide h4,
+.s-style-guide h5,
+.s-style-guide h6 { margin-top: 1.25em; }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-style-guide.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-style-guide.css
@@ -9,11 +9,6 @@ A style guide. This is intended for:
 Styleguide Trumps.Scopes.StyleGuide
 */
 
-.s-style-guide {
-  margin-top: var(--global-space--large);
-  margin-bottom: var(--global-space--x-large);
-}
-
 
 
 
@@ -24,18 +19,34 @@ Styleguide Trumps.Scopes.StyleGuide
 
 /* ELEMENTS: Content Sectioning */
 
-/* Mirrors `s-document` "ELEMENTS: Content Sectioning" */
+/* NOTE: Similar to `s-document` "ELEMENTS: Content Sectioning" */
 
-.s-style-guide h2 {
-  margin: var(--global-space--large) 0 var(--global-space--normal);
+/* To give little margin above isolated headings for sections */
+/* FAQ: Headings with no prior sibling need spacing before the heading */
+/* FAQ: Headings that begin `o-section` already have spacing from `o-section` */
+.s-style-guide section:not(.o-section) > h1:first-child,
+.s-style-guide section:not(.o-section) > h2:first-child,
+.s-style-guide section:not(.o-section) > h3:first-child,
+.s-style-guide section:not(.o-section) > h4:first-child,
+.s-style-guide section:not(.o-section) > h5:first-child,
+.s-style-guide section:not(.o-section) > h6:first-child,
+/* FAQ: Headings after non-headings need spacing before the heading */
+/* FAQ: Headings after headings already have spacing from prior heading */
+.s-style-guide section > :not(h1, h2, h3, h4, h5, h6) + h1,
+.s-style-guide section > :not(h1, h2, h3, h4, h5, h6) + h2,
+.s-style-guide section > :not(h1, h2, h3, h4, h5, h6) + h3,
+.s-style-guide section > :not(h1, h2, h3, h4, h5, h6) + h4,
+.s-style-guide section > :not(h1, h2, h3, h4, h5, h6) + h5,
+.s-style-guide section > :not(h1, h2, h3, h4, h5, h6) + h6 {
+  margin-top: var(--global-space--x-large);
 }
 
-.s-style-guide h3 {
+/* To give much margin below all headings for sections */
+.s-style-guide section > h1,
+.s-style-guide section > h2,
+.s-style-guide section > h3,
+.s-style-guide section > h4,
+.s-style-guide section > h5,
+.s-style-guide section > h6 {
   margin-bottom: var(--global-space--normal);
 }
-
-/* Extra space above lesser headings */
-.s-style-guide h3 { margin-top: 1em; }
-.s-style-guide h4,
-.s-style-guide h5,
-.s-style-guide h6 { margin-top: 1.25em; }

--- a/taccsite_cms/templates/style_guide.html
+++ b/taccsite_cms/templates/style_guide.html
@@ -1,4 +1,4 @@
-{% extends "fullwidth.html" %}
+{% extends "standard.html" %}
 {% load cms_tags staticfiles %}
 
 {% block assets_custom %}
@@ -13,6 +13,7 @@
 {% block content %}
 <div class="container  s-document  s-style-guide">
   {% block guide %}
+    {% include "nav_cms_breadcrumbs.html" %}
     {% placeholder "content" %}
   {% endblock guide %}
 </div>


### PR DESCRIPTION
# Overview

Tweak styles for manual pattern library a.k.a. style guide.

# Changes

- Do __not__ rely on `<section>` tags.
- Space content via heading tags.
- Include breadcrumbs (and extend standard).

# Testing

1. Add `('style_guide.html', 'Style Guide'),` entry to `_CMS_TEMPLATES` in `secrets.py`. 
2. Select "Style Guide" as template for a test page.
3. On the test Style Guide page, add sections and multiple headings of different levels.

    <details>
    <summary>Samples</summary>

	- [c-data-list.html.txt](https://github.com/TACC/Core-CMS/files/7035336/c-data-list.html.txt)
	- a Snippet plugin with:
        - HTML: (none)
        - Template: `snippets/typography-guide.html`

    </details>

3. (Optional) On the test Style Guide page, perform manual testing of complex CSS:

    <details>
    <summary>Markup & Checks</summary>

    - heading as direct, first child of a `<section>` that is __not__ an `.o-section`\*
        - __has__ margin _top_ from style guide CSS
        - __has__ margin _bottom_ from style guide CSS
    - heading as direct, first child of a `<section class="o-section">`\*
        - __no__ margin _top_ from style guide CSS
        - __has__ margin _bottom_ from style guide CSS
    - heading as direct, __not__ first child of a `<section class="o-section">`\*
        - __no__ margin _top_ from style guide CSS
        - __has__ margin _bottom_ from style guide CSS
    - heading immediately after a non-heading, both as direct children of a `<section>`
        - __has__ margin _top_ from style guide CSS
        - __has__ margin _bottom_ from style guide CSS
    - heading immediately after a non-heading, both __not__ direct children of a `<section>`
        - __no__ margin _top_ from style guide CSS
        - __no__ margin _bottom_ from style guide CSS
    - heading immediately after a non-heading, both as direct children of a `<section>`
        - __no__ margin _top_ from style guide CSS
        - __has__ margin _bottom_ from style guide CSS
    - heading immediately after a non-heading, both __not__ direct children of a `<section>`
        - __no__ margin _top_ from style guide CSS
        - __no__ margin _bottom_ from style guide CSS

    </details>

> \* An `.o-section` first, direct child heading should not have margin-top, because the section already adds large padding.

# Screenshots

> The structure of these pages has this content in this hierarchy:
> 
> - __Style__ with __*both*__ "Advanced settings > ADDITIONAL CLASSES: `o-section, o-section--style-light`" __*and*__ "TAG TYPE: `section`"
>     - __Text__ with `<h1>Some title</h1>`
>         - content with headings, all optionally grouped within __Style__ with "TAG TYPE: `section`"

- [Style Guide CSS Tweaks - one Section](https://user-images.githubusercontent.com/62723358/130527691-97fb0489-514c-4580-a792-4802e3750d31.jpeg)
- [Style Guide CSS Tweaks - many Sections](https://user-images.githubusercontent.com/62723358/130527694-2f396d74-51ef-4621-9068-dec646553503.jpeg)
- [Style Guide CSS Tweaks - Data List Components](https://user-images.githubusercontent.com/62723358/130530151-21f30e3e-2f2c-4feb-b476-e0ddda318f7e.jpeg)
- [Style Guide CSS Tweaks - Typography](https://user-images.githubusercontent.com/62723358/130530154-3277e2e4-0d72-4f13-a997-42dddf12d9ff.jpeg)
