### PR TITLE
wip-feat(fp-1487): pythonic app template load

### DIFF
--- a/taccsite_cms/bin/get_dirs_as_app_names.py
+++ b/taccsite_cms/bin/get_dirs_as_app_names.py
@@ -1,0 +1,23 @@
+import os
+
+# Convert directories under given path to a list of app names
+def get_dirs_as_app_names(path):
+    sep = os.path.sep
+    names = []
+
+    for entry in os.scandir(path):
+        is_app = entry.path.find('_readme') == -1
+
+        if entry.is_dir() and is_app:
+            name = entry.path
+
+            # Remove root directory in containers
+            name = name.replace(sep + 'code' + sep, '')
+            # Remove root directory in non-container deploys
+            name = name.replace(sep + 'srv' + sep + 'taccsite' + sep, '')
+            # Convert path to app name
+            name = name.replace(sep, '.')
+
+            names.append(name)
+
+    return names

--- a/taccsite_cms/templates/README.md
+++ b/taccsite_cms/templates/README.md
@@ -2,15 +2,17 @@
 
 All templates specific to the Core CMS __must__ be placed in this directory (or child directories).
 
-> __Remember__: Changes to a template require a server restart to take effect. Changes to secrets (which trigger a reload of `settings.py`) will restart the server.
-
 ## Page Templates
 
-To make certain templates available as page templates for CMS editors, update `CMS_TEMPLATES` secret.
+To make certain templates available as page templates for CMS editors, update `CMS_TEMPLATES` setting.
 
 ## Overwrite Apps or Plugins
 
-To overwrite the templates of any other app (e.g. the `django` CMS, the `djangocms_blog` plugin), add them here _within_ a namespaced directory that has the same structure and file names of the app code. See [How to override Django-CMS templates](https://stackoverflow.com/a/39099777/11817077).
+1. Create sub-directory named the same as the Python module directory of the app/plugin.
+2. Create a template of the same name as the app/plugin template to overwrite.
+3. Replace or extend the content of the overwritten template.
+
+To learn more, see [How to override Django-CMS templates](https://stackoverflow.com/a/39099777/11817077).
 
 ### Examples
 


### PR DESCRIPTION
## Overview

Make template overwrites not require adding new entry to `CMS_TEMPLATES`.

## Related

- [FP-1487](https://jira.tacc.utexas.edu/browse/FP-1487)
- coupled with https://github.com/TACC/Core-CMS-Resources/pull/139

## Changes

- abstract the function that gets CMS app names from file system
- update documentation
- in `TEMPLATES`, replace `loaders ` with `'APP_DIRS': True`

## Testing

1. …

## Screenshots

…

## Notes

This didn't work. I thought it was easy. Guess not. This PR is for reference.
