### PR TITLE
Hotfix: (UTRC-356) Let Banner Section Padding Match Other Sections

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -66,12 +66,6 @@ Styleguide Objects.Section
 
   gap: 0 !important; /* overwrite `o-section--layout-*` */
 }
-/* To take control of padding away from Bootstrap on ALL screen sizes */
-.o-section--banner.container,
-.o-section--banner.container-fluid {
-  padding-left: 0;
-  padding-right: 0;
-}
 
 
 


### PR DESCRIPTION
# Required By

- https://github.com/TACC/Core-CMS-Resources/pull/93
  Ensure UTRC's banner spacing (at narrow window width) matches the spacing of other sections.

# Requires

- https://github.com/TACC/Core-CMS-Resources/pull/91
  Ensure Frontera's homepage banner spacing is not broken more (and fixes its spacing).

# Overview

Remove unique banner section padding so as to:
- match other sections' padding (affects Frontera).
- fix inconsistent spacing for UTRC home page banner.
