### PR TITLE
FP-1234: Add Missing Top Margin for Headings

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
@@ -63,6 +63,8 @@ main {
 }
 
 h1, h2, h3, h4, h5, h6 {
+  margin-top: revert; /* to overwrite Bootstrap `_reboot.css` */
+
   font-weight: var(--bold);
   color: var(--global-color-primary--xx-dark);
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-document.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-document.css
@@ -20,18 +20,12 @@ Styleguide Trumps.Scopes.Document
 /* ELEMENTS: Content Sectioning */
 
 .s-document h2 {
-  margin: var(--global-space--large) 0 var(--global-space--normal);
+  margin-bottom: var(--global-space--normal);
 }
 
 .s-document h3 {
   margin-bottom: var(--global-space--normal);
 }
-
-/* Extra space above lesser headings */
-.s-document h3 { margin-top: 1em; }
-.s-document h4,
-.s-document h5,
-.s-document h6 { margin-top: 1.25em; }
 
 /* ELEMENTS: Text Content */
 


### PR DESCRIPTION
# To Do

- [x] Test on UTRC **after** 2021-09-27 launch.

# Required By

- https://github.com/TACC/Core-CMS/pull/360
  Which makes the missing top margin obvious for `<h1>` (which is used—rightly so—by UTRC).

# Overview

- Use (browser) default margin-top values for headings.
- Thus support a `margin-top` for `<h1>`'s (and other headings on all pages, consistently).

# Issues

- [CEPWMA-672](https://jira.tacc.utexas.edu/browse/CEPWMA-672)

# Screenshots

| `<h1>` | Typography | Guide | Standard | Full Width |
| :-: | :-: | :-: | :-: | :-: |
| <img width="1151" alt="UTRC H1 Test" src="https://user-images.githubusercontent.com/62723358/135287801-aab80e12-82c0-4348-9d76-2a2690b71d02.png"> | ![Typography (MIgrate Styles Removed)](https://user-images.githubusercontent.com/62723358/135290646-3687cebd-7190-45df-b853-78720e4db589.png) | <img width="1298" alt="Guide Page (Happens to be the Typography page with template)" src="https://user-images.githubusercontent.com/62723358/135290874-e9cc8a38-e24e-4ef9-8188-71c29658d31c.png"> | Skipped | Skipped |

# Testing

All headings\* on any UTRC page use default browser `margin-top`:
- ~~Style Guide (template)†~~‡
- Typography (snippet, `snippets/typography.html`)
- Guide(: …) (template)†
- Full Width (template)†
- Standard (template)†

> \* Headings are `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`.
> † To be available, it must be in `CMS_TEMPLATES`.
> ‡ This guide has its won margin. The Style Guide is private, not well-known, manual, and subject to change. Ignoring for now.

# Notes

<details><summary>Why was this not done during v1→v2 CMS migration?</summary>

@tacc-wbomar was lazy, because he was in a hurry **and** was hesitant because he did not have standard typography to work from. He previously did not use `<h1>`'s as first heading level. He used `<h2>` because the text was not as large, so the missing margin top was not as ugly. He should have used `<h1>`.

_@tacc-wbomar has since been given the reins by Design to standard typography._

</details>
