### PR TITLE
FP-1290: Card UI Pattern (Frontera About Page)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.css
@@ -11,6 +11,7 @@ Markup: c-card.html
 
 Styleguide Components.Card
 */
+@import url("_imports/tools/x-article-link.css");
 
 /* Modifiers */
 
@@ -31,10 +32,8 @@ a.c-card--frontera-about-page {
 
   text-decoration: none;
 }
-a.c-card--frontera-about-page:hover {
-  outline: 1px solid var(--global-color-accent--normal);
-  outline-offset: 1em;
-}
+a.c-card--frontera-about-page:hover { @extend %x-article-link-hover; }
+a.c-card--frontera-about-page:active { @extend %x-article-link-active; }
 
 /* Plugins: * > Image + Text */
 .c-card--frontera-about-page img + h3 {

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.css
@@ -26,6 +26,12 @@ Styleguide Components.Card
 /* Plugins: Link / Image with Link */
 a.c-card--frontera-about-page {
   display: inline-block;
+
+  text-decoration: none;
+}
+a.c-card--frontera-about-page:hover {
+  outline: 1px solid var(--global-color-accent--normal);
+  outline-offset: 1em;
 }
 
 /* Plugins: * > Image + Text */
@@ -38,7 +44,7 @@ a.c-card--frontera-about-page {
 
 /* Plugins: * > Image with Caption */
 .c-card--frontera-about-page figure {
-  margin-bottom: 0;
+  margin: 0;
 }
 .c-card--frontera-about-page figcaption {
   color: var(--global-color-primary--xx-dark);

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.css
@@ -1,0 +1,50 @@
+/*
+Card
+
+Container with content and action(s) about a single subject.
+
+.c-card--frontera-about-page - Container/Link with image and large heading below
+
+Markup: c-card.html
+
+Styleguide Components.Card
+*/
+
+/* Modifiers */
+
+
+
+/* Modifiers: Frontera About Page */
+
+.c-card--frontera-about-page {
+  width: fit-content;
+
+  border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--dark);
+  margin-bottom: 4.6rem;
+}
+
+/* Plugins: Link / Image with Link */
+a.c-card--frontera-about-page {
+  display: inline-block;
+}
+
+/* Plugins: * > Image + Text */
+.c-card--frontera-about-page img + h3 {
+  margin-top: 1.6rem;
+}
+.c-card--frontera-about-page img ~ :last-child {
+  margin-bottom: 1.25rem;
+}
+
+/* Plugins: * > Image with Caption */
+.c-card--frontera-about-page figure {
+  margin-bottom: 0;
+}
+.c-card--frontera-about-page figcaption {
+  color: var(--global-color-primary--xx-dark);
+  font-size: var(--global-font-size--x-large);
+  font-weight: var(--bold);
+
+  margin-top: 1.6rem;
+  margin-bottom: 1.25rem;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.css
@@ -3,6 +3,8 @@ Card
 
 Container with content and action(s) about a single subject.
 
+> __ℹ️ Notice__: No default styling.
+
 .c-card--frontera-about-page - Container/Link with image and large heading below
 
 Markup: c-card.html

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.html
@@ -1,0 +1,46 @@
+<details>
+  <summary>Link ▸ Image with Caption</summary>
+
+  <a href="./" class="c-card c-card--frontera-about-page">
+      <figure>
+          <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
+          <figcaption>Meet the Team</figcaption>
+      </figure>
+  </a>
+</details>
+<details>
+  <summary>Link ▸ Image + Text</summary>
+
+  <a href="./" class="c-card c-card--frontera-about-page">
+      <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
+      <h3>Careers</h3>
+  </a>
+</details>
+<details>
+  <summary>Style ▸ Image with Caption</summary>
+
+  <div class="c-card c-card--frontera-about-page">
+      <figure>
+          <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
+          <figcaption>Schedule a Visit</figcaption>
+      </figure>
+  </div>
+</details>
+<details>
+  <summary>Style ▸ Image + Text</summary>
+
+  <div class="c-card c-card--frontera-about-page">
+      <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
+      <h3>Extra Block</h3>
+  </div>
+</details>
+<details>
+  <summary>Image with Caption and Link</summary>
+
+  <a href="./" class="c-card c-card--frontera-about-page">
+      <figure>
+          <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
+          <figcaption>Another One</figcaption>
+      </figure>
+  </a>
+</details>

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.html
@@ -1,3 +1,14 @@
+
+<details>
+  <summary>Image with Caption and Link</summary>
+
+  <a href="./" class="c-card c-card--frontera-about-page">
+      <figure>
+          <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
+          <figcaption>Another One</figcaption>
+      </figure>
+  </a>
+</details>
 <details>
   <summary>Link ▸ Image with Caption</summary>
 
@@ -33,14 +44,4 @@
       <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
       <h3>Extra Block</h3>
   </div>
-</details>
-<details>
-  <summary>Image with Caption and Link</summary>
-
-  <a href="./" class="c-card c-card--frontera-about-page">
-      <figure>
-          <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
-          <figcaption>Another One</figcaption>
-      </figure>
-  </a>
 </details>

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-card.html
@@ -1,47 +1,32 @@
-
-<details>
-  <summary>Image with Caption and Link</summary>
-
-  <a href="./" class="c-card c-card--frontera-about-page">
+<div class="o-grid o-grid--col-min-width" style="--width: 320px">
+  <a href="./" class="c-card {{modifier_class}}">
       <figure>
           <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
-          <figcaption>Another One</figcaption>
+          <figcaption>Image w/ Caption &amp; Link</figcaption>
       </figure>
   </a>
-</details>
-<details>
-  <summary>Link ▸ Image with Caption</summary>
 
-  <a href="./" class="c-card c-card--frontera-about-page">
+  <a href="./" class="c-card {{modifier_class}}">
       <figure>
           <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
-          <figcaption>Meet the Team</figcaption>
+          <figcaption>Link ▸ Image w/ Caption</figcaption>
       </figure>
   </a>
-</details>
-<details>
-  <summary>Link ▸ Image + Text</summary>
 
-  <a href="./" class="c-card c-card--frontera-about-page">
+  <a href="./" class="c-card {{modifier_class}}">
       <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
-      <h3>Careers</h3>
+      <h3>Link ▸ Image + Text</h3>
   </a>
-</details>
-<details>
-  <summary>Style ▸ Image with Caption</summary>
 
-  <div class="c-card c-card--frontera-about-page">
+  <div class="c-card {{modifier_class}}" style="display: inline-block">
       <figure>
           <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
-          <figcaption>Schedule a Visit</figcaption>
+          <figcaption>Style ▸ Image w/ Caption</figcaption>
       </figure>
   </div>
-</details>
-<details>
-  <summary>Style ▸ Image + Text</summary>
 
-  <div class="c-card c-card--frontera-about-page">
+  <div class="c-card {{modifier_class}}" style="display: inline-block">
       <img src="https://cep.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fb/3f/fb3fd4c3-6360-4759-b607-f393b84558c0/spectrum-wide-320px.png__320x160_q85_subject_location-157%2C78_subsampling-2.png" alt="">
-      <h3>Extra Block</h3>
+      <h3>Style ▸ Image + Text</h3>
   </div>
-</details>
+</div>

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -29,6 +29,7 @@
 /* COMPONENTS */
 /* GH-302: HELP: How should all of these become individually built files? */
 /* GH-302: FAQ: Individually built stylesheets could be loaded explicitely. */
+@import url("_imports/components/c-card.css");
 @import url("_imports/components/c-callout.css");
 @import url("_imports/components/c-data-list.css");
 @import url("_imports/components/c-footer.css");


### PR DESCRIPTION
### Overview

Add "Card" UI pattern, for only "Frontera About page" right now:
```
.c-card .c-card--frontera-about-page
```

<details>
<summary><strong>About the Name</strong></summary>

> Suggestions Welcome

This pattern is only designed for one page ([Frontera About](https://xd.adobe.com/view/f3dad8d1-88ee-40eb-b8da-667b00e4f876-a689/screen/8bb9a7de-c5b2-493b-b897-d967ca8a57ec/specs/)). It might be used on some TACC pages\*. So, for now, the style can be `c-card--frontera-about-page`. It can have a new name in the future. The old name can still work. Here's how:

1. In CSS, change `.old-name` to `.new-name`.
2. In CSS, add `.old-name { @extend .new-name; }`.

_\* [TACC Services, User](https://xd.adobe.com/view/75cebc14-7368-4453-bb25-f975528952ac-209d/screen/c0898d6b-2fd9-472a-bcd7-1ae9d4f9a015/) (see "Consulting"); [TACC Partnerships](https://xd.adobe.com/view/75cebc14-7368-4453-bb25-f975528952ac-209d/screen/3b58170c-a8da-4c63-b7bc-e3a311b0af26); [TACC Partnerships, Industry](https://xd.adobe.com/view/75cebc14-7368-4453-bb25-f975528952ac-209d/screen/bce48d0d-bdf0-4d15-8ffd-4d7b8b9c1fdc) (see big list of partners)_

<details>
<summary>Example Code</summary>

```
.c-card--new-better-name {
    ...
}
.c-card--frontera-about-page { @extend .c-card--new-better-name; }
```

</details>

</details>

### Issues

[FP-1290](https://jira.tacc.utexas.edu/browse/FP-1290)

### Screenshots

| [Manual Pattern Demo][cep-ui] | [Auto. Pattern Demo][kss-ui] | DjangoCMS Structure | [About Page (dev)][page-ui][^3]<br />& [Design UI][des-ui] |
| - | - | - | - |
| ![FP-1290 Manual Pattern Demo](https://user-images.githubusercontent.com/62723358/146056418-5534a523-15be-4522-a4fc-237df523f65f.jpeg) | ![FP-1290 KSS Pattern Demo](https://user-images.githubusercontent.com/62723358/146050303-386d21d2-66a4-4d93-bd87-94dd79bbcef0.png) | ![FP-1290 CMS Edit Structure](https://user-images.githubusercontent.com/62723358/146056691-914bbb74-3d5d-490e-88c7-1e8fd658482a.png) | ![FP-1290 About Page](https://user-images.githubusercontent.com/62723358/146049703-b4fb98b9-1fd6-482f-b9a6-bc22532cbcb7.jpeg) |

| Default | Hover | Active |
| - | - | - |
| ![Default State](https://user-images.githubusercontent.com/62723358/146595800-bd984795-9c5a-4664-a927-32227262ea0e.png) | ![Hover State](https://user-images.githubusercontent.com/62723358/146595802-dfff8b5c-1859-4d89-b4df-649c478c6d38.png) | ![Active State](https://user-images.githubusercontent.com/62723358/146595792-d05b1b40-f0c2-45dd-bb8e-dd19501cdf72.png) |

### Testing

> Manual Pattern Demo[^1]: [cep.tacc.utexas.edu][cep-ui]
> Automated Pattern Demo[^2]: [tacc-wbomar-css-pattern-library-kss.surge.sh][kss-ui]

0. Use remote server or [Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes) locally.
1. Review/Create plugin combo's with classes `c-card` and `c-card--frontera-about-page` are on the outermost elements.
2. Check that UI matches [Design UI][des-ui] ([screenshot][des-ui-snap]).

[^1]: Uses a snippet to add `c-card` CSS to live site.
[^2]: Testing ugly KSS pattern library: https://github.com/tacc-wbomar/Core-CMS-Pattern-Library-KSS.
[^3]: VPN required to access.

[cep-ui]: https://cep.tacc.utexas.edu/design-system/ui-patterns/c-card/
[kss-ui]: http://tacc-wbomar-css-pattern-library-kss.surge.sh/section-components.html#kss-fullscreen-kssref-components-card
[des-ui]: https://xd.adobe.com/view/f3dad8d1-88ee-40eb-b8da-667b00e4f876-a689/screen/8bb9a7de-c5b2-493b-b897-d967ca8a57ec/
[des-ui-snap]: https://user-images.githubusercontent.com/62723358/146049703-b4fb98b9-1fd6-482f-b9a6-bc22532cbcb7.jpeg
[page-ui]: https://dev.fronteraweb.tacc.utexas.edu/2022/about
