### PR TITLE
chore(core-styles): build css via JS not CLI

### DIFF
--- a/bin/build-css.js
+++ b/bin/build-css.js
@@ -3,7 +3,7 @@
 /** Build CSS using the Core-Styles CLI */
 
 const fs = require('fs');
-const cmd = require('node-cmd');
+const buildStylesheets = require('@tacc/core-styles').buildStylesheets;
 const mininmist = require('minimist');
 
 const ROOT = __dirname + '/..';
@@ -50,14 +50,14 @@ function _build( name, path, configs, id ) {
 
   console.log(`Overriding config with:`, configs );
   console.log(`Building "${name}" styles:`);
-  cmd.runSync(`
-    core-styles build\
-    --input "${ROOT}/${path}/src/**/*.css"\
-    --output "${ROOT}/${path}/build"\
-    --custom-configs ${configValues}\
-    --build-id "${id}"\
-    --verbose\
-  `);
+  buildStylesheets(
+    `${ROOT}/${path}/src/**/*.css`,
+    `${ROOT}/${path}/build`, {
+      customConfigs: configs,
+      verbose: true,
+      buildId: id
+    }
+  );
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@tacc/core-styles": "^0.5.1",
-        "minimist": "^1.2.6",
-        "node-cmd": "^5.0.0"
+        "minimist": "^1.2.6"
       },
       "engines": {
         "node": "^17.8.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": "git@github.com:TACC/Core-CMS.git",
   "scripts": {
-    "build": "bin/build-css-via-cli.js --project=$npm_config_project --build-id=$npm_config_build_id"
+    "build": "bin/build-css.js --project=$npm_config_project --build-id=$npm_config_build_id"
   },
   "homepage": "https://github.com/TACC/Core-CMS"
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   },
   "devDependencies": {
     "@tacc/core-styles": "^0.5.1",
-    "minimist": "^1.2.6",
-    "node-cmd": "^5.0.0"
+    "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",
   "scripts": {


### PR DESCRIPTION
## Overview

Remove extraneous dependency by using Core-Styles Node module, not CLI.

## Related

- inspired by [TUP-274](https://jira.tacc.utexas.edu/browse/TUP-274)

## Changes

- remove devDependency `node-cmd`
- change how Core-Styles is used (Node module, not CLI)

## Testing

Ensure `npm run build` still works e.g.

0. Checkout `main`.
1. Comment [`.gitignore`'s `build`](https://github.com/TACC/Core-CMS/blob/7b62db1/.gitignore#L15).
2. Delete `taccssite_cms/static/site_cms/css/build`.
3. Build `npm run build --project=frontera-cms`.
4. Stage `taccssite_cms/static/css/build`.
5. Checkout `quick/remove-need-for-node-cmd-dep`.
6. Build `npm run build --project=frontera-cms`.
7. Verify no un-staged changes (besides `.gitignore`).

## Screenshots

<img width="1280" alt="Screen Shot 2022-06-23 at 13 49 05" src="https://user-images.githubusercontent.com/62723358/175375188-df6a4d9a-5b0c-4f32-9883-bc022e3dc5bf.png">