### PR TITLE
Quick: .gitignore: support settings w/ suffixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ repo_name.var
 # Secrets and Customizations
 taccsite_cms/secrets.py
 *.custom.yml
+*settings_custom*.py
+*settings_local*.py
 
 # Makefile var
 cms_name.var
@@ -107,6 +109,3 @@ publish
 # build script local files
 web/build/buildinfo.properties
 web/build/config/buildinfo.properties
-
-*settings_custom.py
-*settings_local.py


### PR DESCRIPTION
# Overview

Support git-ignoring `settings_...py` files with suffixes and prefixes.\*

_\* So that `protx.settings_custom.py` and `settings_custom.protx.py` would both be ignored._

# Screenshots

<details>
<summary>Suffixes</summary>

Gray files are ignored.

![Ignore Suffixes   Prefixes](https://user-images.githubusercontent.com/62723358/134229184-3591b281-2e6e-4b88-a87c-4ecc34c3c911.png)

</details>

<details>
<summary>Prefixes</summary>

Not screen captured, but worked.

</details>

# Testing

1. Add these files (where `___` is whatever text you want):
    - `___.settings_custom.py`
    - `___.settings_local.py`
    - `settings_custom.___.py`
    - `settings_local.___.py`
2. Confirm Git ignores all those files.

# Changes

In `.gitignore`:
- move `settings_....py` to proper location
- support settings with prefixes and/or suffixes