### PR TITLE
FP-1470: Section Pattern: Third Style (and Fix to Dark Style)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -3,6 +3,8 @@ Section
 
 A group of related content.
 
+_Nested sections are an afterthought. No official design uses them._
+
 To Do:
 <details><summary>FP-1463: Extract layout pattern</summary>
 
@@ -112,6 +114,7 @@ Styleguide Objects.Section
 /* Modifers: Style: Text & Background */
 
 [class*="o-section--style"] {
+  --line-width: var(--global-border-width--normal);
   --box-shadow--fake-bkgd: 50vw 0 var(--color--bkgd),
                           -50vw 0 var(--color--bkgd);
 
@@ -119,8 +122,7 @@ Styleguide Objects.Section
   background-color: var(--color--bkgd);
   box-shadow: var(--box-shadow--fake-bkgd);
 }
-/* CAVEAT: No borders for nested sections */
-/* FAQ: Nested sections were an afterhought anyway; no design uses them */
+/* Nested sections must not stretch to page edge */
 [class*="o-section--style"] [class*="o-section--style"] {
   box-shadow: none;
 }
@@ -130,23 +132,25 @@ Styleguide Objects.Section
 /* Pure sections can use just a border */
 .o-section--style-light + .o-section--style-light:not(.container),
 .o-section--style-dark + .o-section--style-dark:not(.container) {
-  border-top: var(--global-border-width--normal) solid var(--color--line);
+  border-top: var(--line-width) solid var(--color--line);
+}
+/* any muted section */ .o-section--style-muted {
+  border-top: var(--line-width) solid var(--color--line);
+  border-bottom: var(--line-width) solid var(--color--line);
 }
 
-/* Muted sections have border that extends to page edge (like background) */
+/* Muted sections have border that extends to page edges (like background) */
 .o-section--style-muted {
   --box-shadow--fake-bkgd:
-    /* background (duplicated definition) */
-    50vw 0 var(--color--bkgd),
-    -50vw 0 var(--color--bkgd),
-    /* three-part fake top border (extends to page edge) */
-    33vw 1px var(--color--line),
-    0 1px var(--color--line),
-    -33vw 1px var(--color--line),
-    /* three-part fake bottom border (extends to page edge) */
-    33vw -1px var(--color--line),
-    0 -1px var(--color--line),
-    -33vw -1px var(--color--line);
+    /* re-build fake background but shorter by two lines' widths */
+    50vw 0 0 calc(-1 * var(--line-width)) var(--color--bkgd),
+    -50vw 0 0 calc(-1 * var(--line-width)) var(--color--bkgd),
+    /* fake top border to page edges using mostly-hidden fake background */
+    33vw 0 var(--color--line),
+    -33vw 0 var(--color--line),
+    /* fake bottom border to page edges using mostly-hidden fake background */
+    33vw 0px var(--color--line),
+    -33vw 0px var(--color--line);
 }
 
 /* Container-based light and dark sections need a border that ignores padding */

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -89,18 +89,21 @@ Styleguide Objects.Section
 
 .o-section--style-light {
   --color--text: var(--global-color-primary--dark);
+  --color--text-strong: var(--global-color-primary--xx-dark);
   --color--bkgd: var(--global-color-primary--xx-light);
   --color--line: var(--global-color-primary--normal);
   --color--link: var(--global-color-link-on-light--normal);
 }
 .o-section--style-muted {
-  --color--text: var(--global-color-primary--xx-dark);
+  --color--text: var(--global-color-primary--x-dark);
+  --color--text-strong: var(--global-color-primary--xx-dark);
   --color--bkgd: var(--global-color-primary--x-light);
   --color--line: var(--global-color-primary--dark);
   --color--link: var(--global-color-link-on-light--normal);
 }
 .o-section--style-dark {
-  --color--text: var(--global-color-primary--xx-light);
+  --color--text: var(--global-color-primary--x-light);
+  --color--text-strong: var(--global-color-primary--xx-light);
   --color--bkgd: var(--global-color-primary--xx-dark);
   --color--line: var(--global-color-primary--xx-light);
   --color--link: var(--global-color-link-on-dark--normal);
@@ -159,7 +162,7 @@ Styleguide Objects.Section
   color: var(--color--link);
 }
 [class*="o-section--style"] :is(h1, h2, h3, h4, h5, h6) {
-  color: var(--color--text);
+  color: var(--color--text-strong);
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -92,6 +92,12 @@ Styleguide Objects.Section
   --color--line: var(--global-color-primary--normal);
   --color--link: var(--global-color-link-on-light--normal);
 }
+.o-section--style-muted {
+  --color--text: var(--global-color-primary--xx-dark);
+  --color--bkgd: var(--global-color-primary--x-light);
+  --color--line: var(--global-color-primary--dark);
+  --color--link: var(--global-color-link-on-light--normal);
+}
 .o-section--style-dark {
   --color--text: var(--global-color-primary--xx-light);
   --color--bkgd: var(--global-color-primary--xx-dark);
@@ -116,13 +122,19 @@ Styleguide Objects.Section
 /* Modifers: Style: Line Between Matching Sections */
 
 /* Pure sections can use just a border */
-[class*="o-section--style"] + [class*="o-section--style"]:not(.container) {
-  border-top: var(--global-border-width--normal) solid
-              var(--color--line);
+.o-section--style-light + .o-section--style-light:not(.container),
+/* any muted instance */ .o-section--style-muted:not(.container),
+.o-section--style-dark + .o-section--style-dark:not(.container) {
+  border-top: var(--global-border-width--normal) solid var(--color--line);
+}
+.o-section--style-muted:not(.container) {
+  border-bottom: var(--global-border-width--normal) solid var(--color--line);
 }
 
 /* Container-based sections need a border that ignores padding */
-[class*="o-section--style"] + [class*="o-section--style"].container {
+.o-section--style-light + .o-section--style-light.container,
+/* any muted instance */ .o-section--style-muted.container,
+.o-section--style-dark + .o-section--style-dark.container {
   @extend %x-fake-border--inset-horz-top;
 
   --fb--line-width: var(--global-border-width--normal);
@@ -131,6 +143,9 @@ Styleguide Objects.Section
   --fb--inset-color: var(--color--bkgd);
 
   --fb--shadow-below: var(--box-shadow--fake-bkgd);
+}
+.o-section--style-muted.container {
+  @extend %x-fake-border--inset-horz-bottom;
 }
 
 /* Modifers: Style: Child Text */

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -144,8 +144,12 @@ Styleguide Objects.Section
 
   --fb--shadow-below: var(--box-shadow--fake-bkgd);
 }
+.o-section--style-light + .o-section--style-light.container,
+.o-section--style-dark + .o-section--style-dark.container {
+  @extend %x-fake-border--inset-horz-top;
+}
 .o-section--style-muted.container {
-  @extend %x-fake-border--inset-horz-bottom;
+  @extend %x-fake-border--inset-horz-both;
 }
 
 /* Modifers: Style: Child Text */

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -119,6 +119,8 @@ Styleguide Objects.Section
   background-color: var(--color--bkgd);
   box-shadow: var(--box-shadow--fake-bkgd);
 }
+/* CAVEAT: No borders for nested sections */
+/* FAQ: Nested sections were an afterhought anyway; no design uses them */
 [class*="o-section--style"] [class*="o-section--style"] {
   box-shadow: none;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -23,6 +23,7 @@ To Do:
 </details>
 
 .o-section--style-light - light background, dark text
+.o-section--style-muted - dull light background, dark text
 .o-section--style-dark  - dark background, light text
 
 Markup: o-section.html

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -84,83 +84,63 @@ Styleguide Objects.Section
 
 /* Modifers: Style */
 
-/* Modifers: Style: Dark & Light */
-/* FP-1470: Add cross-style code and variables when third style is added */
-
-.o-section--style-dark {
-  --box-shadow--fake-bkgd: 50vw 0 var(--global-color-primary--xx-dark),
-                          -50vw 0 var(--global-color-primary--xx-dark);
-
-  color: var(--global-color-primary--xx-light);
-  background-color: var(--global-color-primary--xx-dark);
-  box-shadow: var(--box-shadow--fake-bkgd);
-}
-.o-section--style-dark + .o-section--style-dark:not(.container) {
-  border-top: var(--global-border-width--normal) solid
-              var(--global-color-primary--xx-light);
-}
-.o-section--style-dark + .o-section--style-dark.container {
-  @extend %x-fake-border--inset-horz-top;
-
-  --fb--line-width: var(--global-border-width--normal);
-  --fb--line-color: var(--global-color-primary--xx-light);
-  --fb--inset-width: var(--global-space--grid-gap);
-  --fb--inset-color: var(--global-color-primary--xx-dark);
-
-  --fb--shadow-below: var(--box-shadow--fake-bkgd);
-}
-.o-section--style-dark a {
-  color: var(--global-color-link-on-dark--normal);
-}
-.o-section--style-dark h1,
-.o-section--style-dark h2,
-.o-section--style-dark h3,
-.o-section--style-dark h4,
-.o-section--style-dark h5,
-.o-section--style-dark h6 {
-  color: var(--global-color-primary--xx-light);
-}
+/* Modifers: Style: Options */
 
 .o-section--style-light {
-  --box-shadow--fake-bkgd: 50vw 0 var(--global-color-primary--xx-light),
-                          -50vw 0 var(--global-color-primary--xx-light);
+  --color--text: var(--global-color-primary--dark);
+  --color--bkgd: var(--global-color-primary--xx-light);
+  --color--line: var(--global-color-primary--normal);
+  --color--link: var(--global-color-link-on-light--normal);
+}
+.o-section--style-dark {
+  --color--text: var(--global-color-primary--xx-light);
+  --color--bkgd: var(--global-color-primary--xx-dark);
+  --color--line: var(--global-color-primary--xx-light);
+  --color--link: var(--global-color-link-on-dark--normal);
+}
 
-  color: var(--global-color-primary--dark);
-  background-color: var(--global-color-primary--xx-light);
+/* Modifers: Style: Text & Background */
+
+[class*="o-section--style"] {
+  --box-shadow--fake-bkgd: 50vw 0 var(--color--bkgd),
+                          -50vw 0 var(--color--bkgd);
+
+  color: var(--color--text);
+  background-color: var(--color--bkgd);
   box-shadow: var(--box-shadow--fake-bkgd);
 }
-.o-section--style-light + .o-section--style-light:not(.container) {
-  border-top: var(--global-border-width--normal) solid
-              var(--global-color-primary--normal);
+[class*="o-section--style"] [class*="o-section--style"] {
+  box-shadow: none;
 }
-.o-section--style-light + .o-section--style-light.container {
+
+/* Modifers: Style: Line Between Matching Sections */
+
+/* Pure sections can use just a border */
+[class*="o-section--style"] + [class*="o-section--style"]:not(.container) {
+  border-top: var(--global-border-width--normal) solid
+              var(--color--line);
+}
+
+/* Container-based sections need a border that ignores padding */
+[class*="o-section--style"] + [class*="o-section--style"].container {
   @extend %x-fake-border--inset-horz-top;
 
   --fb--line-width: var(--global-border-width--normal);
-  --fb--line-color: var(--global-color-primary--xx-dark);
+  --fb--line-color: var(--color--line);
   --fb--inset-width: var(--global-space--grid-gap);
-  --fb--inset-color: var(--global-color-primary--xx-light);
+  --fb--inset-color: var(--color--bkgd);
 
   --fb--shadow-below: var(--box-shadow--fake-bkgd);
 }
-.o-section--style-light a {
-  color: var(--global-color-link-on-light--normal);
-}
-.o-section--style-light h1,
-.o-section--style-light h2,
-.o-section--style-light h3,
-.o-section--style-light h4,
-.o-section--style-light h5,
-.o-section--style-light h6 {
-  color: var(--global-color-primary--xx-dark);
-}
 
-/* Modifers: Style: (Fake) Endless Background */
-/* FAQ: Allows background to escape `.container` (whether its self or parent) */
-/* FP-1470: Move this to cross-style code when third style is added */
+/* Modifers: Style: Child Text */
 
-/* Except for nested sections */
-.o-section .o-section { box-shadow: none; }
+[class*="o-section--style"] a {
+  color: var(--color--link);
+}
+[class*="o-section--style"] :is(h1, h2, h3, h4, h5, h6) {
+  color: var(--color--text);
+}
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css
@@ -127,17 +127,28 @@ Styleguide Objects.Section
 
 /* Pure sections can use just a border */
 .o-section--style-light + .o-section--style-light:not(.container),
-/* any muted instance */ .o-section--style-muted:not(.container),
 .o-section--style-dark + .o-section--style-dark:not(.container) {
   border-top: var(--global-border-width--normal) solid var(--color--line);
 }
-.o-section--style-muted:not(.container) {
-  border-bottom: var(--global-border-width--normal) solid var(--color--line);
+
+/* Muted sections have border that extends to page edge (like background) */
+.o-section--style-muted {
+  --box-shadow--fake-bkgd:
+    /* background (duplicated definition) */
+    50vw 0 var(--color--bkgd),
+    -50vw 0 var(--color--bkgd),
+    /* three-part fake top border (extends to page edge) */
+    33vw 1px var(--color--line),
+    0 1px var(--color--line),
+    -33vw 1px var(--color--line),
+    /* three-part fake bottom border (extends to page edge) */
+    33vw -1px var(--color--line),
+    0 -1px var(--color--line),
+    -33vw -1px var(--color--line);
 }
 
-/* Container-based sections need a border that ignores padding */
+/* Container-based light and dark sections need a border that ignores padding */
 .o-section--style-light + .o-section--style-light.container,
-/* any muted instance */ .o-section--style-muted.container,
 .o-section--style-dark + .o-section--style-dark.container {
   @extend %x-fake-border--inset-horz-top;
 
@@ -147,13 +158,6 @@ Styleguide Objects.Section
   --fb--inset-color: var(--color--bkgd);
 
   --fb--shadow-below: var(--box-shadow--fake-bkgd);
-}
-.o-section--style-light + .o-section--style-light.container,
-.o-section--style-dark + .o-section--style-dark.container {
-  @extend %x-fake-border--inset-horz-top;
-}
-.o-section--style-muted.container {
-  @extend %x-fake-border--inset-horz-both;
 }
 
 /* Modifers: Style: Child Text */

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
@@ -49,7 +49,7 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (with Nested Sections)</strong></p>
-  <p>Sections can be nested within me. <small>A nested Section removes the standard Section spacing.</small></p>
+  <p>Sections can be nested within me. <small>A nested Section removes the standard Section spacing.</small> <small>⚠️ It is not used in any design, so its implementation is incomplete (no borders).</small></p>
   <div class="o-section o-section--style-dark">
     <p><strong>(Nested) Dark Section</strong></p>
     <p>I am nested.</p>

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
@@ -56,7 +56,7 @@
   </div>
   <div class="o-section o-section--style-muted">
     <p><strong>(Nested) Muted Section</strong></p>
-    <p>I am nested.</p>
+    <p>I am nested.<!-- <small>No use case for this is expected, but it is available.<small>--></p>
   </div>
   <div class="o-section o-section--style-light">
     <p><strong>(Nested) Light Section</strong></p>

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
@@ -9,11 +9,23 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (First of a Pair)</strong></p>
-  <p>A <strong>light</strong> or <strong>muted</strong> or <strong>dark</strong> Section directly below me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
+  <p>A Section of the same style directly after me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
 </section>
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (Second of a Pair)</strong></p>
-  <p>A <strong>light</strong> or <strong>muted</strong> or <strong>dark</strong> Section directly above me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
+  <p>A Section of the same style directly after me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
+</section>
+
+<br />
+
+{# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
+<section class="container  o-section {{modifier_class}} {{ html }}">
+  <p><strong>Container Section (First of a Pair)</strong></p>
+  <p>A <code>.container</code> Section has Container padding and a fake border.</small></p>
+</section>
+<section class="container  o-section {{modifier_class}} {{ html }}">
+  <p><strong>Container Section (First of a Pair)</strong></p>
+  <p>A <code>.container</code> Section has Container padding and a fake border.</small></p>
 </section>
 
 <br />

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
@@ -1,7 +1,7 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section</strong></p>
-  <p>I am a Section. <small>Use light Sections to wrap most content. Use dark Sections to highlight some content.</small></p>
+  <p>I am a Section. <small>Use light Sections to wrap most content. Use muted Sections to gently highlight some content. Use dark Sections to strongly highlight some content.</small></p>
 </section>
 
 <br />
@@ -9,11 +9,27 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (First of a Pair)</strong></p>
-  <p>A <strong>light</strong> or <strong>dark</strong> Section directly below me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
+  <p>A <strong>light</strong> or <strong>muted</strong> or <strong>dark</strong> Section directly below me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
 </section>
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (Second of a Pair)</strong></p>
-  <p>A <strong>light</strong> or <strong>dark</strong> Section directly above me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
+  <p>A <strong>light</strong> or <strong>muted</strong> or <strong>dark</strong> Section directly above me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
+</section>
+
+<br />
+
+{# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
+<section class="o-section {{modifier_class}} {{ html }}">
+  <p><strong>Section (before Muted Section)</strong></p>
+  <p>A pair of <strong>light</strong> or <strong>dark</strong> Sections may have a <strong>muted</strong> Section between them.</p>
+</section>
+<section class="o-section o-section--style-muted">
+  <p><strong>(Muted) Section</strong></p>
+  <p>A <strong>muted</strong> Section would appear between two <strong>light</strong> or <strong>dark</strong> Sections. <small>It probably would not appear between two <strong>muted</strong> Sections.</small></p>
+</section>
+<section class="o-section {{modifier_class}} {{ html }}">
+  <p><strong>Section (before Muted Section)</strong></p>
+  <p>A pair of <strong>light</strong> or <strong>dark</strong> Sections may have a <strong>muted</strong> Section between them.</p>
 </section>
 
 <br />
@@ -24,6 +40,10 @@
   <p>Sections can be nested within me. <small>A nested Section removes the standard Section spacing.</small></p>
   <div class="o-section o-section--style-dark">
     <p><strong>(Nested) Dark Section</strong></p>
+    <p>I am nested.</p>
+  </div>
+  <div class="o-section o-section--style-muted">
+    <p><strong>(Nested) Muted Section</strong></p>
     <p>I am nested.</p>
   </div>
   <div class="o-section o-section--style-light">

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
@@ -69,5 +69,5 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (at Bottom of Page)</strong></p>
-  <p>At the bottom of a page: a dark Section will visually merge with the Footer, a light Section will stand out above the Footer.</p>
+  <p>At the bottom of a page: a light Section will stand out above the Footer, a muted Section will stand out above the Footer, a dark Section will visually merge with the Footer.</p>
 </section>

--- a/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.html
@@ -9,11 +9,11 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (First of a Pair)</strong></p>
-  <p>A Section of the same style directly after me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
+  <p>A Section of the same style directly after me will create a border between both. <small>Muted sections should <strong>not</strong> appear consectuively.</small></p>
 </section>
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (Second of a Pair)</strong></p>
-  <p>A Section of the same style directly after me will create a border between both. <small>An <strong>un-styled</strong> Section never has a border.</small></p>
+  <p>A Section of the same style directly after me will create a border between both. <small>Muted sections should <strong>not</strong> appear consectuively.</small></p>
 </section>
 
 <br />
@@ -21,11 +21,11 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
 <section class="container  o-section {{modifier_class}} {{ html }}">
   <p><strong>Container Section (First of a Pair)</strong></p>
-  <p>A <code>.container</code> Section has Container padding and a fake border.</small></p>
+  <p>A <code>.container</code> Section has Container padding and a fake border.<small>Muted sections should <strong>not</strong> appear consectuively.</small></p>
 </section>
 <section class="container  o-section {{modifier_class}} {{ html }}">
   <p><strong>Container Section (First of a Pair)</strong></p>
-  <p>A <code>.container</code> Section has Container padding and a fake border.</small></p>
+  <p>A <code>.container</code> Section has Container padding and a fake border.<small>Muted sections should <strong>not</strong> appear consectuively.</small></p>
 </section>
 
 <br />
@@ -33,15 +33,15 @@
 {# The {{ html }} allows DjangoCMS Snippet to pass in class names #}
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (before Muted Section)</strong></p>
-  <p>A pair of <strong>light</strong> or <strong>dark</strong> Sections may have a <strong>muted</strong> Section between them.</p>
+  <p>A pair of <strong>light</strong> or <strong>dark</strong> Sections may have a <strong>muted</strong> Section between them. <small>Muted sections should <strong>not</strong> appear consectuively.</small></p>
 </section>
 <section class="o-section o-section--style-muted">
   <p><strong>(Muted) Section</strong></p>
-  <p>A <strong>muted</strong> Section would appear between two <strong>light</strong> or <strong>dark</strong> Sections. <small>It probably would not appear between two <strong>muted</strong> Sections.</small></p>
+  <p>A <strong>muted</strong> Section would appear between two <strong>light</strong> or <strong>dark</strong> Sections. <small>It would probably not appear between two <strong>muted</strong> Sections.</small></p>
 </section>
 <section class="o-section {{modifier_class}} {{ html }}">
   <p><strong>Section (before Muted Section)</strong></p>
-  <p>A pair of <strong>light</strong> or <strong>dark</strong> Sections may have a <strong>muted</strong> Section between them.</p>
+  <p>A pair of <strong>light</strong> or <strong>dark</strong> Sections may have a <strong>muted</strong> Section between them. <small>Muted sections should <strong>not</strong> appear consectuively.</small></p>
 </section>
 
 <br />

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-fake-border.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-fake-border.css
@@ -6,6 +6,8 @@ Fake borders that have features unavailable to regular borders
 (custom property a.k.a. variable prefix `fb` stands for __f__ake __b__order)
 
 %x-fake-border--inset-horz-top - A top border that is not full width
+%x-fake-border--inset-horz-both - Borders top & bottom that are not full width
+%x-fake-border--inset-horz-bottom - A bottom border that is not full width
 
 Styleguide Tools.ExtendsAndMixins.Overlay
 */
@@ -30,14 +32,14 @@ To avoid overwriting an existing `box-shadow`, use the public shadow variables:
 - `--fb--shadow-above: var(--YOUR-existing-shadow-ABOVE-fake-border)`
 - `--fb--shadow-below: var(--YOUR-existing-shadow-BELOW-fake-border)`
 */
-%x-fake-border--inset-horz-top {
+%x-fake-border--inset-horz {
   --fb--line-width: 0px; /* CAVEAT: add unit so `calc()` will not fail */
   --fb--line-color: transparent;
 
   --fb--inset-width: 0px; /* CAVEAT: add unit so `calc()` will not fail */
   --fb--inset-color: transparent;
 
-  --fb--line: inset 0 var(--fb--line-width) var(--fb--line-color);
+  /* --fb--line: */
   --fb--start: inset calc( 1 * var(--fb--inset-width)) 0 var(--fb--inset-color);
   --fb--end: inset calc(-1 * var(--fb--inset-width)) 0 var(--fb--inset-color);
 
@@ -51,5 +53,20 @@ To avoid overwriting an existing `box-shadow`, use the public shadow variables:
     var(--fb),
     var(--fb--shadow-below, 0 0 transparent)
 }
-/* TODO: For FP-1470, create `--inset-horz-bottom` */
-/* TODO: As needed, create `--inset-horz-bottom`, `--inset-vert-left`, etc. */
+%x-fake-border--inset-horz-top {
+  @extend %x-fake-border--inset-horz;
+
+  --fb--line: inset 0 calc( 1 * var(--fb--line-width)) var(--fb--line-color);
+}
+%x-fake-border--inset-horz-both {
+  @extend %x-fake-border--inset-horz;
+
+  --fb--line: inset 0 calc( 1 * var(--fb--line-width)) var(--fb--line-color),
+              inset 0 calc(-1 * var(--fb--line-width)) var(--fb--line-color);
+}
+%x-fake-border--inset-horz-bottom {
+  @extend %x-fake-border--inset-horz;
+
+  --fb--line: inset 0 calc(-1 * var(--fb--line-width)) var(--fb--line-color);
+}
+/* TODO: As needed, create `--inset-vert-left`, `--inset-vert-right` */

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-fake-border.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-fake-border.css
@@ -51,4 +51,5 @@ To avoid overwriting an existing `box-shadow`, use the public shadow variables:
     var(--fb),
     var(--fb--shadow-below, 0 0 transparent)
 }
+/* TODO: For FP-1470, create `--inset-horz-bottom` */
 /* TODO: As needed, create `--inset-horz-bottom`, `--inset-vert-left`, etc. */


### PR DESCRIPTION
## Overview

- Add third Section style for [new About page design][design].
- Use variables for DRY-er Section code.

_Code rearranged for legibility, so changes may be easier to review via [split diff](https://github.blog/2014-09-03-introducing-split-diffs/)._

## Tickets

* [FP-1470](https://jira.tacc.utexas.edu/browse/FP-1470)

## Changes

- Add `.o-section--style-muted`.
- Change `.o-section` code to use more variables.
- Add `.x-fake-border--inset-horz-bottom` & `...--inset-horz-both`.
- Change `.x-fake-border` code to use more variables.

## Screenshots

ℹ  Window size for testing and screenshots was 991px.

| Where | Before | After |
| - | - | - |
| Patterns | [FP-1470 Patterns Local Before](https://user-images.githubusercontent.com/62723358/156847320-8e5abc4d-a105-4620-8a5f-003f1db69b29.jpeg) | [FP-1470 Patterns Local After](https://user-images.githubusercontent.com/62723358/156858082-99de913c-3d78-4e52-ab12-4e3b617badb4.jpeg) |
| Frontera Home | [FP-1470 Frontera Dev Before](https://user-images.githubusercontent.com/62723358/156847321-3d00bf31-3111-4d50-bebc-a3c3ae00cd2b.jpeg) | [FP-1470 Frontera Dev After](https://user-images.githubusercontent.com/62723358/156858095-8e4d28ad-05d3-42cf-a8b1-b59c4541cd35.jpeg) |

## Testing

ℹ  Window size for testing and screenshots was 991px.

### Section Pattern

1. Review [Core Section Pattern (dev)](https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/o-section/).\*†
2. <details>
    <summary>🆕  Confirm new "Muted" Section renders with expected UI <sup>(click to reveal)</sup>.</summary>

	- dull light background
	- dark text
	- border on top and bottom
	- spacing that matches Light and Dark Sections
	- matches [design][design] _except for spacing_[^3]

    </details>
4. 🛠  Confirm existing "Dark" Section heading text is brighter than paragraph.[^4]
5. Confirm Light and Dark Section patterns have **not**‡ otherwise changed.[^1]

<details><summary><sub>* <strong>If</strong> you want to test locally, <strong>then</strong> create these snippets (click to reveal):</sub></summary>

> NAME: `HTML: O-Section: Light`
> HTML: __`o-section--style-light`__
> TEMPLATE: `snippets/manual-pattern-library/o-section.html`

> NAME: `HTML: O-Section: Muted`
> HTML: __`o-section--style-muted`__
> TEMPLATE: `snippets/manual-pattern-library/o-section.html`

> NAME: `HTML: O-Section: Dark`
> HTML: __`o-section--style-dark`__
> TEMPLATE: `snippets/manual-pattern-library/o-section.html`

</details>
<details><summary>† <sub>Build & Deploy Jobs (click to reveal):</sub></summary>

- Build: https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/412
- Deploy: https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/1130

</details>
<sub>‡ Any change to text does <strong>not</strong> count as changes to pattern.</sub>

[^1]: To compare: build `main` on local, see "Screenshots".
[^3]: Designer does not use consistent spacing, especially for quick designs like this third style.
[^4]: Contrast between text colors is difficult to tell via screenshots. Compare new pattern UI to [CEP Prod pattern UI](https://cep.tacc.utexas.edu/design-system/ui-patterns/o-section/).

### Frontera Homepage

1. Review [Frontera Homepage (dev)](http://pprd.frontera-portal.tacc.utexas.edu/).\*†
2. Confirm that section UI has **not**‡ changed.[^2]

<sub>* <strong>If</strong> you want to test locally, <strong>then</strong> replicate the home page <a href="https://github.com/TACC/Core-CMS/wiki/How-to-Use-DjangoCMS-Transfer" target="_blank">via <code>djangocms-transfer</code></a>.</sub>
<details><summary><sub>† Build & Deploy Jobs (click to reveal):</sub></summary>

- Build: https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/413
- Deploy: https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/1131

</details>
<sub>‡ One expected change is the fix from #446 (pprd had bug of wider section border).</sub>

---

[^2]: To compare: build `main` on local, see "Screenshots", reference [Frontera Pprd](https://pprd.frontera-portal.tacc.utexas.edu/).

[design]: https://xd.adobe.com/view/2310393b-dd24-4c7d-a117-c35a613a55f3-7643/
