### PR TITLE
Hotfix: (UTRC-356) Avoid Grid Blowout

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css
@@ -11,6 +11,7 @@ Styles that allow re-usable layouts.
 
 Styleguide Tools.ExtendsAndMixins.Layout
 */
+@import url("_imports/tools/media-queries.css");
 
 
 
@@ -42,7 +43,7 @@ Styleguide Tools.ExtendsAndMixins.Layout
 
 @media (--medium-and-below) {
   .x-layout--b, /* DEPRECATED */
-  %x-layout--b { grid-template-columns: 1fr; }
+  %x-layout--b { grid-template-columns: minmax(0,1fr); }
 }
 @media (--medium-and-above) {
   .x-layout--b, /* DEPRECATED */
@@ -53,7 +54,7 @@ Styleguide Tools.ExtendsAndMixins.Layout
 
 @media (--medium-and-below) {
   .x-layout--c, /* DEPRECATED */
-  %x-layout--c { grid-template-columns: 1fr; }
+  %x-layout--c { grid-template-columns: minmax(0,1fr); }
 }
 @media (--medium-and-above) {
   .x-layout--c, /* DEPRECATED */


### PR DESCRIPTION
# Overview

Avoid "grid blowout" (like UTRC homepage text below banner not wrapping*).

> \* This could happen if its `.s-focus-list` items have text that is longer than available space.

# Changes

- Add missing import of custom media queries.\*
- Use `min-width` (via `minmax()` for to prevent grid cells from overflowing grid box.

> \* This did not cause a bug for Frontera, because the build process for its homepage stylesheet imported other stylesheets that imported custom media queries.

# Notes

- [CSS Tricks: Preventing a Grid Blowout](https://css-tricks.com/preventing-a-grid-blowout/)