### PR TITLE
Minor: Fix: x-layout CSS docblock typo

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-layout.css
@@ -7,7 +7,7 @@ Styles that allow re-usable layouts.
 %x-layout--b - Widest: one wide column & one narrow column
 %x-layout--c - Widest: one narrow column & one wide column
 %x-layout--d - Widest: three even columns
-%x-layout--d - Always: multiple even rows
+%x-layout--e - (deprecated) Always: multiple even rows
 
 Styleguide Tools.ExtendsAndMixins.Layout
 */


### PR DESCRIPTION
## Overview

Developer-facing tweaks to CSS documentation.

## Changes

- Fix a typo.
- Add deprecation note.