### PR TITLE
bug/FP-1359: Callout Plugin Active+Focus State Anomaly within Dark Section

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-callout.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-callout.css
@@ -180,3 +180,4 @@ Styleguide Components.Callout
 
 a.c-callout:hover { @extend %x-article-link-hover; text-decoration: none; }
 a.c-callout:active { @extend %x-article-link-active; }
+a.c-callout:focus { text-decoration: none; }


### PR DESCRIPTION
## Overview: ##
Removed dotted underline added to Callout links when in :focus state.

## Related Jira tickets: ##

* [FP-1359](https://jira.tacc.utexas.edu/browse/FP-1359)

## Summary of Changes: ##
- Added a `:focus` selector for the `a.c-callout` selector which specifies no text decoration on focus state.

## Testing Steps: ##
1. On local Core-CMS, duplicate the 'Quick Start Guide' Style object from [dev Frontera](https://dev.fronteraweb.tacc.utexas.edu/system/) and all of its nested objects.
2. In Style object, change 'o-section--style-light' to 'o-section--style-dark'.
3. In Developer Tools, on the `<a>` (the blue box), click "Force element state" and then click ":focus".
4. Confirm that no dotted underline appears on the callout text.

## UI Photos:
Before: 
<img width="790" alt="image" src="https://user-images.githubusercontent.com/43251554/156260378-ae594ab0-ea9b-4e98-94e1-2b25a457a6e9.png">

After: 
<img width="790" alt="image" src="https://user-images.githubusercontent.com/43251554/156260468-903b67ff-633e-4377-988d-15635f7df4a1.png">


## Notes: ##