### PR TITLE
Hotfix/FP-1194: Use gettext_lazy Not gettext (fixed tup-cms deploy)

### DIFF
--- a/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
+++ b/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
@@ -6,7 +6,7 @@ try:
     # SEE: https://github.com/django-cms/djangocms-bootstrap4/pull/138
     import copy
 
-    from django.utils.translation import gettext_lazy as _
+    from django.utils.translation import gettext as _
 
     from cms.plugin_pool import plugin_pool
 

--- a/taccsite_cms/contrib/bootstrap4_djangocms_picture/cms_plugins.py
+++ b/taccsite_cms/contrib/bootstrap4_djangocms_picture/cms_plugins.py
@@ -2,7 +2,7 @@
 # FAQ: Bootstrap Image plugin has features not desirable in TACC plugins
 # FAQ: We must not break sites that already use Bootstrap Image plugin
 try:
-    from django.utils.translation import gettext_lazy as _
+    from django.utils.translation import gettext as _
 
     from cms.plugin_pool import plugin_pool
 

--- a/taccsite_cms/contrib/taccsite_data_list/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_data_list/cms_plugins.py
@@ -1,6 +1,6 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 
 from taccsite_cms.contrib.constants import TEXT_FOR_NESTED_PLUGIN_CONTENT_SWAP
 from taccsite_cms.contrib.helpers import concat_classnames

--- a/taccsite_cms/contrib/taccsite_data_list/models.py
+++ b/taccsite_cms/contrib/taccsite_data_list/models.py
@@ -1,7 +1,7 @@
 from cms.models.pluginmodel import CMSPlugin
 
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 
 from djangocms_attributes_field import fields
 

--- a/taccsite_cms/contrib/taccsite_sample/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_sample/cms_plugins.py
@@ -1,7 +1,7 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from cms.models.pluginmodel import CMSPlugin
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.utils.encoding import force_text
 
 from .models import TaccsiteSample

--- a/taccsite_cms/contrib/taccsite_system_monitor/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_system_monitor/cms_plugins.py
@@ -1,6 +1,6 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 
 from taccsite_cms.contrib.helpers import concat_classnames
 

--- a/taccsite_cms/contrib/taccsite_system_monitor/models.py
+++ b/taccsite_cms/contrib/taccsite_system_monitor/models.py
@@ -1,5 +1,5 @@
 from cms.models.pluginmodel import CMSPlugin
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 
 from django.db import models
 


### PR DESCRIPTION
# Overview / Changes

Use `gettext` instead of `gettext_lazy`.

# Issues

None. Hotfix during testing after FP-1194 (#341).

# Screenshots

N/A

# Testing

> Tested on [dev.tup](https://dev.tup.tacc.utexas.edu/) around 2021-09-17 @ 18:00 ([build](https://jenkins01.tacc.utexas.edu/job/Core_CMS/206/), [deploy](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/561/)).

1. Have a CMS expectant server with a fresh CMS database.
2. Build an image off branch `task/FP-1194--submod-updates-for-testing--test-fix-for-tup`.\*
3. Deploy the image.
4. Ensure build and deploy succeed and site does not crash.

<details><summary>Footnotes</summary>

_\* This branch has the commit in this PR. It was cherry-picked to here. This branch is used for testing instead of `hotfix/support…`, because `hotfix/support…` is based off of `main` which was merged while its related submodule changes have not been merged while `task/FP-1194--submod…` has all the necessary submodule changes._

</details>

# Reference

- [deploy failure for dev.tup before this fix](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/565/console) 
- https://github.com/django-cms/django-cms/issues/6687