### PR TITLE
TUP-271: Use Core-Styles from TUP-UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Sign your commits ([see this link](https://help.github.com/en/github/authenticat
 [Core Portal Deployments]: https://github.com/TACC/Core-Portal-Deployments
 [Camino]: https://github.com/TACC/Camino
 [Core CMS]: https://github.com/TACC/Core-CMS
-[Core Styles]: https://github.com/TACC/Core-Styles
+[Core Styles]: https://github.com/TACC/tup-ui/tree/main/libs/core-styles
 [Core CMS Resources]: https://github.com/TACC/Core-CMS-Resources
 [Core Portal]: https://github.com/TACC/Core-Portal
 [1]: https://docs.docker.com/get-docker/

--- a/bin/build-css-via-cli.js
+++ b/bin/build-css-via-cli.js
@@ -52,7 +52,7 @@ function _build( name, path, configs, id ) {
   console.log(`Building "${name}" styles:`);
   cmd.runSync(`
     core-styles build\
-    --input "${ROOT}/${path}/src"\
+    --input "${ROOT}/${path}/src/**/*.css"\
     --output "${ROOT}/${path}/build"\
     --custom-configs ${configValues}\
     --build-id "${id}"\

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "^0.6.0-alpha.2",
+        "@tacc/core-styles": "^0.6.0-beta",
         "minimist": "^1.2.6",
         "node-cmd": "^5.0.0"
       },
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-alpha.2.tgz",
-      "integrity": "sha512-0mNOraMAzVUj+w/8h/mLSJutc4xK0tlohUATybYEzFLJOEr+pWpejRlq3aWmWhEVvb/gpPp9plaEvEb9sOkABA==",
+      "version": "0.6.0-beta",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.tgz",
+      "integrity": "sha512-y8AGbm5LnPxsBBJCwnV9fTDpGthAidkKD2n/BUIziUnB4c9zHI1WKdKI3a2lM5dNq3vzOFVgGWmhW0xEZFnk+Q==",
       "dev": true,
       "dependencies": {
         "commander": "^9.0.0",
@@ -3938,9 +3938,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.6.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-alpha.2.tgz",
-      "integrity": "sha512-0mNOraMAzVUj+w/8h/mLSJutc4xK0tlohUATybYEzFLJOEr+pWpejRlq3aWmWhEVvb/gpPp9plaEvEb9sOkABA==",
+      "version": "0.6.0-beta",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.tgz",
+      "integrity": "sha512-y8AGbm5LnPxsBBJCwnV9fTDpGthAidkKD2n/BUIziUnB4c9zHI1WKdKI3a2lM5dNq3vzOFVgGWmhW0xEZFnk+Q==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "^0.6.0-alpha",
+        "@tacc/core-styles": "^0.6.0-alpha.2",
         "minimist": "^1.2.6",
         "node-cmd": "^5.0.0"
       },
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.6.0-alpha",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-alpha.tgz",
-      "integrity": "sha512-lpuDxcHN9FyrJmSM2if2aPohDUmjb+iQQy5wMsODSuiYE4Z2eF196VqPNMacoVQrErvASUhrSOyH3fWV8AXXKw==",
+      "version": "0.6.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-alpha.2.tgz",
+      "integrity": "sha512-0mNOraMAzVUj+w/8h/mLSJutc4xK0tlohUATybYEzFLJOEr+pWpejRlq3aWmWhEVvb/gpPp9plaEvEb9sOkABA==",
       "dev": true,
       "dependencies": {
         "commander": "^9.0.0",
@@ -3938,9 +3938,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.6.0-alpha",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-alpha.tgz",
-      "integrity": "sha512-lpuDxcHN9FyrJmSM2if2aPohDUmjb+iQQy5wMsODSuiYE4Z2eF196VqPNMacoVQrErvASUhrSOyH3fWV8AXXKw==",
+      "version": "0.6.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-alpha.2.tgz",
+      "integrity": "sha512-0mNOraMAzVUj+w/8h/mLSJutc4xK0tlohUATybYEzFLJOEr+pWpejRlq3aWmWhEVvb/gpPp9plaEvEb9sOkABA==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "^0.5.1",
+        "@tacc/core-styles": "^0.6.0-alpha",
         "minimist": "^1.2.6",
         "node-cmd": "^5.0.0"
       },
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.5.1.tgz",
-      "integrity": "sha512-RZNNfgzydXhsAtLANiKOEkLXYcI2saoKKawOscRdvn98y27of0yFOnLOsLroHJTUy/x5kaAduUr3/5tQPLQH6Q==",
+      "version": "0.6.0-alpha",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-alpha.tgz",
+      "integrity": "sha512-lpuDxcHN9FyrJmSM2if2aPohDUmjb+iQQy5wMsODSuiYE4Z2eF196VqPNMacoVQrErvASUhrSOyH3fWV8AXXKw==",
       "dev": true,
       "dependencies": {
         "commander": "^9.0.0",
@@ -3938,9 +3938,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.5.1.tgz",
-      "integrity": "sha512-RZNNfgzydXhsAtLANiKOEkLXYcI2saoKKawOscRdvn98y27of0yFOnLOsLroHJTUy/x5kaAduUr3/5tQPLQH6Q==",
+      "version": "0.6.0-alpha",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-alpha.tgz",
+      "integrity": "sha512-lpuDxcHN9FyrJmSM2if2aPohDUmjb+iQQy5wMsODSuiYE4Z2eF196VqPNMacoVQrErvASUhrSOyH3fWV8AXXKw==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "git+https://git@github.com/TACC/Core-Styles.git#v0.5.0",
+        "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?tup-starter-nx--core-styles-integration",
         "minimist": "^1.2.6",
         "node-cmd": "^5.0.0"
       },
@@ -63,8 +63,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "3.0.0",
-      "resolved": "git+https://git@github.com/TACC/Core-Styles.git#17cfd7c62f03f619f23feb2fb8ad1a1e1428a390",
+      "version": "0.5.1",
+      "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?tup-starter-nx--core-styles-integration",
+      "integrity": "sha512-Q+vox5U3/y78taZv30IOM2t5MLpMvbw7cwYoySCybmFFIc78UJ0xNuBzI/Tdqv+bT2kLEP69nLy4rc8RwcjdIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -80,7 +81,7 @@
         "postcss-preset-env": "^6.7.0"
       },
       "bin": {
-        "core-styles": "cli.js"
+        "core-styles": "src/cli.js"
       },
       "engines": {
         "node": ">=15.x",
@@ -3938,9 +3939,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+https://git@github.com/TACC/Core-Styles.git#17cfd7c62f03f619f23feb2fb8ad1a1e1428a390",
+      "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?tup-starter-nx--core-styles-integration",
+      "integrity": "sha512-Q+vox5U3/y78taZv30IOM2t5MLpMvbw7cwYoySCybmFFIc78UJ0xNuBzI/Tdqv+bT2kLEP69nLy4rc8RwcjdIg==",
       "dev": true,
-      "from": "@tacc/core-styles@git+https://git@github.com/TACC/Core-Styles.git#v0.5.0",
       "requires": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "git+https://git@github.com/TACC/Core-Styles.git#v0.5.0",
+    "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?tup-starter-nx--core-styles-integration",
     "minimist": "^1.2.6",
     "node-cmd": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "^0.6.0-alpha.2",
+    "@tacc/core-styles": "^0.6.0-beta",
     "minimist": "^1.2.6",
     "node-cmd": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "^0.6.0-alpha",
+    "@tacc/core-styles": "^0.6.0-alpha.2",
     "minimist": "^1.2.6",
     "node-cmd": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "^0.5.1",
+    "@tacc/core-styles": "^0.6.0-alpha",
     "minimist": "^1.2.6",
     "node-cmd": "^5.0.0"
   },

--- a/taccsite_cms/static/site_cms/css/.postcssrc.yml
+++ b/taccsite_cms/static/site_cms/css/.postcssrc.yml
@@ -5,9 +5,8 @@ plugins:
     # In any source file, every @import path, not prepended with "./" nor "../",
     # is relative to only one of these directories in this order.
     path:
-      - 'taccsite_cms/static/site_cms/css/src' # TACC/Core-CMS
-      - 'node_modules/@tacc/core-styles/source' # TACC/Core-Styles
-      - 'node_modules/@tacc/core-styles/src/lib' # TACC/tup-ui:/libs/core-styles
+      - 'taccsite_cms/static/site_cms/css/src' # Core-CMS CSS source files
+      - 'node_modules/@tacc/core-styles/src/lib' # Core-Styles CSS source files
   postcss-env-function:
     importFrom:
       - 'node_modules/@tacc/core-styles/src/lib/_themes/default.json'

--- a/taccsite_cms/static/site_cms/css/.postcssrc.yml
+++ b/taccsite_cms/static/site_cms/css/.postcssrc.yml
@@ -5,8 +5,9 @@ plugins:
     # In any source file, every @import path, not prepended with "./" nor "../",
     # is relative to only one of these directories in this order.
     path:
-      - 'taccsite_cms/static/site_cms/css/src' # Core-CMS CSS source files
-      - 'node_modules/@tacc/core-styles/source' # Core-Styles CSS source files
+      - 'taccsite_cms/static/site_cms/css/src' # TACC/Core-CMS
+      - 'node_modules/@tacc/core-styles/source' # TACC/Core-Styles
+      - 'node_modules/@tacc/core-styles/src/lib' # TACC/tup-ui:/libs/core-styles
   postcss-env-function:
     importFrom:
-      - 'node_modules/@tacc/core-styles/source/_themes/default.json'
+      - 'node_modules/@tacc/core-styles/src/lib/_themes/default.json'

--- a/taccsite_cms/static/site_cms/css/README.md
+++ b/taccsite_cms/static/site_cms/css/README.md
@@ -17,4 +17,4 @@ See [repo `README.md` at "Static Files"](/README.md#static-files).
 
 [Core CMS]: https://github.com/TACC/Core-CMS
 [Core CMS Resources]: https://github.com/TACC/Core-CMS-Resources
-[Core Styles]: https://github.com/TACC/Core-Styles
+[Core Styles]: https://github.com/TACC/tup-ui/tree/main/libs/core-styles

--- a/taccsite_cms/static/site_cms/css/src/README.md
+++ b/taccsite_cms/static/site_cms/css/src/README.md
@@ -52,4 +52,4 @@ _This directory exists in `static/` __only__ because it is customary, using Djan
 
 <!-- Link Aliases -->
 
-[Core Styles]: https://github.com/TACC/Core-Styles
+[Core Styles]: https://github.com/TACC/tup-ui/tree/main/libs/core-styles

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -9,7 +9,7 @@ Reference:
 
 Styleguide Components.DjangoCMS.Blog.App
 */
-@import url("@tacc/core-styles/source/_imports/components/bootstrap.pagination.css");
+@import url("@tacc/core-styles/src/lib/_imports/components/bootstrap.pagination.css");
 
 @import url("./django.cms.blog.app.page.css");
 @import url("./django.cms.blog.app.item.css");

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -7,8 +7,8 @@ Reference:
 
 Styleguide Components.DjangoCMS.Blog.App.Item
 */
-@import url("@tacc/core-styles/source/_imports/tools/x-article-link.css");
-@import url("@tacc/core-styles/source/_imports/tools/x-truncate.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-article-link.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-truncate.css");
 
 @import url("_imports/tools/selectors.css");
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
@@ -1,4 +1,4 @@
-@import url("@tacc/core-styles/source/_imports/settings/color.css");
+@import url("@tacc/core-styles/src/lib/_imports/settings/color.css");
 
 :root {
   /* CAVEAT: A standard accent color definition is pending more designs */

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/font.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/font.css
@@ -1,4 +1,4 @@
-@import url("@tacc/core-styles/source/_imports/settings/font.css");
+@import url("@tacc/core-styles/src/lib/_imports/settings/font.css");
 
 :root {
   --global-font-family--sans: "Benton Sans", "Roboto", sans-serif;

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/space.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/space.css
@@ -1,4 +1,4 @@
-@import url("@tacc/core-styles/source/_imports/settings/space.css");
+@import url("@tacc/core-styles/src/lib/_imports/settings/space.css");
 
 :root {
   --global-space--hr-margin: 30px;     /* constant unit allows consistency */

--- a/taccsite_cms/templates/snippets/manual-pattern-library/c-callout.html
+++ b/taccsite_cms/templates/snippets/manual-pattern-library/c-callout.html
@@ -1,1 +1,1 @@
-../../../../node_modules/@tacc/core-styles/source/_imports/components/c-callout.html
+../../../../node_modules/@tacc/core-styles/src/lib/_imports/components/c-callout.html

--- a/taccsite_cms/templates/snippets/manual-pattern-library/c-nav.content.html
+++ b/taccsite_cms/templates/snippets/manual-pattern-library/c-nav.content.html
@@ -1,1 +1,1 @@
-../../../../node_modules/@tacc/core-styles/source/_imports/components/c-nav.html
+../../../../node_modules/@tacc/core-styles/src/lib/_imports/components/c-nav.html

--- a/taccsite_cms/templates/snippets/manual-pattern-library/o-grid.content.html
+++ b/taccsite_cms/templates/snippets/manual-pattern-library/o-grid.content.html
@@ -1,1 +1,1 @@
-../../../../node_modules/@tacc/core-styles/source/_imports/objects/o-grid.html
+../../../../node_modules/@tacc/core-styles/src/lib/_imports/objects/o-grid.html

--- a/taccsite_cms/templates/snippets/manual-pattern-library/o-section.content.html
+++ b/taccsite_cms/templates/snippets/manual-pattern-library/o-section.content.html
@@ -1,1 +1,1 @@
-../../../../node_modules/@tacc/core-styles/source/_imports/objects/o-section.html
+../../../../node_modules/@tacc/core-styles/src/lib/_imports/objects/o-section.html


### PR DESCRIPTION
## Overview

Load core styles from new monorepo instead of recent standalone repo.

### Background

For TUP, a monorepo ([TACC/tup-ui](https://github.com/TACC/tup-ui/)) houses core styles, core components, and new UI client.

## Related

- [TUP-271](https://jira.tacc.utexas.edu/browse/TUP-271)
- mimics https://github.com/TACC/Core-Portal/pull/651

## Changes

- load `@tacc/core-styles` from [TACC/tup-ui:/libs/core-styles](https://github.com/TACC/tup-ui/tree/tup-starter-nx--core-styles-integration/libs/core-styles) instead of [TACC/Core-Styles](https://github.com/TACC/Core-Styles)
- update paths to stylesheets
- update symlinks to sample markup

## Testing

See [How to Test Core-Styles Version Change](https://github.com/TACC/Core-CMS/wiki/How-to-Test-Core-Styles-Version-Change).

## Screenshots

[`TUP-271-cms.log`](https://github.com/TACC/Core-CMS/files/8970388/TUP-271-cms.log)

| first build count |  second build count |
| - | - |
| ![main](https://user-images.githubusercontent.com/62723358/175384637-19b5be03-62f2-40fa-a57f-4e39c708f33b.png) | ![tup-271](https://user-images.githubusercontent.com/62723358/175384643-6a0de50e-fe58-40b8-bf79-0ac79abd0444.png) |