### PR TITLE
GH-353: Fix Missing Bold for Guide Pages

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-inline-dl.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-inline-dl.css
@@ -19,6 +19,8 @@ dl.s-inline-dl dt {
   /* Remove space between <dt> and <dd> (from our styles) */
   /* SEE: ../elments/html-elements.html */
   margin-bottom: 0;
+
+  font-weight: bold;
 }
 dl.s-inline-dl dd {
   clear: right;

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-inline-dl.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-inline-dl.css
@@ -20,7 +20,7 @@ dl.s-inline-dl dt {
   /* SEE: ../elments/html-elements.html */
   margin-bottom: 0;
 
-  font-weight: bold;
+  font-weight: var(--bold);
 }
 dl.s-inline-dl dd {
   clear: right;


### PR DESCRIPTION
# Overview

Restore bold for `<dt>` elements on Guide pages.

# Issues

Closes #353.

# Changes

- Add `font-weight: bold` to relevant file loaded by Guide stylesheet.

# Screenshots

<details><summary>Before</summary>

![GH-353 DT Before](https://user-images.githubusercontent.com/62723358/134465930-bf42efab-8ba2-48de-852d-45687d10763a.png)

</details>

<details>
<summary>After</summary>

![GH-353 DT After](https://user-images.githubusercontent.com/62723358/134465923-60402466-355f-4570-9a35-6681e3d18e08.png)

</details>


# Testing

> Build: https://jenkins01.tacc.utexas.edu/job/Core_CMS/219
> Deploy: https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/606

1. Load a CMS that has page using the "Guide: Portal Technology Stack" template.
2. Scroll to bottom of page.
3. Check that "Frontend" and "Environment" _non-bulleted_ list items start with bold term.

