### PR TITLE
UTRC-356: New UTRC Homepage & Relevant Core Fixes

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
@@ -32,7 +32,7 @@ body {
   min-width: 290px; /* developer-decided value */
 
   /* To overwrite Bootstrap */
-  color: var(--global-color-primary--dark);
+  color: var(--global-color-primary--x-dark);
   font-family: var(--global-font-family);
   font-size: var(--global-font-size--medium);
   line-height: 1.4;

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -66,12 +66,6 @@ Styleguide Objects.Section
 
   gap: 0 !important; /* overwrite `o-section--layout-*` */
 }
-/* To take control of padding away from Bootstrap on ALL screen sizes */
-.o-section--banner.container,
-.o-section--banner.container-fluid {
-  padding-left: 0;
-  padding-right: 0;
-}
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -199,20 +199,6 @@ Styleguide Objects.Section
 .o-section--banner .o-section__banner-overlay {
   position: relative;
   z-index: 2;
-
-  /* Avoids the need to add placeholder markup for empty column */
-  /* FAQ: The image "leaves" the column via `position: absolute` */
-  grid-column-start: 2;
-
-  background-color: rgba(var(--color-bkgd-rgb), 0.65);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-}
-.o-section--banner.o-section--style-dark .o-section__banner-overlay {
-  --color-bkgd-rgb: var(--global-color-primary--x-dark-rgb);
-}
-.o-section--banner.o-section--style-light .o-section__banner-overlay {
-  --color-bkgd-rgb: var(--global-color-primary--x-light-rgb);
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -155,7 +155,10 @@ Styleguide Objects.Section
 .o-section--layout-b,
 .o-section--layout-c,
 .o-section--layout-d {
-  gap: 3.0rem; /* GH-99: Use standard spacing value */
+  /* GH-99: Use standard spacing value */
+  --gap: 3.0rem; /* to allow instances to re-use the gap value */
+
+  gap: var(--gap);
 }
 .o-section--layout-a { @extend .x-layout--a; }
 .o-section--layout-b { @extend .x-layout--b; }

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
@@ -20,6 +20,7 @@
   /* Primary (Text, Layout) */
 
   --global-color-primary--xx-light: #FFFFFF;
+    --global-color-primary--xx-light-rgb: 255, 255, 255;
   --global-color-primary--x-light: #F4F4F4;
     --global-color-primary--x-light-rgb: 244, 244, 244;
   --global-color-primary--light: #C6C6C6;
@@ -28,6 +29,7 @@
   --global-color-primary--x-dark: #484848;
     --global-color-primary--x-dark-rgb: 72, 72, 72;
   --global-color-primary--xx-dark: #222222;
+    --global-color-primary--xx-dark-rgb: 34, 34, 34;
 
   /* Distinct Hues */
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css
@@ -11,6 +11,7 @@ Styles that allow re-usable layouts.
 
 Styleguide Tools.ExtendsAndMixins.Layout
 */
+@import url("_imports/tools/media-queries.css");
 
 
 
@@ -42,7 +43,7 @@ Styleguide Tools.ExtendsAndMixins.Layout
 
 @media (--medium-and-below) {
   .x-layout--b, /* DEPRECATED */
-  %x-layout--b { grid-template-columns: 1fr; }
+  %x-layout--b { grid-template-columns: minmax(0,1fr); }
 }
 @media (--medium-and-above) {
   .x-layout--b, /* DEPRECATED */
@@ -53,7 +54,7 @@ Styleguide Tools.ExtendsAndMixins.Layout
 
 @media (--medium-and-below) {
   .x-layout--c, /* DEPRECATED */
-  %x-layout--c { grid-template-columns: 1fr; }
+  %x-layout--c { grid-template-columns: minmax(0,1fr); }
 }
 @media (--medium-and-above) {
   .x-layout--c, /* DEPRECATED */

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-overlay.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-overlay.css
@@ -1,0 +1,28 @@
+/*
+Overlay
+
+Colored boxes that appear atop a large image (like a banner).
+
+%x-overlay--curtain - A full size transluscent curtain over the background
+%x-overlay--callout - A transluscent box surrounding the content
+
+Styleguide Tools.ExtendsAndMixins.Overlay
+*/
+
+.x-overlay--curtain {
+  --color-text: inherit;
+  --color-bkgd-rgb: var(--global-color-primary--normal);
+
+  color: var(--color-text);
+  background-color: rgba(var(--color-bkgd-rgb), 0.65);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.x-overlay--callout {
+  --color-text: inherit;
+  --color-bkgd-rgb: var(--global-color-primary--normal);
+
+  color: var(--color-text);
+  background-color: rgba(var(--color-bkgd-rgb), 0.90);
+}


### PR DESCRIPTION
# Requires

- https://github.com/TACC/Core-CMS-Resources/pull/94
  The bulk of the UTRC styles and changes to Frontera required by changes to Core.

# Overview

New UTRC Homepage and relevant Core fixes.

# Issues

- [UTRC-356](https://jira.tacc.utexas.edu/browse/UTRC-356)

# Changes
These changesets __are__ in this PR (even though they are closed).

- TACC/Core-CMS#367
- TACC/Core-CMS#361
- TACC/Core-CMS#363
- TACC/Core-CMS#362
- TACC/Core-CMS#365
- TACC/Core-CMS#366

# Testing

<details>
<summary>Before Fixes</summary>

> Build: [job #225](https://jenkins01.tacc.utexas.edu/job/Core_CMS/225)
> Deploy: https://pprd.utrc.tacc.utexas.edu/custom-homepage (via [job #614](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/614))
> Deploy: https://prod.utrc.tacc.utexas.edu/ (via [job #615](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/615))

</details>

<details open>
<summary>After Fixes</summary>

> Build: [job #230](https://jenkins01.tacc.utexas.edu/job/Core_CMS/225)
> Deploy: https://pprd.utrc.tacc.utexas.edu/custom-homepage (via [job #618](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/618))
> Deploy: https://prod.utrc.tacc.utexas.edu/ (via [job #619](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/619))

</details>

1. Compare to Design at window width of 1200px.
	- Banner is _intentionally_ different, because CMD provided new banner.
	- Difference in spacing, if present, be negligible (5–10 pixels).\*
	- Alignment of layout items is important.
2. Review responsive design at [TACC CMS standard breakpoints](https://confluence.tacc.utexas.edu/x/b4AZCg).
	- text should not overflow
	- if text overflows, it should truncate
	- columns beneath banner should stack at narrow screen
	- banner overlay text should remain aligned to content text until very narrow window width
	- icon list (beneath banner, right column) text should not wrap at any breakpoint.
	- icons may resize to prevent text wrap/overflow

> \* I use standard spacing, or round to nearest pixel, where sensible (subjective, I know—I probably have a set of rules in my head, but I can't think through it, right now).