### PR TITLE
Quick: Permit Root Contianer in Structure

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -66,10 +66,18 @@
     <div id="content-wrap" class="o-site__body">
       <!-- This block used regardless. -->
       {% block content %}
+
+      {# To allow extra Container in page structure by hiding extra padding #}
+      <style type="text/css">
+        .container > .s-breadcrumbs + .container { padding-inline: 0; }
+      </style>
+
+      {# To wrap breadcrumbs in Container without relying on CMS editor #}
       <div class="container">
         {% include "nav_cms_breadcrumbs.html" %}
         {% placeholder "content" %}
       </div>
+
       {% endblock content %}
       <!-- End of Block. -->
     </div>


### PR DESCRIPTION
## Overview

- Allow CMS editors to retain/add Container in page structure.

## Issues

Fixes problem caused by #310.

## Screenshots

…

## Testing

…

## Notes

0. <details>
	<summary>Background</summary>

	0. Most v2 CMS pages use Full Width template, which has no `.container`.
	1. #311 introduced Standard template that provides `.container` and breadcrumbs.
	2. @tacc-wbomar announced that Standard template should be used:
	    - This is how to get breadcrumbs, which are (usually) for all pages except home page.
	    - This meant that "Container" must not be in Structure (because it adds nested padding).
	    - This means page edits on all existing v2 sites as they being to use Standard.
	3. Today, Wes realized that this could be solved with CSS instead of page edits.

	</details>
1. <details>
	<summary>I am open to suggestion for better location, but <a href="https://confluence.tacc.utexas.edu/x/IAA9Cw" target="_blank">ITCSS organization</a> has rules.</summary>

	- The [`bootstrap.container.css`](https://github.com/TACC/Core-CMS/blob/e4ed6d7d/taccsite_cms/static/site_cms/css/src/_imports/components/bootstrap.container.css) is a Component stylesheet. A component does not permit Scope class, like `.s-breadcrumb`.
	- If `.s-breadcrumb` is not included to limit range of style cascade, then the structure can hide nested Containers (usually undesired) because the tell-tale sign of nested padding would be hidden.
	- The [`s-breadcrumb.css`](https://github.com/TACC/Core-CMS/blob/adef3a6/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-breadcrumbs.css) is a Scope stylesheet. A scope only permits styling of the scope and its children.
	- Both `.s-breadcrumb` and `.container` are equally relevant, so the styles should not belong to one or the other. And ITCSS _intentionally_ does not provide stylesheets for this kind of mixing.

	So, I opted to put the styles exactly where the problem is.

	</details>