### PR TITLE
FP-1318: Create Section Pattern via Style Plugin

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -423,6 +423,38 @@ SETTINGS_EXPORT_VARIABLE_NAME = 'settings'
 
 FEATURES = ''
 
+########################
+# PLUGIN SETTINGS
+########################
+
+# https://github.com/django-cms/djangocms-style
+DJANGOCMS_STYLE_CHOICES = [
+    # https://confluence.tacc.utexas.edu/x/c5TtDg
+    'o-section o-section--style-light',
+    'o-section o-section--style-dark',
+    # RFE: Consider adding:
+    # 'c-callout',
+    # 'c-recognition c-recognition--style-light',
+    # 'c-recognition c-recognition--style-dark',
+    # et cetera
+]
+DJANGOCMS_STYLE_TAGS = [
+    # Even though <div> is often NOT the most semantic choice;
+    # CMS editor may neglect tag, any other tag could be inaccurate,
+    # and <div> is never inaccurate; so <div> is placed first 😞
+    # RFE: Support automatically choosing tag based on class name
+    # SEE: taccsite_cms/templatetags/preferred_tag_for_class.py
+    'div',
+    # Ordered by expected usage
+    'section', 'article', 'header', 'footer', 'aside',
+    # Not expected but not unreasonable
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
+]
+
+########################
+# IMPORT & EXPORT
+########################
+
 try:
     from taccsite_cms.settings_custom import *
 except:

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -443,7 +443,7 @@ DJANGOCMS_STYLE_TAGS = [
     # CMS editor may neglect tag, any other tag could be inaccurate,
     # and <div> is never inaccurate; so <div> is placed first 😞
     # RFE: Support automatically choosing tag based on class name
-    # SEE: taccsite_cms/templatetags/preferred_tag_for_class.py
+    # SEE: https://github.com/TACC/Core-CMS/pull/432
     'div',
     # Ordered by expected usage
     'section', 'article', 'header', 'footer', 'aside',


### PR DESCRIPTION
## Overview

Quickly create existing TACC Section _pattern_ via already-installed Django Style _plugin_.

 _CMS Admin/Designer has approved (via private review), but implementation should have dev review._

## Tickets

* [FP-1318](https://jira.tacc.utexas.edu/browse/FP-1318)

## Changes

To our default `settings`:
* Add `DJANGOCMS_STYLE_CHOICES` ([docs](https://github.com/django-cms/djangocms-style#configuration)).
    * to allow user to quickly create light Section or dark Section
* Add `DJANGOCMS_STYLE_TAGS` ([docs](https://github.com/django-cms/djangocms-style#configuration)).
    * to support `<aside>`
    * to document expected usage
    * to reference [proof-of-concept improvement](https://github.com/TACC/Core-CMS/compare/poc/djangocms_style-automatic-tag)

## Screenshots

> ⚠️ This video shows more class choices, because it includes #419 also.

https://user-images.githubusercontent.com/62723358/150380415-277e1044-3c24-4c9d-8af8-c5f70d46860b.mov

## Testing

> __local__: [instructions](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes)
> __remote__: https://dev.cep.tacc.utexas.edu/ ([build](https://jenkins01.tacc.utexas.edu/view/WMA%20CEP/job/Core_CMS_Build/345/), [deploy](https://jenkins01.tacc.utexas.edu/view/WMA%20CEP/job/Core_Portal_Deploy/1020))

1. On any page, create a Style plugin.
2. Choose CLASS NAME `o-section o-section--style-dark`.
3. Confirm dark Section is added.\*
4. Choose CLASS NAME `o-section o-section--style-light`.
5. Confirm light Section is added.\*

\* You may confirm that the markup of the element added has the classname chosen. To see what the section should **look** like, compare to [manual pattern library](https://cep.tacc.utexas.edu/design-system/ui-patterns/o-section/).

## Notes

### Related PRs
- Adding More Classes:
    https://github.com/TACC/Core-CMS/pull/419
- Using Container Instead:
    https://github.com/TACC/Core-CMS/pull/431