### PR TITLE
GH-339: Support Local Django and Django CMS Cache Settings

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -316,7 +316,7 @@ if LDAP_ENABLED:
     ''' End LDAP Auth Settings '''
 
 if getattr(current_secrets, '_CACHES', None):
-    CACHES = secrets._CACHES                        # Are we actually using this setting?
+    CACHES = current_secrets._CACHES
 
 DATABASES = current_secrets._DATABASES
 

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -318,6 +318,13 @@ if LDAP_ENABLED:
 if getattr(current_secrets, '_CACHES', None):
     CACHES = current_secrets._CACHES
 
+if getattr(current_secrets, 'CMS_PLACEHOLDER_CACHE', None):
+    CMS_PAGE_CACHE = current_secrets._CMS_PAGE_CACHE
+if getattr(current_secrets, 'CMS_PLACEHOLDER_CACHE', None):
+    CMS_PLACEHOLDER_CACHE = current_secrets._CMS_PLACEHOLDER_CACHE
+if getattr(current_secrets, 'CMS_PLACEHOLDER_CACHE', None):
+    CMS_PLUGIN_CACHE = current_secrets._CMS_PLUGIN_CACHE
+
 DATABASES = current_secrets._DATABASES
 
 MIGRATION_MODULES = { }


### PR DESCRIPTION
# Important

- __Upcoming Compatibility Concern__: This PR may not be compatible with a major change coming to CMS architecture.
- __Known Better Settings Management Solution__: https://github.com/TACC/Core-CMS/issues/39



# Overview & Changes

Allow dev to disable (or otherwise manipulate) cache for (at least) local development.

1. Fix typo in settings that causes crash on trying to set Django cache via secrets.
2. Support Django CMS cache settings (in secrets, like Django cache is supported/fixed).



# Issues

- Closes GH-339



# Screenshots

N/A



# Testing

## 1. Fix Django Cache Setting Support

1. Add `_CACHE` to local `secrets.py` with [valid value](https://docs.djangoproject.com/en/2.2/ref/settings/#caches).
2. Ensure server does not crash when run.

## 2. Add Django CMS Cache Setting Support

1. Add `_CMS_PAGE_CACHE`, `_CMS_PLACEHOLDER_CACHE`, and `_CMS_PLUGIN_CACHE` to local `secrets.py` with valid values:
    - `True`
    - `False`
2. Ensure server does not crash when run.