### PR TITLE
Hotfix/FP-1332: Horz. Scrollbar Caused by Sections

### DIFF
--- a/taccsite_cms/templates/standard.html
+++ b/taccsite_cms/templates/standard.html
@@ -4,6 +4,7 @@
 {% block assets_custom %}
   {{ block.super }}
 
+  {# TODO: FP-1318: Solve section overflow in `o-section` code #}
   <style>
   /* To hide `.o-section--style-…` and `.o-section__banner-image` overflow */
   /* FAQ: Isolate from other templates to avoid unexpected side-effects */

--- a/taccsite_cms/templates/standard.html
+++ b/taccsite_cms/templates/standard.html
@@ -1,4 +1,16 @@
 {% extends "base.html" %}
 {% load cms_tags %}
 
+{% block assets_custom %}
+  {{ block.super }}
+
+  <style>
+  /* To hide `.o-section--style-…` and `.o-section__banner-image` overflow */
+  /* FAQ: Isolate from other templates to avoid unexpected side-effects */
+  main,
+  /* HACK: Using ID until upstream updates markup via `quick/create-and-document-element-stylesheets` */
+  #content-wrap { overflow: hidden; }
+  </style>
+{% endblock assets_custom %}
+
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}


### PR DESCRIPTION
## Suggested

- to also fix UTRC, https://github.com/TACC/Core-CMS-Resources/pull/108

## Overview

Avoid horizontal scrollbar on pages known to use sections. (I am the only one adding sections, until [FP-1318](https://jira.tacc.utexas.edu/browse/FP-1318).)

## Issues

[FP-1332](https://jira.tacc.utexas.edu/browse/FP-1332)

## Testing

1. Load these pages to test:
    - https://pprd.frontera-portal.tacc.utexas.edu/system [^0] (uses Core Standard template)
    - https://pprd.utrc.tacc.utexas.edu/ [^0] (uses UTRC Home template)
1. Verify window has **no** horizontal scrollbar.

[^0]: Deployed via https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/849/ which loads image from branch `main--v3-3-0-with-hotfixes`.

## Notes

This is not a long-term solution. Via [FP-1318](https://jira.tacc.utexas.edu/browse/FP-1318), I will fix the problem at the source (I do not know how yet, but I'll figure it out).