### PR TITLE
chore(python): support 3.8.N+ base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.12-buster as python-base
+FROM python:3.8-buster as python-base
 
 LABEL maintainer="TACC-ACI-WMA <wma_prtl@tacc.utexas.edu>"
 


### PR DESCRIPTION
## Overview

> Would recommend changing line 1 of [Dockerfile] to:
> `FROM python:3.8-buster as python-base`
> 
> in order to always pick up patch versions of 3.8 on new builds
> — [Sal in PR #448](https://github.com/TACC/Core-CMS/pull/448/files/394751dd3bcd98c5622a76d92b96aaf4bce899a9#r833424225)
