### PR TITLE
FP-1235: Do not support dropdown menu text as link

### DIFF
--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -7,17 +7,14 @@
 {% for child in children %}
 <li class="nav-item{% if child.selected or child.ancestor %} active{% endif %}{% if child.children %} dropdown{% endif %}">
   {% if child.children %}
-  <span class="nav-link">
-    <a href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">
-      {{ child.get_menu_title|safe }}
-      {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
-    </a>
     <a
       href=""
-      class="dropdown-toggle dropdown-toggle-split"
+      class="nav-link dropdown-toggle"
       data-toggle="dropdown"
       aria-haspopup="true"
       aria-expanded="false">
+      {{ child.get_menu_title|safe }}
+      {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
       <span class="sr-only">Toggle Dropdown</span>
     </a>
     <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown">
@@ -31,7 +28,6 @@
         {% if grandchild.selected %}<span class="sr-only">(current)</span>{% endif %}
       </a>
       {% endfor %}
-  </span>
   {% else %}
   <a class="nav-link" href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">
     {{ child.get_menu_title|safe }}


### PR DESCRIPTION
## Overview

Do not let dropdown menu text be a link.

## Issues

- [FP-1235](https://jira.tacc.utexas.edu/browse/FP-1235)

## Changes

- __Nest menu text and dropdown arrow inside link that opens dropdown.__
- Remove superfluous `<span>` tag.

## Screenshots

| | Before | After |
| - | - | - |
| No Action | ![Before - Normal](https://user-images.githubusercontent.com/62723358/140224111-1d5cc713-b458-4ef2-8c8c-83ea8da57997.png) | ![After - Normal](https://user-images.githubusercontent.com/62723358/140224302-99a85fb4-fa44-4d5f-adef-bc2a3faf365b.png) |
| Hover on Text | ![Before - Hover](https://user-images.githubusercontent.com/62723358/140224445-c48e1803-2f75-425b-a586-a0facf9372df.png) | ![After - Hover](https://user-images.githubusercontent.com/62723358/140224526-ee9b2251-94f9-4d4c-beab-d88ea7236b24.png) |
| Click on Text | ![Before - Click](https://user-images.githubusercontent.com/62723358/140224713-db0634bf-9efb-4228-9525-a1c0b24d232f.png) | ![After - Click](https://user-images.githubusercontent.com/62723358/140224881-72e2bcb6-56cc-4b3e-b58d-128a6ff554c3.png) |

## Testing

0. Know how to test CMS changes.
1. Create a top-level page with a sup-page link.
2. Test that use cannot navigate to top-level page by clicking any part of the nav menu element.