### PR TITLE
FP-1408: (Frontera) Fix Clickable Area of Article List Link

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
@@ -172,6 +172,9 @@ Styleguide Trumps.Scopes.ArticleList
 
 /* Expand link to cover its container */
 .s-article-list--links p:not(:last-child) { position: relative; }
+/* Prevent clickable area of link from changing */
+/* FAQ: Override html-elements.css `a:active` */
+.s-article-list--links p:not(:last-child) a:active { position: static; }
 .s-article-list--links p:not(:last-child) a::before {
   content: '';
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
@@ -191,7 +191,7 @@ Styleguide Trumps.Scopes.ArticleList
 /* FP-1249: If <a> wraps list item, then no need to `x-article-link-stretch` */
 /* SEE: https://github.com/TACC/Core-CMS/pull/429 */
 .s-article-list--links p:not(:last-child) a:active {
-  position: static; /* oOverride html-elements.css `a:active` */
+  position: static; /* override html-elements.css `a:active` */
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
@@ -188,8 +188,8 @@ Styleguide Trumps.Scopes.ArticleList
   @extend .x-article-link-hover--gapless;
 }
 /* Disable link click feedback because `x-article-link-stretch` is used */
-/* FAQ: Only the outline was moved not list item (weird) */
 /* FP-1249: If <a> wraps list item, then no need to `x-article-link-stretch` */
+/* SEE: https://github.com/TACC/Core-CMS/pull/429 */
 .s-article-list--links p:not(:last-child) a:active {
   position: static; /* oOverride html-elements.css `a:active` */
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
@@ -172,9 +172,6 @@ Styleguide Trumps.Scopes.ArticleList
 
 /* Expand link to cover its container */
 .s-article-list--links p:not(:last-child) { position: relative; }
-/* Prevent clickable area of link from changing */
-/* FAQ: Override html-elements.css `a:active` */
-.s-article-list--links p:not(:last-child) a:active { position: static; }
 .s-article-list--links p:not(:last-child) a::before {
   content: '';
 
@@ -190,7 +187,12 @@ Styleguide Trumps.Scopes.ArticleList
 .s-article-list--layout-gapless.s-article-list--links p:not(:last-child) a:hover::before {
   @extend .x-article-link-hover--gapless;
 }
-
+/* Disable link click feedback because `x-article-link-stretch` is used */
+/* FAQ: Only the outline was moved not list item (weird) */
+/* FP-1249: If <a> wraps list item, then no need to `x-article-link-stretch` */
+.s-article-list--links p:not(:last-child) a:active {
+  position: static; /* oOverride html-elements.css `a:active` */
+}
 
 
 /* Modifiers: Layout */


### PR DESCRIPTION
## Overview

Make sure clickable area of article list link always opens new page.

## Issues

* [FP-1408](https://jira.tacc.utexas.edu/browse/FP-1408)

## Changes

Prevent clickable area from changing shape while link is actively being clicked i.e. during `:active` state.

## Screenshots

[FP-1408.Prod.vs.Local.mov](https://user-images.githubusercontent.com/62723358/149438828-4253b8d3-96cd-4435-ac88-bf2b30f2c70a.mov)

> ℹ️ Bug is now not reproducible on prod (cuz of snippet-based fix). You can reproduce the bug on pre-prod.

## Testing

> **local**: [setup instructions](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes) — recreating page takes too long  
> **remote (sans fix)**: [pprd.frontera-portal.tacc.utexas.edu](https://pprd.frontera-portal.tacc.utexas.edu/)  
> **remote (with fix)** (via jenkins): [dev.fronteraweb.tacc.utexas.edu](https://dev.fronteraweb.tacc.utexas.edu/)([build](https://jenkins01.tacc.utexas.edu/view/WMA%20CEP/job/Core_CMS/338),[deploy](https://jenkins01.tacc.utexas.edu/view/WMA%20CEP/job/Core_Portal_Deploy/1014))  
> **remote (with fix)** (via snippet): [frontera-portal.tacc.utexas.edu](https://frontera-portal.tacc.utexas.edu/)([snippet](https://frontera-portal.tacc.utexas.edu/admin/djangocms_snippet/snippet/36/change/))

On Frontera home page, under "User Guides" (near bottom of page):

1.  Hover over document link.
    * Document title should be underlined (solid line).
    * Outline should appear around document.
2.  Click and hold a document link.
    * Document title should be underlined (dotted line).
    * Outline should remain around document.
    * Document (whole list item and item outline) should move down by one pixel.*
3.  Release click on document link.
    * Page should open.

_\* This fix removes a (broken) feature, which is okay. The feature was that the link title would move down by one pixel on click. The whole list item (and item outline) should move down, not just the title. [FP-1249](https://jira.tacc.utexas.edu/browse/FP-1249) will make it all move appropriately. There is a comment for this in the changed code in this PR._

## Notes

<details><summary>Breakdown of Problem & Solution</summary>

**Situation**  
There are four list items (html `<li>`) on the[Frontera home page](http://frontera-portal.tacc.utexas.edu/). Each list item is a document with a description and a link (html `<a>`) (the title of the document). That link/title has a pseudo element (css `a::before`). That pseudo element is stretched to be the same size as the list item, so that when that list item is hovered or clicked, it triggers the link being hovered/clicked.

**What is Working? What is Broken?**  
✓ As list item is hovered, link is hovered.  
⨂ As list item is clicked, link is**not**clicked.

**Problem**  
The pseudo element (which increases the size of the clickable link) changes shape when link is clicked. Thus, wherever was clicked, after it is clicked, is not longer a clickable area. So when mouse click is released, browser does not register click in the area.

**Why Does this Happen?**  
Upon click, [offending code](https://github.com/TACC/Core-CMS/blob/9765e5e/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css#L146) changes the link's `position` to `relative`(so it can move the link up or down). If link is `relative`, then the pseudo element stretches to fill the link (which is just the text area) instead of the whole link. Further detail requires[understanding CSS `position: absolute`](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning#absolute_positioning) and its relationship to `position: relative`.

**Solution**  
Disable the [offending code](https://github.com/TACC/Core-CMS/blob/9765e5e/taccsite_cms/static/site_cms/css/src/_imports/elements/html-elements.css#L146) for article list links (until[FP-1249](https://jira.tacc.utexas.edu/browse/FP-1249) changes article list markup to support the disabled code).

</details>