### PR TITLE
Noop: FIx Typo in Templates README

### DIFF
--- a/taccsite_cms/templates/README.md
+++ b/taccsite_cms/templates/README.md
@@ -6,7 +6,7 @@ All templates specific to the Core CMS __must__ be placed in this directory (or 
 
 ## Page Templates
 
-To make certain templates available as page templates for CMS editors, update `_CMS_TEMPLATES` secret.
+To make certain templates available as page templates for CMS editors, update `CMS_TEMPLATES` secret.
 
 ## Overwrite Apps or Plugins
 


### PR DESCRIPTION
## Overview

Fix a typo... well, really remove underscore that was accurate before a major change.