### PR TITLE
feat: install core-styles via npm at v0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "git+https://git@github.com/TACC/Core-Styles.git#v0.5.0",
+        "@tacc/core-styles": "^0.5.1",
         "minimist": "^1.2.6",
         "node-cmd": "^5.0.0"
       },
@@ -63,10 +63,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "3.0.0",
-      "resolved": "git+https://git@github.com/TACC/Core-Styles.git#17cfd7c62f03f619f23feb2fb8ad1a1e1428a390",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.5.1.tgz",
+      "integrity": "sha512-RZNNfgzydXhsAtLANiKOEkLXYcI2saoKKawOscRdvn98y27of0yFOnLOsLroHJTUy/x5kaAduUr3/5tQPLQH6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -3938,9 +3938,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+https://git@github.com/TACC/Core-Styles.git#17cfd7c62f03f619f23feb2fb8ad1a1e1428a390",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.5.1.tgz",
+      "integrity": "sha512-RZNNfgzydXhsAtLANiKOEkLXYcI2saoKKawOscRdvn98y27of0yFOnLOsLroHJTUy/x5kaAduUr3/5tQPLQH6Q==",
       "dev": true,
-      "from": "@tacc/core-styles@git+https://git@github.com/TACC/Core-Styles.git#v0.5.0",
       "requires": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "git+https://git@github.com/TACC/Core-Styles.git#v0.5.0",
+    "@tacc/core-styles": "^0.5.1",
     "minimist": "^1.2.6",
     "node-cmd": "^5.0.0"
   },


### PR DESCRIPTION
## Overview

Install `@tacc/core-styles` from NPM.

## Related

- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- mirrors https://github.com/TACC/Core-Portal/pull/653
- required by https://github.com/TACC/Core-CMS/pull/495

## Changes

- re-install `core-styles` (same version, but via npm)
- update `core-styles` to [v0.5.1](https://github.com/TACC/Core-Styles/releases/tag/v0.5.1) (no functional change)


## Testing

1. `npm run build` does not fail.

## Screenshots

N/A