### PR TITLE
Quick: Changelog: Move out a fix not in v3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bugfix/FP-1277: Extra Margin from Container by User on Standard Template (#370)
+
 ## [3.0.7] - 2021-10-26: Hotfixes (mostly for Frontera); Rename Unused Component
 
 ### Changed
 
-- (Noop) task/FP-1260 Rename Component ReadMore to ShowMore (#376)
+- task/FP-1260 Rename Component ReadMore to ShowMore (#376)
 
 ### Fixed
 
 - FP-1270: Provide Header CSS that Only Docs Needs (#381)
-- Bugfix/FP-1277: Extra Margin from Container by User on Standard Template (#370)
 - (UTRC) FP-1234: Add Missing Top Margin for Headings (#359)
 - Quick: Complete Core fix for section header colors (#385)
 - Hotfix: Local Images for Getting Started Guide (#369)


### PR DESCRIPTION
## Overview

There was an item placed in 3.0.7 release that is not actually prepared for release.

## Notes

The fix is good, it's just not in the Docker images I prepared and tested for release.