### PR TITLE
Quick: ID Attrs for Manual Pattern Lib. Snippets

### DIFF
--- a/taccsite_cms/templates/snippets/manual-pattern-library/o-grid.html
+++ b/taccsite_cms/templates/snippets/manual-pattern-library/o-grid.html
@@ -1,4 +1,4 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
-{% if html %}<h2><pre>{{ html }}</pre></h2>{% endif %}
+{% if html %}<h2 id="{{ html|slugify }}"><pre>{{ html }}</pre></h2>{% endif %}
 
 {% include './o-grid.content.html' %}

--- a/taccsite_cms/templates/snippets/manual-pattern-library/o-section.html
+++ b/taccsite_cms/templates/snippets/manual-pattern-library/o-section.html
@@ -1,4 +1,4 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
-{% if html %}<h2><pre>{{ html }}</pre></h2>{% endif %}
+{% if html %}<h2 id="{{ html|slugify }}"><pre>{{ html }}</pre></h2>{% endif %}
 
 {% include './o-section.content.html' %}


### PR DESCRIPTION
## Overview

Add `id` markup attributes to manual pattern library snippets.

## Changes

- Slugify pattern lib snippet content.
- Add text as value of new `id` attr in heading.
