### PR TITLE
Quick: Move Code & Samp CSS from Site to Doc Page

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css
@@ -171,12 +171,6 @@ code kbd {
 
 /* Code: any content or context) */ code,
 /* Code: content has only output */ pre > samp {
-  background-color: var(--global-color-primary--x-light);
-
-  border-width: var(--global-border-width--normal);
-  border-style: solid;
-  border-color: var(--global-color-primary--light);
-
   /* Undo Bootstrap */
   color: unset;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-document.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-document.css
@@ -72,6 +72,17 @@ p + dl.small {
   margin-bottom: 1rem; /* mirror Bootstrap `_reboot.css` <p> */
 }
 
+/* ELEMENTS: Inline Text Semantics */
+
+/* (any content or context) */ code,
+/* (content has only output) */ pre > samp {
+  background-color: var(--global-color-primary--x-light);
+
+  border-width: var(--global-border-width--normal);
+  border-style: solid;
+  border-color: var(--global-color-primary--light);
+}
+
 
 /* ELEMENTS: Image & Multimedia */
 


### PR DESCRIPTION
### Overview

Move color and border styles for code and sample computer output to the Guide page styles with which it belongs.

### Changes

Migrate CSS for `<code>` and `<samp>` to `s-document.css` stylesheet (from stylesheet that is loaded by `site.css`).

### Testing

1. Create a `<code>` element on a page that _is **not**_ using a Guide page template.
2. Test that `<code>` element _does **not**_ have a border nor a background color.
3. Review a `<code>` element on a page that _**is**_ using a Guide page template.
4. Test that `<code>` element _**does**_ have a border nor a background color.

### Notes

<details>
<summary>Background</summary>

This CSS was for doc page but put in Site, because I thought it was styled well enough for global use. Then during BM-6 I used `<code>` inside Callout... ugly, so unsuitable for Site CSS.

</details>