### PR TITLE
Quick: (UTRC-356) Migrate Banner Overlay Styles from Core (to Frontera)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -205,20 +205,6 @@ Styleguide Objects.Section
 .o-section--banner .o-section__banner-overlay {
   position: relative;
   z-index: 2;
-
-  /* Avoids the need to add placeholder markup for empty column */
-  /* FAQ: The image "leaves" the column via `position: absolute` */
-  grid-column-start: 2;
-
-  background-color: rgba(var(--color-bkgd-rgb), 0.65);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-}
-.o-section--banner.o-section--style-dark .o-section__banner-overlay {
-  --color-bkgd-rgb: var(--global-color-primary--x-dark-rgb);
-}
-.o-section--banner.o-section--style-light .o-section__banner-overlay {
-  --color-bkgd-rgb: var(--global-color-primary--x-light-rgb);
 }
 
 


### PR DESCRIPTION
# Requires 

- https://github.com/TACC/Core-CMS-Resources/pull/90
  Give Frontera these banner styles it used from Core.

# Required By

- https://github.com/TACC/Core-CMS-Resources/pull/93
  The new homepage styles for which this change happened. (UTRC banner overlay differs from Frontera.)

# Overview

Migrate CSS for banner overlay styles (which UTRC styles differently) __from Core__ _to Frontera_.

# Notes

1. One banner overlay style was _designed_ for Frontera.
2. That banner overlay style was _assumed_ for TACC.
3. TACC redesign shows banner overlay will **_not_** be used on TACC.
4. UTRC homepage will use a _different_ banner overlay style.