### PR TITLE
FP-1410: Shrink Guide Images & Add Links to Open in New Tab

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-document.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-document.css
@@ -41,15 +41,6 @@ Styleguide Trumps.Scopes.Document
   blockquote { width: 600px; }
 }
 
-.s-document figure {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.s-document figcaption {
-  font-weight: bold;
-}
-
 /* Treat nested definition lists like other nested lists */
 /* NOTE: See `../elments/html-elements.html` for `dl dl` reference styles */
 p + dl.small {
@@ -87,9 +78,10 @@ p + dl.small {
 /* ELEMENTS: Image & Multimedia */
 
 /* NOTE: The `data_transfer.html` template uses <figure>'s */
-.s-document img/*:not(figure > img)*/ {
+.s-document img {
   display: block;
-  max-width: 75%;
+  width: 100%;
+  max-width: 800px;
 
   border: var(--global-border--normal);
 }

--- a/taccsite_cms/templates/guides/data_transfer.globus.html
+++ b/taccsite_cms/templates/guides/data_transfer.globus.html
@@ -1,6 +1,13 @@
 {% extends "guide.html" %}
 
 {% block guide %}
+  {# HACK: New markup (`<figure>`) or some classnames may be better, but new guides/docs are coming, so I'm solving this quick #}
+  <style>
+  /* To prevent image link from being as wide as col (even when image is not) */
+  .col p ~ a {
+    display: inline-block;
+  }
+  </style>
   <div class="row">
     <div class="col">
       <h2>
@@ -50,7 +57,9 @@
         as XSEDE is a CILogon Identity Provider.
       </p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/b2/a8/b2a856d2-e079-48f1-8785-dbf758534510/picture1.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/b2/a8/b2a856d2-e079-48f1-8785-dbf758534510/picture1.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/b2/a8/b2a856d2-e079-48f1-8785-dbf758534510/picture1.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>
         After successfully authenticating at your chosen Identity Provider, you are redirected back to CILogon, where you can find your Certificate Subject that you will need to copy and paste in the next step:
@@ -64,7 +73,9 @@
         and select "Account Profile" from the main menu under the "Home" dropdown.
       </p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/d9/a7/d9a7c353-416b-44b1-9c16-3014d6308b01/picture2.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/d9/a7/d9a7c353-416b-44b1-9c16-3014d6308b01/picture2.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/d9/a7/d9a7c353-416b-44b1-9c16-3014d6308b01/picture2.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>
         On the left of the page is a list of account actions, select "Manage DNs". You will be presented with a list of the DNs currently associated with your TACC account and a text field to associate a new DN to your account. Enter the Certificate Subject obtained from
@@ -72,7 +83,9 @@
         in the text field. Click the button to "Associate DN". This will associate the new DN with your account. Please note, it may take up to 30 minutes for this change to propagate to all TACC systems.
       </p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/06/b0/06b0c288-90cc-4bd0-9650-45d25497bbc5/picture3.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/06/b0/06b0c288-90cc-4bd0-9650-45d25497bbc5/picture3.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/06/b0/06b0c288-90cc-4bd0-9650-45d25497bbc5/picture3.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
     </div>
   </div>
 
@@ -92,23 +105,31 @@
         and log in.
       </p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/64/ec/64ec67d5-29fb-4a8c-84bf-d8e52860083a/picture4.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/64/ec/64ec67d5-29fb-4a8c-84bf-d8e52860083a/picture4.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/64/ec/64ec67d5-29fb-4a8c-84bf-d8e52860083a/picture4.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>
         Upon successful login you, you will be directed to the "File Manager" landing page.
       </p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/04/cc/04cc029b-9af8-4cb0-8698-943ae93d9e0e/picture5.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/04/cc/04cc029b-9af8-4cb0-8698-943ae93d9e0e/picture5.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/04/cc/04cc029b-9af8-4cb0-8698-943ae93d9e0e/picture5.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>Click on Endpoints.</p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/14/a5/14a540bd-9666-449c-be18-ef18456faf42/picture6.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/14/a5/14a540bd-9666-449c-be18-ef18456faf42/picture6.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/14/a5/14a540bd-9666-449c-be18-ef18456faf42/picture6.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>
         Click “+ Create new endpoint” and follow the instructions to set up your desktop/laptop as an endpoint.
       </p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/71/94/71947964-5a11-4bb3-ab5e-b8b2ae1b1c86/picture7.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/71/94/71947964-5a11-4bb3-ab5e-b8b2ae1b1c86/picture7.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/71/94/71947964-5a11-4bb3-ab5e-b8b2ae1b1c86/picture7.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>
         Enter a Display Name to identify your local endpoint like My Laptop, My Desktop at Home, etcetera and then click Generate Setup Key and click copy to copy the Personal Setup Key.
@@ -124,11 +145,15 @@
         Click on “File Manager”, and next click on the Collection field. You can choose "Your collections" and click on "My Laptop" to select the created endpoint to your computer.
       </p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/6f/ee/6feecdb0-0abc-4732-85a0-88f3e58a361f/picture8.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/6f/ee/6feecdb0-0abc-4732-85a0-88f3e58a361f/picture8.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/6f/ee/6feecdb0-0abc-4732-85a0-88f3e58a361f/picture8.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>You can now access the files on your desktop/laptop via Globus.</p>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/0f/3d/0f3daa28-6632-4d3e-a964-706d33dc2fa3/picture9.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/0f/3d/0f3daa28-6632-4d3e-a964-706d33dc2fa3/picture9.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/0f/3d/0f3daa28-6632-4d3e-a964-706d33dc2fa3/picture9.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>
         You can also click on Panels to look at two endpoints at the same time. In the other transfer endpoint, search for "TACC" and select the appropriate allocation storage system (Frontera, Stampede2, Corral, Ranch, etcetera) for the desired data.
@@ -160,7 +185,9 @@
         </dl>
       </details>
 
-      <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/5b/7a/5b7adb5f-da51-4dd0-9b84-44ce69c41da6/picture10.png__1170x0_q85_subsampling-2_upscale.png" />
+      <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/5b/7a/5b7adb5f-da51-4dd0-9b84-44ce69c41da6/picture10.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/5b/7a/5b7adb5f-da51-4dd0-9b84-44ce69c41da6/picture10.png__1170x0_q85_subsampling-2_upscale.png" />
+      </a>
 
       <p>
         After successfully authenticating, you will be redirected back to Globus and you will now be able to access your data on the allocation storage system (Frontera, Stampede2, Corral, Ranch):
@@ -221,7 +248,9 @@
           <ul>
             <li>
               <p>You will find the Project Id on your “My Projects” list in the second column.</p>
-              <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/53/f4/53f40efb-3207-44e8-a84c-59a2a97a9b56/picture11_a2cps.png__1170x0_q85_subsampling-2_upscale.png" />
+              <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/53/f4/53f40efb-3207-44e8-a84c-59a2a97a9b56/picture11_a2cps.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+                <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/53/f4/53f40efb-3207-44e8-a84c-59a2a97a9b56/picture11_a2cps.png__1170x0_q85_subsampling-2_upscale.png" />
+              </a>
             </li>
             <li>
               <p>If you are viewing a project, the Project Id will be appended to the URL in your browser as:

--- a/taccsite_cms/templates/guides/data_transfer.html
+++ b/taccsite_cms/templates/guides/data_transfer.html
@@ -1,6 +1,11 @@
 {% extends "guide.html" %}
 
 {% block guide %}
+  <style>
+  .s-document img {
+    max-width: 570px;
+  }
+  </style>
   <div class="row">
     <div class="col">
       <h2>Data Transfer and Management Guide</h2>
@@ -208,7 +213,9 @@
         Once you have identified the location of the files, you can right-click on them and select either Get Info (on Mac) or Properties (on Windows) to view the path location on your local system.
       </p>
       <figure id="figure1">
-        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/6c/ea/6ceacba9-7824-4925-b924-dd317040b629/picture1.png__1170x0_q85_subsampling-2_upscale.png" />
+        <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/6c/ea/6ceacba9-7824-4925-b924-dd317040b629/picture1.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+          <img style="max-width: 380px;" src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/6c/ea/6ceacba9-7824-4925-b924-dd317040b629/picture1.png__1170x0_q85_subsampling-2_upscale.png" />
+        </a>
         <figcaption>
           Figure 1. Use Get Info to determine “Where” the path of your data file(s) is
         </figcaption>
@@ -434,7 +441,9 @@ Changing to:
       </p>
 
       <figure id="figure2">
-        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/a9/9f/a99fa278-ae07-4b5e-9219-f9db3c2c89d5/picture2.png__1170x0_q85_subsampling-2_upscale.png" />
+        <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/a9/9f/a99fa278-ae07-4b5e-9219-f9db3c2c89d5/picture2.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+          <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/a9/9f/a99fa278-ae07-4b5e-9219-f9db3c2c89d5/picture2.png__1170x0_q85_subsampling-2_upscale.png" />
+        </a>
         <figcaption>
           Figure 2. Windows Cyberduck and “Open Connection” setup screen
         </figcaption>
@@ -449,7 +458,9 @@ Changing to:
         <em>If you have not done so already, replace the “Path” with the path to your individualized transfer directory.</em>
       </p>
       <figure id="figure3">
-        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/10/fb/10fbbb2a-dcd8-44d8-9ade-fb4ed3df8487/picture3.png__1170x0_q85_subsampling-2_upscale.png" />
+        <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/10/fb/10fbbb2a-dcd8-44d8-9ade-fb4ed3df8487/picture3.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+          <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/10/fb/10fbbb2a-dcd8-44d8-9ade-fb4ed3df8487/picture3.png__1170x0_q85_subsampling-2_upscale.png" />
+        </a>
         <figcaption>
           Figure 3. Windows “Open Connection” setup screen
         </figcaption>
@@ -482,7 +493,9 @@ Changing to:
         <kbd>host</kbd>. Add your TACC username and password in the spaces provided. If the “More Options” area is not shown, click the small triangle or button to expand the window; this will allow you to enter the path to your transfer directory, <kbd>/transfer/directory/path</kbd>, so that when Cyberduck opens the connection you will immediately be in your individualized transfer directory on the system. As you fill out the information, Cyberduck will create the bookmark for you. Exit out of the setup screen and click on your newly created bookmark to launch the connection.
       </p>
       <figure id="figure4">
-        <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fa/b3/fab3edd6-c7a6-46dc-8103-09917ef02240/picture4.png__1170x0_q85_subsampling-2_upscale.png" />
+        <a href="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fa/b3/fab3edd6-c7a6-46dc-8103-09917ef02240/picture4.png__1170x0_q85_subsampling-2_upscale.png" target="_blank">
+          <img src="https://a2cps-staging.tacc.utexas.edu/media/filer_public_thumbnails/filer_public/fa/b3/fab3edd6-c7a6-46dc-8103-09917ef02240/picture4.png__1170x0_q85_subsampling-2_upscale.png" />
+        </a>
         <figcaption>Figure 4. macOS “New Bookmark” setup screen</figcaption>
       </figure>
 

--- a/taccsite_cms/templates/guides/data_transfer.html
+++ b/taccsite_cms/templates/guides/data_transfer.html
@@ -2,6 +2,7 @@
 
 {% block guide %}
   <style>
+  /* To override 800px (from stylesheet) which is too big for these images */
   .s-document img {
     max-width: 570px;
   }


### PR DESCRIPTION
## Overview

- Shrink […] Data Transfer guide images consistently on wide screens.
- Link images so they open in new tab. (Add bug fix for it.)

## Related

* __fixes: [FP-1410](https://jira.tacc.utexas.edu/browse/FP-1410)__
* _created after work began: [FP-1542](https://jira.tacc.utexas.edu/browse/FP-1542) (to replace the URLs with ones to locally-available images)_

## Changes

- delete redundant code
- add `<a>`'s
- set absolute max-width for images, but otherwise (i.e. mobile) let images grow to fill screen
- shrink one image a little extra
- prevent new bug of really large invisible link

## Testing

1. Load these pages[^1]:
    - https://dev.cep.tacc.utexas.edu/guides/data-transfer-guide/
    - https://dev.cep.tacc.utexas.edu/guides/globus-data-transfer-guide/
2. Scroll to see all images while on wide screen.
3. Scroll to see all images while on narrow screen.
4. No image should be excessively large nor small.[^2]
5. Each image should link to full-size.
6. Report any seemingly related UI bugs.

[^1]: If testing locally, you'll need to create those two pages. To put content on them, choose the correct page template, which are best to define in the `settings_custom.py`. Example: `('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer')`.
[^2]: At some widths (992px or 576px depending on the page), images are larger than before. That's okay—they were too small on mobile for narrow screens, and Design likes images on mobile to take up all of page width (unless its some intentionally small image). What I did was pick a max size for these guides' images that offered legibility without being too large. At a much wider width, the images are _definitely_ smaller than before.

## Screenshots

### Data Transfer Guide

<details><summary>576px</summary>

| AFTER | BEFORE |
| - | - |
| ![Data Transfer 576px AFTER](https://user-images.githubusercontent.com/62723358/157765603-b39c55d1-a85a-4c5b-9fd3-3e7766ed2170.jpeg) | ![Data Transfer 576px BEFORE](https://user-images.githubusercontent.com/62723358/157765607-16834347-5da1-45c7-b7b5-486fe450c394.jpeg) |

</details><details><summary>992px</summary>

| AFTER | BEFORE |
| - | - |
| ![Data Transfer 992px AFTER](https://user-images.githubusercontent.com/62723358/157765608-f2482471-bec3-4b33-997f-cb4e72a5c22d.jpeg) | ![Data Transfer 992px BEFORE](https://user-images.githubusercontent.com/62723358/157765610-7e09fd46-437c-4417-a182-2aa7887da070.jpeg) |

</details><details><summary>1680px</summary>

| AFTER | BEFORE |
| - | - |
| ![Data Transfer 1680px AFTER](https://user-images.githubusercontent.com/62723358/157765613-9c39cdad-931f-4739-b148-f54058cffcfa.jpeg) | ![Data Transfer 1680px BEFORE](https://user-images.githubusercontent.com/62723358/157765616-f9ea24f0-4a6a-4211-bbf6-bd656fbe0345.jpeg) |

</details>

### Globus Data Transfer Guide

<details><summary>576px</summary>

| AFTER | BEFORE |
| - | - |
| ![Globus Data 576px AFTER](https://user-images.githubusercontent.com/62723358/157765618-2235ae60-aab4-4b52-acbb-f2efd33454b0.jpeg) | ![Globus Data 576px BEFORE](https://user-images.githubusercontent.com/62723358/157765619-2e4a94a2-ba7a-46a8-a5da-3ef18ab4c61e.jpeg) |

</details><details><summary>992px</summary>

| AFTER | BEFORE |
| - | - |
| ![Globus Data 992px AFTER](https://user-images.githubusercontent.com/62723358/157765621-7e36add7-befb-4a03-a012-a9744bb2dcc9.jpeg) | ![Globus Data 992px BEFORE](https://user-images.githubusercontent.com/62723358/157765622-bbf5c093-0e7d-4c9b-a84c-cf90db93bf7c.jpeg) |

</details><details><summary>1680px</summary>

| AFTER | BEFORE |
| - | - |
| ![Globus Data 1680px AFTER](https://user-images.githubusercontent.com/62723358/157765623-54bb08d5-4eac-4aeb-9882-1abae00f9e11.jpeg) | ![Globus Data 1680px BEFORE](https://user-images.githubusercontent.com/62723358/157765624-2d1b4bb8-8b2e-475c-8c88-bfe4c41047c1.jpeg) |

</details>