### PR TITLE
Quick: Remove errant comma in settings

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -245,7 +245,7 @@ INSTALLED_APPS = [
     # FAQ: The djangocms_bootstrap4 library can serve as an example
     'taccsite_cms.contrib.taccsite_sample',
     'taccsite_cms.contrib.taccsite_system_monitor',
-    'taccsite_cms.contrib.taccsite_data_list',
+    'taccsite_cms.contrib.taccsite_data_list'
 ]
 
 # Convert list of paths to list of dotted module names


### PR DESCRIPTION
# Goal

Remove errant comma in `settings.py`.

# Notes

I am surprised more branches aren't failing, given that this caused a server crash on `task/GH-101...`.