### PR TITLE
Bug/FP-1423: Fix medium width negative space for system spec.

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-system-specs.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-system-specs.css
@@ -57,6 +57,17 @@ Styleguide Trumps.Scopes.SystemSpecs
 
 /* Sizes */
 
+@media only screen and (--wide-and-above) {
+    .s-system-specs {
+        --col-width--thin: 42%;
+    }
+
+    .s-system-specs > aside {
+        width: var(--col-width--thin);
+    }
+}
+
+
 @media only screen and (--medium-and-above) {
   .s-system-specs {
     --col-width--thin: 42%;

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-system-specs.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-system-specs.css
@@ -68,8 +68,10 @@ Styleguide Trumps.Scopes.SystemSpecs
   }
   .s-system-specs > div,
   .s-system-specs > aside {
-    width: var(--col-width--thin);
     padding-inline: var(--col-padding);
+  }
+  .s-system-specs > div {
+    width: var(--col-width--thin);
   }
   .s-system-specs > figure {
     width: var(--col-width--wide);


### PR DESCRIPTION
## Overview: ##
From Jira: When screen is medium width, the [Frontera System](https://frontera-portal.tacc.utexas.edu/system/) page layout has excess negative space.
We fix this here 🙂 

## Related Jira tickets: ##

* [FP-1423](https://jira.tacc.utexas.edu/browse/FP-1423)

## Summary of Changes: ##
Use the narrow width (100%?) for "SUBSYSTEMS AND ..." on medium width.

## Testing Steps: ##
1. Create the System Specs layout using the plugin on the CMS. 
2. Ensure that the negative space issue for the "SUBSYSTEMS AND ..." part is resolved!

## UI Photos:
![Screenshot from 2022-02-17 14-47-35](https://user-images.githubusercontent.com/9425579/154568101-db3de02a-7144-49c9-84b6-7d81e9a8b341.png)

## Notes: ##

From Jira:
> B. Prep for [FP-1306](https://jira.tacc.utexas.edu/browse/FP-1306): No CSS. Duplicate the System page. Recreate the layout (not the styles: typography, minor spacing, etc.) with Generic "Text" and Bootstrap "Column" and "Row" plugins. That prep page would be welcome 

I've tried recreating this purely in Bootstrap.
I think my css-fu is limiting 😰.

The best I could do was:

![Screenshot from 2022-02-17 14-56-54](https://user-images.githubusercontent.com/9425579/154569530-635d81d8-7c48-4f04-a0a3-7452aaa3e4eb.png)

Medium Width:
![Screenshot from 2022-02-17 14-57-17](https://user-images.githubusercontent.com/9425579/154569535-3d04d64c-5715-4fd9-9df3-c88495c5ad8e.png)

Narrow Width:
![Screenshot from 2022-02-17 14-57-28](https://user-images.githubusercontent.com/9425579/154569546-5dc16462-aa16-44ce-92b5-9d971f63ebf4.png)

However, with the wide width, I could not get the columns to work properly.
I could only get the last column to offset to the right. But that did not resemble the original plugin..