### PR TITLE
Hotfix: Fix Branding Links not Opening in New Window

### DIFF
--- a/taccsite_cms/templates/header_branding.html
+++ b/taccsite_cms/templates/header_branding.html
@@ -5,7 +5,7 @@
 <div id="header-branding" class="branding-header {{className}}">
   {# DEBUG: #}{# <code>{{ brands|first }}</code> #}
   {% for brand in brands %}
-    {% with filename=brand|index:1 selectors=brand|index:2 targeturl=brand|index:3 targetType=brand|index:4 accessibility=brand|index:5 corstype=brand|index:6 visibility=brand|index:7 %}
+    {% with filename=brand|index:1 selectors=brand|index:2 targeturl=brand|index:3 targettype=brand|index:4 accessibility=brand|index:5 corstype=brand|index:6 visibility=brand|index:7 %}
       {% if visibility == "True" %}
         {% if brand == brands|first %}
         <a href="{{ targeturl }}" target="{{ targettype }}">

--- a/taccsite_cms/templates/header_logo.html
+++ b/taccsite_cms/templates/header_logo.html
@@ -2,7 +2,7 @@
 {% load staticfiles custom_portal_settings %}
 
 {% with settings.LOGO as logo %}
-  {% with filename=logo|index:1 selectors=logo|index:2 targeturl=logo|index:3 targetType=logo|index:4 accessibility=logo|index:5 corstype=logo|index:6 visibility=logo|index:7 %}
+  {% with filename=logo|index:1 selectors=logo|index:2 targeturl=logo|index:3 targettype=logo|index:4 accessibility=logo|index:5 corstype=logo|index:6 visibility=logo|index:7 %}
     {% if visibility == "True" %}
     <a id="header-logo" class="navbar-brand {{className}}" href="{{ targeturl }}" target="{{ targettype }}">
       <img class="portal-logo {{ selectors }}" src="{% static filename %}" crossorigin="{{ corstype }}" alt="{{ accessibility }}" >


### PR DESCRIPTION
## Overview

Fix typo (age unknown) in Core that preventing branding links from opening in new window (without JavaScript*).

_This was noticed on Brainmap, but affects all CMS's._

> \* Some CMS's has a JavaScript snippet that incidentally, dynamically fixes this.

## Changes

- Fix typo so that `target` attribute renders value from settings.

## Testing

0. Know how to [Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes).
1. Load up CMS using [Frontera's `settings.custom.py`](https://github.com/TACC/Core-CMS-Resources/blob/main/frontera-cms/settings_custom.py#L28-L37) (because it meets requirements).

	<details><summary>Requirements</summary>

    - value of 3rd entry in array is external link
    - value of 4th entry in array is `"_blank"`

	</details>

2. Confirm that rendered link has `target="_blank"`