### PR TITLE
Hotfix/FP-1331: Do Not Hide Header Drodpowns

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-site.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-site.css
@@ -23,8 +23,4 @@ Styleguide Objects.Site
 .o-site__head,
 .o-site__foot {
   flex-shrink: 0;
-
-  /* Hides any overflow from `o-site__body` (e.g. `o-section__banner-image`) */
-  position: relative;
-  z-index: 1;
 }


### PR DESCRIPTION
## Overview

Do not hide header dropdown menus underneath body content.

## Issues

[FP-1331](https://jira.tacc.utexas.edu/browse/FP-1331)

## Testing

1. Load these pages to test:
    - https://pprd.frontera-portal.tacc.utexas.edu/system [^0]
    - https://pprd.frontera-portal.tacc.utexas.edu/ [^0]
1. Be logged into portal.
    1. Login to Portal.
    2. Return to CMS.
2. Open Portal dropdown menu.
3. Verify dropdown menu can be seen (test both pages).

[^0]: Deployed via https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/849/ which loads image from branch `main--v3-3-0-with-hotfixes`.

## Notes

This [removed code](https://github.com/TACC/Core-CMS/pull/404/files#diff-a246d241c0f3a3caf41f81713609e56f78fb0dfdb873536a8867f87356f0df00L26-L29) had solved a problem that has since been solved by [other code](https://github.com/TACC/Core-CMS-Resources/blob/3d01e03/frontera-cms/templates/home.html#L15-L19).