### PR TITLE
FP-1270: Provide Header CSS that Only Docs Needs

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/site.header.docs.css
+++ b/taccsite_cms/static/site_cms/css/src/site.header.docs.css
@@ -1,0 +1,7 @@
+/* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
+
+/* NOTE: This file exists so User Guide can load header styles only it needs */
+
+/* FAQ: User Guide lacks the vars that _imports/trumps/s-header.css expects */
+@import url("_imports/settings/color.css");
+@import url("_imports/settings/border.css");


### PR DESCRIPTION
## Required By

- [Bitbucket `taccaci/frontera-tech-docs` PR #27](https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/27/fp-1270-fix-wrong-colors-and-missing)

## Overview

Fix wrong colors and missing borders on header.

## Issues

- [FP-1270](https://jira.tacc.utexas.edu/browse/FP-1270)

## Changes

Provide new stylesheet with variables User Guide does not have.

## Screenshots

| Before | After |
| - | - |
| ![Pprd Bug](https://user-images.githubusercontent.com/62723358/140959849-16e045b6-4ab9-417b-bba7-cad800aeb991.png) | ![Local Fix](https://user-images.githubusercontent.com/62723358/140959843-6c13d9d2-3e1e-4eb1-8170-f4ecf0455709.png) |

## Testing

1. __Either__ load local test: http://localhost:8001/static/site_cms/css/build/site.header.docs.css
	__Or__ load remote test: https://dev.fronteraweb.tacc.utexas.edu/static/site_cms/css/build/site.header.docs.css
2. Confirm that file is loaded and has CSS that defines color and border variables.
	<details>

	```
	:root{--global-color-primary--xx-light:#fff;--global-color-primary--xx-light-rgb:255,255,255;--global-color-primary--x-light:#f4f4f4;--global-color-primary--x-light-rgb:244,244,244;--global-color-primary--light:#c6c6c6;--global-color-primary--normal:#afafaf;--global-color-primary--dark:#707070;--global-color-primary--x-dark:#484848;--global-color-primary--x-dark-rgb:72,72,72;--global-color-primary--xx-dark:#222;--global-color-primary--xx-dark-rgb:34,34,34;--global-color-accent--normal:#877453;--global-color-link-on-light--normal:#039;--global-color-link-on-dark--normal:#08f}:root{--global-border-width--normal:1px;--global-border--normal:var(--global-border-width--normal) solid var(--global-color-primary--normal);--global-border-width--thick:2px;--global-border--thick:var(--global-border-width--thick) solid var(--global-color-primary--normal);--global-border-width--x-thick:3px;--global-border--x-thick:var(--global-border-width--x-thick) solid var(--global-color-primary--normal)}
	```

	</details>

