### PR TITLE
FP-1524: Section Pattern: Simpler Extended Background

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -95,7 +95,11 @@ Styleguide Objects.Section
   background-color: var(--global-color-primary--xx-dark);
   box-shadow: var(--box-shadow--fake-bkgd);
 }
-.o-section--style-dark + .o-section--style-dark {
+.o-section--style-dark + .o-section--style-dark:not(.container) {
+  border-top: var(--global-border-width--normal) solid
+              var(--global-color-primary--xx-light);
+}
+.o-section--style-dark + .o-section--style-dark.container {
   @extend %x-fake-border--inset-horz-top;
 
   --fb--line-width: var(--global-border-width--normal);
@@ -125,7 +129,11 @@ Styleguide Objects.Section
   background-color: var(--global-color-primary--xx-light);
   box-shadow: var(--box-shadow--fake-bkgd);
 }
-.o-section--style-light + .o-section--style-light {
+.o-section--style-light + .o-section--style-light:not(.container) {
+  border-top: var(--global-border-width--normal) solid
+              var(--global-color-primary--normal);
+}
+.o-section--style-light + .o-section--style-light.container {
   @extend %x-fake-border--inset-horz-top;
 
   --fb--line-width: var(--global-border-width--normal);

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -39,6 +39,9 @@ Styleguide Objects.Section
 /* Block */
 
 .o-section {
+  --border-width: var(--global-border-width--normal);
+  --border-width--neg: calc(-1 * var(--border-width));
+
   /* GH-99: Use standard spacing value */
   padding-block: 45px; /* designs vary but this is the approx. average */
 }
@@ -84,11 +87,17 @@ Styleguide Objects.Section
 /* Modifers: Style */
 
 /* Modifers: Style: Dark & Light */
+/* FP-1470: Add cross-style code and variables when third style is added */
 
-.o-section--style-dark,
-.o-section--style-dark::before {
+.o-section--style-dark {
   color: var(--global-color-primary--xx-light);
   background-color: var(--global-color-primary--xx-dark);
+  box-shadow: 50vw 0 var(--global-color-primary--xx-dark),
+              -50vw 0 var(--global-color-primary--xx-dark);
+}
+.o-section--style-dark + .o-section--style-dark {
+  border-top: var(--border-width) solid
+              var(--global-color-primary--xx-light);
 }
 .o-section--style-dark a {
   color: var(--global-color-link-on-dark--normal);
@@ -101,15 +110,16 @@ Styleguide Objects.Section
 .o-section--style-dark h6 {
   color: var(--global-color-primary--xx-light);
 }
-.o-section--style-dark + .o-section--style-dark {
-  border-top: var(--global-border-width--normal) solid
-              var(--global-color-primary--xx-light);
-}
 
-.o-section--style-light,
-.o-section--style-light::before {
+.o-section--style-light {
   color: var(--global-color-primary--dark);
   background-color: var(--global-color-primary--xx-light);
+  box-shadow: 50vw 0 var(--global-color-primary--xx-light),
+              -50vw 0 var(--global-color-primary--xx-light);
+}
+.o-section--style-light + .o-section--style-light {
+  border-top: var(--border-width) solid
+              var(--global-color-primary--normal);
 }
 .o-section--style-light a {
   color: var(--global-color-link-on-light--normal);
@@ -122,44 +132,13 @@ Styleguide Objects.Section
 .o-section--style-light h6 {
   color: var(--global-color-primary--xx-dark);
 }
-.o-section--style-light + .o-section--style-light {
-  border-top: var(--global-border-width--normal) solid
-              var(--global-color-primary--normal);
-}
 
 /* Modifers: Style: (Fake) Endless Background */
 /* FAQ: Allows background to escape `.container` (whether its self or parent) */
-/* SEE: "Tricks" section */
+/* FP-1470: Move this to cross-style code when third style is added */
 
-[class*="o-section--style"] {
-  /* To anchor the `position: absolute` pseudo-element */
-  /* To allow `z-index` on children as necessary */
-  position: relative;
-
-  /* CAVEAT: We MUST maintain intentional horizontal overflow of pseudo-child */
-  overflow-x: visible !important; /* do not allow accidental hide of fake bkgd */
-}
-[class*="o-section--style"] > * {
-  /* To ensure children are above `position: absolute` pseudo-element */
-  position: relative;
-  z-index: 1;
-}
-[class*="o-section--style"]::before {
-  content: '';
-  z-index: 0; /* To ensure real element children are above this */
-
-  position: absolute;
-  display: block;
-  width: 100vw;
-  top: 0;
-  bottom: 0;
-
-  /* To horizontally center */
-  left: 50%;
-  transform: translateX(-50%);
-}
 /* Except for nested sections */
-.o-section .o-section::before { content: none; }
+.o-section .o-section { box-shadow: none; }
 
 
 
@@ -242,6 +221,7 @@ Styleguide Objects.Section
 /* FP-1462: Extract to new banner component(s) */
 
 /* HACK: To hide vertical overflow by placing sibling sections atop */
+[class*="o-section--style"] { position: relative; }
 /* NOTE: This selector assumes only a banner section has vertical overflow */
 /* CAVEAT: Any banner pop-out el's can NOT overflow atop sibling sections */
 [class*="o-section--style"].o-section--banner { z-index: 0; }
@@ -249,12 +229,7 @@ Styleguide Objects.Section
 /* CAVEAT: Any section pop-out el's can NOT overflow atop section after it */
 [class*="o-section--style"] { z-index: 1; }
 
-
-
-/* Tricks: /* Modifiers: Style */
-/* Tricks: /* Children: Banner Image */
-
-/* HACK: To hide `.o-section--style-…` & `.o-section__banner-image` overflow */
+/* HACK: To hide `.o-section__banner-image` overflow */
 main /* SEE: https://github.com/TACC/Core-CMS/pull/151 */,
 #content-wrap /* HACK: Using ID selector until <main> exists */ {
   overflow-x: hidden;

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -39,9 +39,6 @@ Styleguide Objects.Section
 /* Block */
 
 .o-section {
-  --border-width: var(--global-border-width--normal);
-  --border-width--neg: calc(-1 * var(--border-width));
-
   /* GH-99: Use standard spacing value */
   padding-block: 45px; /* designs vary but this is the approx. average */
 }
@@ -96,7 +93,7 @@ Styleguide Objects.Section
               -50vw 0 var(--global-color-primary--xx-dark);
 }
 .o-section--style-dark + .o-section--style-dark {
-  border-top: var(--border-width) solid
+  border-top: var(--global-border-width--normal) solid
               var(--global-color-primary--xx-light);
 }
 .o-section--style-dark a {
@@ -118,7 +115,7 @@ Styleguide Objects.Section
               -50vw 0 var(--global-color-primary--xx-light);
 }
 .o-section--style-light + .o-section--style-light {
-  border-top: var(--border-width) solid
+  border-top: var(--global-border-width--normal) solid
               var(--global-color-primary--normal);
 }
 .o-section--style-light a {

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -31,6 +31,7 @@ Styleguide Objects.Section
 */
 @import url("_imports/tools/media-queries.css");
 @import url("_imports/tools/x-layout.css");
+@import url("_imports/tools/x-fake-border.css");
 
 
 
@@ -87,14 +88,22 @@ Styleguide Objects.Section
 /* FP-1470: Add cross-style code and variables when third style is added */
 
 .o-section--style-dark {
+  --box-shadow--fake-bkgd: 50vw 0 var(--global-color-primary--xx-dark),
+                          -50vw 0 var(--global-color-primary--xx-dark);
+
   color: var(--global-color-primary--xx-light);
   background-color: var(--global-color-primary--xx-dark);
-  box-shadow: 50vw 0 var(--global-color-primary--xx-dark),
-              -50vw 0 var(--global-color-primary--xx-dark);
+  box-shadow: var(--box-shadow--fake-bkgd);
 }
 .o-section--style-dark + .o-section--style-dark {
-  border-top: var(--global-border-width--normal) solid
-              var(--global-color-primary--xx-light);
+  @extend %x-fake-border--inset-horz-top;
+
+  --fb--line-width: var(--global-border-width--normal);
+  --fb--line-color: var(--global-color-primary--xx-light);
+  --fb--inset-width: var(--global-space--grid-gap);
+  --fb--inset-color: var(--global-color-primary--xx-dark);
+
+  --fb--shadow-below: var(--box-shadow--fake-bkgd);
 }
 .o-section--style-dark a {
   color: var(--global-color-link-on-dark--normal);
@@ -109,14 +118,22 @@ Styleguide Objects.Section
 }
 
 .o-section--style-light {
+  --box-shadow--fake-bkgd: 50vw 0 var(--global-color-primary--xx-light),
+                          -50vw 0 var(--global-color-primary--xx-light);
+
   color: var(--global-color-primary--dark);
   background-color: var(--global-color-primary--xx-light);
-  box-shadow: 50vw 0 var(--global-color-primary--xx-light),
-              -50vw 0 var(--global-color-primary--xx-light);
+  box-shadow: var(--box-shadow--fake-bkgd);
 }
 .o-section--style-light + .o-section--style-light {
-  border-top: var(--global-border-width--normal) solid
-              var(--global-color-primary--normal);
+  @extend %x-fake-border--inset-horz-top;
+
+  --fb--line-width: var(--global-border-width--normal);
+  --fb--line-color: var(--global-color-primary--xx-dark);
+  --fb--inset-width: var(--global-space--grid-gap);
+  --fb--inset-color: var(--global-color-primary--xx-light);
+
+  --fb--shadow-below: var(--box-shadow--fake-bkgd);
 }
 .o-section--style-light a {
   color: var(--global-color-link-on-light--normal);
@@ -162,7 +179,7 @@ Styleguide Objects.Section
 /* FP-1462: Extract to new banner component(s) */
 
 [class*="o-section--style"].o-section--banner + [class*="o-section--style"] {
-  border-top: none;
+  box-shadow: var(--box-shadow--fake-bkgd);
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-fake-border.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-fake-border.css
@@ -1,0 +1,54 @@
+/*
+Fake Border
+
+Fake borders that have features unavailable to regular borders
+
+(custom property a.k.a. variable prefix `fb` stands for __f__ake __b__order)
+
+%x-fake-border--inset-horz-top - A top border that is not full width
+
+Styleguide Tools.ExtendsAndMixins.Overlay
+*/
+
+/*
+Inset Border
+
+To create the border, three lines are drawn via these private variables:
+- `--fb--line` (the fake border on one side of element box)
+- `--fb--start` (a perpindicular strip to shorten the start of the line)
+- `--fb--end` (a perpindicular strip to shorten the end of the line)
+
+To customize the lines, there are some public variables:
+- `--fb--line-width` (default: 0px) (add unit so `calc()` will not fail)
+- `--fb--line-color` (default: transparent)
+- `--fb--inset-width` (default: 0px) (add unit so `calc()` will not fail)
+- `--fb--inset-color` (default: transparent)
+- `--fb--shadow-above` (default: 0 0 transparent)
+- `--fb--shadow-below` (default: 0 0 transparent)
+
+To avoid overwriting an existing `box-shadow`, use the public shadow variables:
+- `--fb--shadow-above: var(--YOUR-existing-shadow-ABOVE-fake-border)`
+- `--fb--shadow-below: var(--YOUR-existing-shadow-BELOW-fake-border)`
+*/
+%x-fake-border--inset-horz-top {
+  --fb--line-width: 0px; /* CAVEAT: add unit so `calc()` will not fail */
+  --fb--line-color: transparent;
+
+  --fb--inset-width: 0px; /* CAVEAT: add unit so `calc()` will not fail */
+  --fb--inset-color: transparent;
+
+  --fb--line: inset 0 var(--fb--line-width) var(--fb--line-color);
+  --fb--start: inset calc( 1 * var(--fb--inset-width)) 0 var(--fb--inset-color);
+  --fb--end: inset calc(-1 * var(--fb--inset-width)) 0 var(--fb--inset-color);
+
+  --fb:
+    var(--fb--start), /* cover the start of the line */
+    var(--fb--end),   /* cover the end of the line */
+    var(--fb--line);  /* draw the line underneath */
+
+  box-shadow:
+    var(--fb--shadow-above, 0 0 transparent),
+    var(--fb),
+    var(--fb--shadow-below, 0 0 transparent)
+}
+/* TODO: As needed, create `--inset-horz-bottom`, `--inset-vert-left`, etc. */


### PR DESCRIPTION
## Overview

Fix UI bugs introduced in Section pattern since their new code in #433.

## Issues

- __[FP-1524](https://jira.tacc.utexas.edu/browse/FP-1524)__
- Review Ticket: [FP-1530](https://jira.tacc.utexas.edu/browse/FP-1530)

## Changes

<details>
<summary>Use <code>box-shadow</code>, not <code>::before</code> to extend section backgrounds.</summary>

- Add the `box-shadow` solution (tiny).
- Remove the `::before` solution (massive).
- Move the `border` code.
- Note [FP-1470](https://jira.tacc.utexas.edu/browse/FP-1470) tasks.

</details>

## Screenshots

<details open>
<summary>Round 2</summary>

| | Before | After, Main | After, Detail
| - | - | - | - |
| Frontera Home | ![FP-1524 Frontera Home Before](https://user-images.githubusercontent.com/62723358/155414880-4cf9a5d4-2b20-4b64-b579-b912d6917689.png) | ![FP-1524 Frontera Home New Fix](https://user-images.githubusercontent.com/62723358/156420451-1e2d844f-2771-4699-a4c8-edc1849d4457.png) | ![FP-1524 Frontera Home New Fix - Detail](https://user-images.githubusercontent.com/62723358/156420496-b9fa9b0d-31ed-415f-a5d3-19d440fa1225.png)|
| Section Pattern | ![FP-1524 Section Pattern Before](https://user-images.githubusercontent.com/62723358/155414883-ec2a74be-1999-4a40-9c5d-e6fd683c0719.png) | ![FP-1524 Section Pattern After](https://user-images.githubusercontent.com/62723358/156423343-9c86b124-0b6a-49db-8f14-a5fdf3d019b3.png) | ![FP-1524 Section Pattern After, Detail](https://user-images.githubusercontent.com/62723358/156421871-75327d03-30cb-469d-a030-90c1551c22b4.png)<br />+`.container` → short border ✓ |

</details>

<details>
<summary>Round 1</summary>

| | Before | After |
| - | - | - |
| Frontera Home | ![FP-1524 Frontera Home Before](https://user-images.githubusercontent.com/62723358/155414880-4cf9a5d4-2b20-4b64-b579-b912d6917689.png) | ![FP-1524 Frontera Home After](https://user-images.githubusercontent.com/62723358/155414875-0f6fb9a8-41f8-4adf-9c74-33bc60a73029.png) |
| Section Pattern | ![FP-1524 Section Pattern Before](https://user-images.githubusercontent.com/62723358/155414883-ec2a74be-1999-4a40-9c5d-e6fd683c0719.png) | ![FP-1524 Section Pattern After](https://user-images.githubusercontent.com/62723358/155414885-664a7159-782c-46d7-95d7-6201bd654415.png) |

</details>

## Testing

### Section Pattern

<details><summary>Deploy Tracking</summary>

- Build: https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/399/console
- Deploy: https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/1115/console

</details>

1. Review [Core Section Pattern (dev)](https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/o-section/).
    - _**If** you want to test locally, **then** replicate pattern test page by creating two snippets (see below steps)._
2. Confirm that two successive sections of same color have a border between them.
3. Confirm that border does **not** extend to the edge of the page.
4. Confirm that all sections' (except nested ones) white or black background extend to edge of page.
5. Confirm no other UI change compared to [FP-1524 Section Pattern Before](https://user-images.githubusercontent.com/62723358/155414883-ec2a74be-1999-4a40-9c5d-e6fd683c0719.png).

<details><summary><em>Snippets to Create (only if you test locally)</em></summary>

> NAME: `HTML: O-Section: Light`
> HTML: __`o-section--style-light`__
> TEMPLATE: `snippets/manual-pattern-library/o-section.html`

> NAME: `HTML: O-Section: Dark`
> HTML: __`o-section--style-dark`__
> TEMPLATE: `snippets/manual-pattern-library/o-section.html`

</details>

### Frontera Homepage

<details><summary>Deploy Tracking</summary>

- Build: https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/398/console
- Deploy: https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/1114/console

</details>

1. Review [Frontera Homepage (pprd)](http://pprd.frontera-portal.tacc.utexas.edu/).
    - _**No** local reproduction steps. This is an ungodly chore. I've done it 4 times. I wish it upon **no one**._
2. Confirm that the two black sections after the banner have a border between them.
3. Confirm that border does **not** extend to the edge of the page.
4. Confirm that those two sections' black background extend to edge of page.
5. Confirm no other UI change compared to https://pprd.frontera-portal.tacc.utexas.edu/.