### PR TITLE
Noop: Fix Comment Typo & Move Styles Down Under It

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -180,8 +180,6 @@ Styleguide Objects.Section
 
 /* Added `.o-section--banner` to require parent modifier class in markup */
 .o-section--banner .o-section__banner-image {
-  position: absolute;
-  z-index: 1;
 
   /* To size image to cover section dimensions but maintain ratio */
   /* CAVEAT: This causes image to overflow beyond section */
@@ -191,7 +189,9 @@ Styleguide Objects.Section
   min-height: 100%;
   object-fit: cover;
 
-  /* To vertically center image within section */
+  /* To center image within section */
+  position: absolute;
+  z-index: 1;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
# Overview

Fix a comment and move styles within the same rule.

# Changes

- Fix a comment typo.
- Move related exisitng styles to under updated comment.