### PR TITLE
FP-1502: Fix Callout Title Height

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-callout.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-callout.css
@@ -62,8 +62,8 @@ Styleguide Components.Callout
     padding: 20px;
     text-align: left;
 
-    grid-template-columns: min-content; /* prevent extra horz. space in cell */
-    grid-template-rows: min-content;    /* prevent extra vert. space in cell */
+    grid-template-columns: min-content auto; /* prevent extra figure h. space */
+    grid-template-rows: auto min-content;    /* prevent extra title v. space */
     grid-template-areas:
       'figure title'
       'figure desc';


### PR DESCRIPTION
## Overview

Change Callout pattern's grid's row and column dimensions to fix [FP-1502](https://jira.tacc.utexas.edu/browse/FP-1502) bug.

## Issues

[FP-1502](https://jira.tacc.utexas.edu/browse/FP-1502)

## Screenshots

| State | Image |
| - | - |
| Before | <img width="1170" alt="FP-1502 Broken" src="https://user-images.githubusercontent.com/62723358/153504081-a1c705c5-665e-43db-96f6-a627b034a549.png"> |
| After | <img width="1170" alt="FP-1502 Fixed" src="https://user-images.githubusercontent.com/62723358/153504005-5973f9d2-b4e2-41a8-bbe9-69ad92bf6e0d.png"> |

## Testing

1. Create a Callout pattern (`.c-callout` with `img` and `h2` and `p`).
2. Ensure the image is taller than the description and title together.
3. Confirm no excess vertical space between title and description.