### PR TITLE
Update settings.py

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -30,6 +30,9 @@ ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']   # In development.
 # Requires django-auth-ldap ≥ 2.0.0
 LDAP_ENABLED = True
 
+# Default portal authorization verification endpoint.
+CEP_AUTH_VERIFICATION_ENDPOINT =  'localhost' #'https://0.0.0.0:8000'
+
 ########################
 # DATABASE SETTINGS
 ########################


### PR DESCRIPTION
Should we include a default setting value (which would be overridden in any `secrets.py` file on the host system) so the cms remote_login works "out-of-the-box"?