### PR TITLE
Quick: Remove sentence from Getting Started doc

### DIFF
--- a/taccsite_cms/templates/guides/getting_started.html
+++ b/taccsite_cms/templates/guides/getting_started.html
@@ -24,8 +24,7 @@
 
       <p>
         Before you can access the Portal, you must first have an active
-        account with TACC. You can create one that is linked to your UT System
-        Institution credentials.
+        account with TACC.
       </p>
 
       <div class="row">


### PR DESCRIPTION
## Overview

Remove sentence from Getting Started template.

## Issue

- [Slack message from T.B.](https://tacc-team.slack.com/archives/C02HKF81CBA/p1637078725004400) (but **keep** _first_ sentence, **remove** _second_ sentence)

## Screenshots

| Before (i.e. actual current state) | After (note: this is approximated) |
| - | - |
| ![Getting Started BEFORE](https://user-images.githubusercontent.com/62723358/142032907-48e62003-2c5b-4583-89fc-799bbf766fbb.png) | ![Getting Started AFTER (faked)](https://user-images.githubusercontent.com/62723358/142032912-e4f3400e-955e-4717-831c-0b72dad4aa16.png) |
| | Image is faked. Testing would show it as this, though. |

## Notes

This is okay for Core, even though it was reported for 3Dem ([question](https://tacc-team.slack.com/archives/C02HKF81CBA/p1637080535007500), [answer](https://tacc-team.slack.com/archives/C02HKF81CBA/p1637080640007700)).