### PR TITLE
FP-1540: Hotfix: Update ES to Fix Security Issue

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,7 +31,7 @@ services:
       - core_cms_net
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
     ulimits:
       memlock: -1
     environment:


### PR DESCRIPTION
## Overview

Update ElasticSearch version by changing out base image for docker service.

## Related

* [FP-1540](https://jira.tacc.utexas.edu/browse/FP-1540)

## Changes

* Update `elasticsearch` image to one with version `7.17.0`.

> **Instructions for Others After Merge**
> Local environments may have a security issue. Please checkout Core-CMS `main` branch and pull the latest, then run `docker compose -f docker-compose.dev.yml up --force-recreate --build elasticsearch`. (If you have a _custom_ docker compose file, update it to match the change from [PR #456](https://github.com/TACC/Core-CMS/pull/456/files) and run the command but reference your custom file.)

## Testing

1. Re-build `elasticsearch` container.
2. Enter shell in `elasticsearch` container.
3. Run `curl -XGET 'http://localhost:9200`. ([source](https://kb.objectrocket.com/elasticsearch/how-to-check-your-elasticsearch-version-from-the-command-line))
4. Confirm version of ElasticSearch is updated.

## Screenshots

![CMS ElasticSearch 7 17 0](https://user-images.githubusercontent.com/62723358/156820868-4227b966-7f45-4e6e-b994-372d643b948f.png)

## Notes

- [The fix and related patch came in version `7.16.2`.](https://www.elastic.co/blog/new-elasticsearch-and-logstash-releases-upgrade-apache-log4j2)
- [The Portal recently had its version updated to `7.17.0`.](https://github.com/TACC/Core-Portal/blob/579349b/server/poetry.lock#L545-L547)