### PR TITLE
Hotfix: (UTRC-356) Darker Core Body Text

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
@@ -32,7 +32,7 @@ body {
   min-width: 290px; /* developer-decided value */
 
   /* To overwrite Bootstrap */
-  color: var(--global-color-primary--dark);
+  color: var(--global-color-primary--x-dark);
   font-family: var(--global-font-family);
   font-size: var(--global-font-size--medium);
   line-height: 1.4;


### PR DESCRIPTION
# Overview

Darken the body text to be closer to various CMS page designs\*.

> \* Designer has habit of not checking our standard colors, and relying on me to round. I should provide him better reference.

# Notes

Reference Designs:
- [UTRC Homepage](https://xd.adobe.com/view/c4167d5f-56fa-47fa-acc7-ec194e694ad5-9145/specs/)
- [CMS Common Components](https://xd.adobe.com/view/b37b291a-7798-4814-90f3-7ac63c48a3e0-e628/screen/7ecf7f47-e43b-4839-a8b4-a4b51777fa5e/specs/)
- [Frontera Redesign](https://xd.adobe.com/view/f3dad8d1-88ee-40eb-b8da-667b00e4f876-a689/screen/8bb9a7de-c5b2-493b-b897-d967ca8a57ec/specs/)