### PR TITLE
FP-1485: Load iFrame Content with Auto. Height

### DIFF
--- a/taccsite_cms/templates/snippets/full-size-iframe.html
+++ b/taccsite_cms/templates/snippets/full-size-iframe.html
@@ -1,0 +1,67 @@
+<style>
+body {
+  font-size: 0; /* remove extra visual space cause by markup whitespace */
+}
+iframe.full-size {
+  border: 0;
+  width: 100%;
+}
+</style>
+
+<iframe
+  src="{{ html|default:"/cms/sample/markup/" }}"
+  class="full-size"
+  onload="taccAutosizeIframe.resize(this, true)"
+></iframe>
+
+<script>
+  const taccAutosizeIframe = {
+    /**
+     * Resize given `<iframe>` once (or once and automatically afterward)
+     * @param {HTMLIFrameElement} iframe - The inline frame element to resize
+     * @param {boolean} shouldAutoResize - Whether to automatically resize
+     */
+    resize: function (iframe, shouldAutoResize) {
+      iframe.height = this.getHeight(iframe) + 'px';
+      // console.debug('Resized iframe');
+
+      // To trigger resize from iframe content, have iframe itself call:
+      // parent.resizeIframe(this.frameElement);
+      // SEE: https://stackoverflow.com/a/14618068/11817077
+
+      if (shouldAutoResize) {
+        this.resizeOnHeightChange(iframe);
+      }
+    },
+
+    /**
+     * Get height of a given `<iframe>`'s content
+     * @param {HTMLIFrameElement} iframe - The inline frame element to resize
+     */
+    getHeight: function (iframe) {
+      return iframe.contentWindow.document.body.scrollHeight;
+    },
+
+    /**
+     * On each animation, if `<iframe>` content height changes, resize iframe
+     * @param {HTMLIFrameElement} iframe - The inline frame element to resize
+     * @see https://stackoverflow.com/a/14618068/11817077
+     */
+    resizeOnHeightChange: function (iframe) {
+      let lastScrollHeight = this.getHeight(iframe);
+      let contentBody = iframe.contentWindow.document.body;
+
+      const watch = () => {
+        cancelAnimationFrame(watcher);
+
+        if (lastScrollHeight !== contentBody.scrollHeight) {
+          // console.log(`Should resize iframe because lastScrollHeight: '${lastScrollHeight}', contentBody.scrollHeight: '${contentBody.scrollHeight}'`);
+          this.resize(iframe);
+        }
+        lastScrollHeight = contentBody.scrollHeight;
+        watcher = window.requestAnimationFrame(watch);
+      };
+      let watcher = window.requestAnimationFrame(watch);
+    },
+  }
+</script>

--- a/taccsite_cms/templates/snippets/sample-markup.html
+++ b/taccsite_cms/templates/snippets/sample-markup.html
@@ -1,0 +1,5 @@
+<h2>Core CMS Raw Sample Markup</h2>
+
+<p>This content is from a template that does not load CMS header nor footer.</p>
+
+<small>This content can be used to test markup in isolation, like for testing access into an iframe while avoiding cross-origin problems caused by doing so when iframe loads external site.</small>

--- a/taccsite_cms/urls.py
+++ b/taccsite_cms/urls.py
@@ -10,6 +10,7 @@ from django.contrib.auth import views
 from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.views.static import serve
+from django.views.generic.base import TemplateView
 from taccsite_cms import remote_cms_auth as remote_cms_auth
 
 from django.http import request
@@ -24,8 +25,8 @@ urlpatterns = [
     url(r'^cms/logout/', views.LogoutView.as_view(), name='logout'),
 ]
 
+# Custom URLs only for Portal
 if getattr(settings, 'INCLUDES_CORE_PORTAL', True):
-    from django.views.generic.base import TemplateView
     urlpatterns += [
         # FAQ: Allow direct access to markup for Portal and User Guide to render
         url(r'^cms/nav/search/markup/$', TemplateView.as_view(template_name='nav_search.raw.html'), name='search_bar_markup'),
@@ -35,6 +36,12 @@ if getattr(settings, 'INCLUDES_CORE_PORTAL', True):
         url(r'^remote/login/$', remote_cms_auth.verify_and_auth, name='verify_and_auth'),
     ]
 
+# Custom URLs
+urlpatterns += [
+    url(r'^cms/sample/markup/$', TemplateView.as_view(template_name='snippets/sample-markup.html'), name='sample_markup'),
+]
+
+# Standard URLs
 urlpatterns += [
     url(r'^', include('cms.urls')),
 ]


### PR DESCRIPTION
## Status

This was a proposal. Its feedback is now part of new ticket, [FP-1490](https://jira.tacc.utexas.edu/browse/FP-1490), created to do this in a way that meets user expectations.

## Overview

Support automatically resizing `<iframe>` height to match content height.

## Issues

- [FP-1485](https://jira.tacc.utexas.edu/browse/FP-1485)

## Changes

- Add new template for Snippets to load webpage in iframe.
- Add sample markup to serve as fallback content.
- Support internal URL for sample content.

## Screenshots & Testing

Or [videos (on UT Box)](https://utexas.box.com/s/rdlkpb50croakd7scqnd27qcpla5m2m9).

| Step | Description | Screenshot |
| - | - | - |
| 1 | The `<iframe>` was resized upon page load. Console shows log of this. | <img width="1080" alt="1 Initial Resize - Console Log" src="https://user-images.githubusercontent.com/62723358/151472631-2f7a7567-8605-4cf7-a357-97846ed3cee6.png"> |
| 2 | After initial resize, the `<iframe>` itself is `150px` tall. | <img width="1080" alt="2 Initial Resize - Iframe Height" src="https://user-images.githubusercontent.com/62723358/151472634-b0468814-352e-4ab7-bc48-7aa61e4c80e7.png"> |
| 3 | After initial resize, the `<iframe>` content is `150px` tall. | <img width="1080" alt="3 Initial Resize - Iframe Content Height" src="https://user-images.githubusercontent.com/62723358/151472636-92d10b83-fb7e-43e8-bd9c-1474cc6daca3.png"> |
| 4 | After initial resize, reducing the height of the window only shows *one* scrollbar. The `<iframe>` has no scrollbar. | <img width="1080" alt="4 Initial Resize - Force Scrollbar" src="https://user-images.githubusercontent.com/62723358/151472640-e8282660-aa61-43be-afd7-2a2c2caaa19b.png"> |
| 5 | To change the content height live, the markup is edited to have much more text. | <img width="1080" alt="5 Content Height Change - Markup" src="https://user-images.githubusercontent.com/62723358/151472641-3ad3f2c4-743c-4751-812d-d6a1686b485e.png"> |
| 6 | The `<iframe>` was resized upon content height change. Console shows log of this. | <img width="1080" alt="6 Content Height Change - Console" src="https://user-images.githubusercontent.com/62723358/151472645-b1b11ee6-e1b3-47b8-aa61-d5223e313f12.png"> |

## Notes

**⚠️ Caveat**: The resize does **not** work with _external_ URLs.