### PR TITLE
Hotfix/Resolve README CMS Deploy Fail

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -321,7 +321,8 @@ INSTALLED_APPS = [
 def get_subdirs_as_module_names(path):
     module_names = []
     for entry in os.scandir(path):
-        if entry.is_dir():
+        is_app = entry.path.find('_readme') == -1
+        if entry.is_dir() and is_app:
             # FAQ: There are different root paths to tweak:
             #      - Containers use `/code/…`
             #      - Python Venvs use `/srv/taccsite/…`


### PR DESCRIPTION
## Overview

Fix build error.

<details>

```
Mar 23 10:49:16 dev.cep.tacc.utexas.edu portal_cms[27210]: django.core.exceptions.ImproperlyConfigured: The app module <module 'taccsite_custom.README-cms' (namespace)> has multiple filesystem locations (['/code/taccsite_custom/README-cms', '/code/./taccsite_custom/README-cms']); you must configure this app with an AppConfig subclass with a 'path' class attribute.
```

</details>

## Related

* [v3.5.0](https://github.com/TACC/Core-CMS/releases/tag/v3.5.0)

### Requires

* https://github.com/TACC/Core-CMS-Resources/pull/125

## Changes

- __Ignore `_readme` in `taccsite_custom` when installing apps.__
- `taccsite_custom`
    - Rename `README-cms` to `_readme-cms`.
    - Rename `_readme-cms/static` and `.../templates` to `_static/` and `_templates/`.
    - Add step for new project: "Read `/_readme-cms`."

## Testing

1. Build ([#480](https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/480/console).
2. Deploy ([#1206](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/1206/console)).
3. Confirm successful deploy (https://dev.cep.tacc.utexas.edu).

## Notes

All the changed code has been part of a placeholder solution which will be revisited in [FP-1487](https://jira.tacc.utexas.edu/browse/FP-1487).
