### PR TITLE
feat(fp-1648): only build css files

### DIFF
--- a/bin/build-css-via-cli.js
+++ b/bin/build-css-via-cli.js
@@ -52,7 +52,7 @@ function _build( name, path, configs, id ) {
   console.log(`Building "${name}" styles:`);
   cmd.runSync(`
     core-styles build\
-    --input "${ROOT}/${path}/src"\
+    --input "${ROOT}/${path}/src/**/*.css"\
     --output "${ROOT}/${path}/build"\
     --custom-configs ${configValues}\
     --build-id "${id}"\


### PR DESCRIPTION
## Overview

Fix styles build failure by updating input path in styles build command.

<details><summary>How did this happen?</summary>

#489 test case was not specific enough. If first build is not cleared, and second build fails, number of files built is the same. Test case did not mention clearing first build nor checking for build errors.

</details>

## Related

- [FP-1648](https://jira.tacc.utexas.edu/browse/FP-1648)
- fixes https://github.com/TACC/Core-CMS/pull/489

## Changes

- change `--input` path to only include CSS files (not include everything)

## Testing

```
npm ci
npm run build
```

1. See how many stylesheets are built on `v3.7.0` tag:
    - `git checkout v3.7.0`
    - `npm ci`
    - `npm run build`
    - `find taccsite_cms/static/site_cms/css/build -type f | wc -l`
1. Clear CSS build output:
    - `rm -rf taccsite_cms/static/site_cms/css/build`
    - `git restore taccsite_cms/static/site_cms/css/build/README.md` — ℹ️  this file is committed
3. See how many stylesheets are built on __this__ branch:
    - `git checkout fix/fp-1648-build-only-css-files`
    - `npm ci`
    - `npm run build` — ❗️ verify **no error** occurs
    - `find taccsite_cms/static/site_cms/css/build -type f | wc -l`
4. Verify same number of files is output as before this PR.

## Screenshots

Yes, more local files are processed (because #482), but the output is the same, `29`, and __the build does not fail__.

| first build count |  second build count |
| - | - |
| ![v3 7 0 aka a3e518b](https://user-images.githubusercontent.com/62723358/171467908-0b66976a-eff1-49f6-9bea-37c890fd03fb.png) | ![fix:fp-1648-build-only-css-files](https://user-images.githubusercontent.com/62723358/171467901-a119abeb-2e72-43ed-bb7f-f37688f1b837.png) |
