### PR TITLE
Quick: (UTRC-356) Overlay CSS Mixins

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-overlay.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-overlay.css
@@ -1,0 +1,28 @@
+/*
+Overlay
+
+Colored boxes that appear atop a large image (like a banner).
+
+%x-overlay--curtain - A full size transluscent curtain over the background
+%x-overlay--callout - A transluscent box surrounding the content
+
+Styleguide Tools.ExtendsAndMixins.Overlay
+*/
+
+.x-overlay--curtain {
+  --color-text: inherit;
+  --color-bkgd-rgb: var(--global-color-primary--normal);
+
+  color: var(--color-text);
+  background-color: rgba(var(--color-bkgd-rgb), 0.65);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.x-overlay--callout {
+  --color-text: inherit;
+  --color-bkgd-rgb: var(--global-color-primary--normal);
+
+  color: var(--color-text);
+  background-color: rgba(var(--color-bkgd-rgb), 0.90);
+}


### PR DESCRIPTION
# Required By

- https://github.com/TACC/Core-CMS-Resources/pull/93
  UTRC expects one of these overlay mixins to be available.
- https://github.com/TACC/Core-CMS-Resources/pull/90
  Frontera expects one of these overlay mixins to be available.

# Overview

Create re-usable styles for boxes (of text and/or content) that overlay atop banners (or other large images).

# Notes

Used on:
- [UTRC Homepage](https://xd.adobe.com/view/c4167d5f-56fa-47fa-acc7-ec194e694ad5-9145/specs/)
- [Frontera Homepage](https://xd.adobe.com/view/f3dad8d1-88ee-40eb-b8da-667b00e4f876-a689/specs/)