### PR TITLE
GH-331: Cleanup Fullwidth Template

### DIFF
--- a/taccsite_cms/default_secrets.py
+++ b/taccsite_cms/default_secrets.py
@@ -64,7 +64,7 @@ _CMS_TEMPLATES = (
     # For standard pages (has Container and Breadcrumbs)
     ('standard.html', 'Standard'),
     # For content that spans full window width (no Container nor Breadcrumbs)
-    ('fullwidth.html', 'Fullwidth'),
+    ('fullwidth.html', 'Full Width'),
 
     # Any project that needs per-project styles must have a custom template
     # FAQ: This is a tedious solution until a cleaner solution is devised

--- a/taccsite_cms/templates/fullwidth.html
+++ b/taccsite_cms/templates/fullwidth.html
@@ -3,20 +3,7 @@
 
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}
 
-{% block assets_custom %}
-{{ block.super }}
-
-<script>
-  console.info('Core `fullwidth.html` loads no custom assets');
-</script>
-{% endblock assets_custom %}
-
+{# To remove container and breadcrumbs #}
 {% block content %}
 {% placeholder "content" %}
 {% endblock content %}
-
-{% block assets_custom_delayed %}
-<script>
-  console.info('Core `fullwidth.html` loads no (delayed) custom assets');
-</script>
-{% endblock assets_custom_delayed %}


### PR DESCRIPTION
# Overview / Issues

- Closes #331

# Changes

- e60ba1d Rename template from "Fullwidth" to "Full Width".
- 0c4a38f Remove excess code from `fullwidth.html` Template.
- afa0672 Related https://github.com/TACC/Core-CMS-Resources/pull/73.

# Screenshots

N/A to Core. See "Related PRs".

# Notes

Related yet Independent PRs:

- https://github.com/TACC/Core-CMS-Resources/pull/69
- https://github.com/TACC/Core-CMS-Resources/pull/73
