### PR TITLE
Hotfix/FP-1333: Callout Title Color

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -7,6 +7,7 @@ Markup: o-section.html
 
 Styleguide Objects.Section
 */
+/* TODO: FP-1318: Move styling of tags (<a>, <h1–6>) to `s-section` */
 @import url("_imports/tools/media-queries.css");
 @import url("_imports/tools/x-layout.css");
 
@@ -237,3 +238,14 @@ Styleguide Objects.Section
 /* NOTE: A `z-index` > 0 is only necessary for sections before banner */
 /* CAVEAT: Any section pop-out el's can NOT overflow atop section after it */
 [class*="o-section--style"] { z-index: 1; }
+
+
+
+
+
+/* Scope (should be moved to `s-section`) */
+/* NOTE: FP-1318: Other should-be-scope CSS (<a>, <h1–6>) is in this file */
+
+[class*="o-section--style"] .c-callout__title {
+  color: var(--global-color-primary--xx-light);
+}


### PR DESCRIPTION
## Overview

Ensure callout title is always white, even inside a section which tries to color headings.

## Issues

[FP-1333](https://jira.tacc.utexas.edu/browse/FP-1333)

## Testing

1. Load https://pprd.frontera-portal.tacc.utexas.edu/system. [^0]
1. Scroll down to Callout.
2. Verify title is white.
3. Change `o-section--style-light` class of the ancestor `<section>` to `o-section--style-dark`.
4. Verify title is _still_ white.

[^0]: Deployed via https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/851/ which loads image from branch `main--v3-3-0-with-hotfixes`.

## Notes

In [FP-1318](https://jira.tacc.utexas.edu/browse/FP-1318), I will move this and related styles to a new [trump](https://confluence.tacc.utexas.edu/x/IAA9Cw) file `s-section.css`.

<details>
<summary>Why?</summary>

Because a ["scope" (`s-`) trump](https://confluence.tacc.utexas.edu/x/IAA9Cw) is more appropriate for cross-layer styles (e.g. `…-section` and `.c-callout`, `…-section` and any element/tag).

</details>