### PR TITLE
CEPWMA-674: Fix Inconsistent Icon Size

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/icon.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/icon.css
@@ -8,7 +8,7 @@
 .icon {
   width: 1em;
   height: 1em;
-  font-size: 1.125rem; /* ~18px (16px design * 1.2 design-to-app ratio) (rounded) */
+  font-size: 1.125em; /* ~18px (16px design * 1.2 design-to-app ratio) (rounded) */
   vertical-align: middle;
   display: inline-flex; /* `flex` to align `::before`; `inline` to not trigger new line */
                         /* a modern slimmer alternative to `&::before { display: block; }` */


### PR DESCRIPTION
# Overview

Fix icon size that was inconsistent.

# Issues

[CEPWMA-674](https://jira.tacc.utexas.edu/browse/CEPWMA-674)

# Screenshots

# Testing

1. Be able to [Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes) across Portal, Docs, and CMS.
2. Confirm that icon size is 18px in Portal, Docs, and CMS.