### PR TITLE
V3.6.0/form plugin fixes

### DIFF
--- a/taccsite_cms/_settings/form_plugin.py
+++ b/taccsite_cms/_settings/form_plugin.py
@@ -113,3 +113,14 @@ _INSTALLED_APPS = [
     'django.forms',            # support form template override
     'captcha',                 # support recaptcha for djangocms_forms
 ]
+
+########################
+# DJANGO: RECAPTCHA
+########################
+
+# To properly avoid client error about using test keys
+# RECAPTCHA_PUBLIC_KEY = '__this_must_be_on_server_not_here__'
+# RECAPTCHA_SECRET_KEY = '__this_must_be_on_server_not_here__'
+
+# To silence server error about using test keys
+# SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
@@ -64,6 +64,16 @@ p.help-text:last-child {
   margin-bottom: 0; /* overwrite forms.css label */
 }
 
+:root {
+  /* TUP-271: Add to & Import from @core-styles */
+  /* https://github.com/TACC/tup-ui/blob/c5454ba/libs/core-styles/src/lib/_imports/settings/color.css */
+  --global-color-danger--dark: #ab1717;
+}
+.asterisk {
+  margin-left: 0.5em;
+  color: var(--global-color-danger--dark);
+}
+
 
 
 /* Errors */

--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/form.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/form.css
@@ -13,7 +13,6 @@ Reference:
 
 Styleguide Elements.Forms
 */
-@import url("_imports/tools/media-queries.css");
 
 form {
   font-family: var(--global-font-family--sans-alt);

--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/form.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/form.css
@@ -38,7 +38,16 @@ textarea {
   padding: 15px 10px;
   border: var(--global-border--normal);
 }
-
+input:not(
+  [type="time"],
+  [type="date"],
+  [type="checkbox"],
+  [type="radio"]
+),
+select,
+textarea {
+  width: 100%;
+}
 input[type="time"],
 input[type="date"] {
   font-family: var(--global-font-family--mono);

--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/form.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/form.css
@@ -13,6 +13,7 @@ Reference:
 
 Styleguide Elements.Forms
 */
+@import url("_imports/tools/media-queries.css");
 
 form {
   font-family: var(--global-font-family--sans-alt);
@@ -35,7 +36,6 @@ fieldset:not(:last-child) {
 input,
 select,
 textarea {
-  padding: 15px 10px;
   border: var(--global-border--normal);
 }
 input:not(
@@ -51,4 +51,19 @@ textarea {
 input[type="time"],
 input[type="date"] {
   font-family: var(--global-font-family--mono);
+}
+
+@media (pointer: coarse) {
+  input,
+  select,
+  textarea {
+    padding: 15px 10px;
+  }
+}
+@media (pointer: fine), (pointer: none) {
+  input,
+  select,
+  textarea {
+    padding: 5px 10px;
+  }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
@@ -1,0 +1,13 @@
+@import url("@tacc/core-styles/source/_imports/settings/color.css");
+
+:root {
+  /* Accent Hues */
+  --global-color-accent--x-light: #F2DFBD; /* originally #e3d7fd */
+  --global-color-accent--light: #BDA374;   /* originally #a387ed */
+  --global-color-accent--normal: #877453;  /* originally #784fe8 */
+  --global-color-accent--dark: #64563E;    /* originally #6039cc */
+  --global-color-accent--x-dark: #403014;  /* originally #3d189b */
+
+  --global-color-accent--alt: #E0D8C9;     /* originally #d2cce7 */
+  --global-color-accent--weak: #9D702140;  /* originally #6039cc40 */
+}

--- a/taccsite_cms/templates/djangocms_forms/form_template/default.html
+++ b/taccsite_cms/templates/djangocms_forms/form_template/default.html
@@ -24,7 +24,7 @@
 						{{ field }}
 					{% endif %}
 					<label for="{{ field.id_for_label }}">
-						{{ field.label }}{% if field|is_required %}<span class="asterisk">*</span>{% endif %}
+						{{ field.label }}{% if field|is_required %}<span class="asterisk">(required)</span>{% endif %}
 					</label>
 					{% if not field|is_checkbox %}
 						{{ field }}


### PR DESCRIPTION
## Overview

Miscellaneous bug fixes and updates for form plugin.

## Related
- [FP-1700](https://jira.tacc.utexas.edu/browse/FP-1700)
- [TUP-285](https://jira.tacc.utexas.edu/browse/TUP-285)
- builds off https://github.com/TACC/Core-CMS/pull/500
- referenced by https://github.com/TACC/Core-CMS/pull/498

## Changes

See commit messages.

## Testing

| website | status | notes |
| - | :-: | - |
| [frontera (pprd)](https://pprd.frontera-portal.tacc.utexas.edu/test/tup-230-form-plugin/) | ✓ |
| [core (dev)](https://dev.cep.tacc.utexas.edu/test/tup-230-form-plugin/?edit_off=true) | ✓ |
| [apcd (pprd)](https://apcd-qa.tacc.utexas.edu/test/tup-230-form-plugin/) | ✓ |
| tup (dev) | ⓧ | pending [FP-1700](https://jira.tacc.utexas.edu/browse/FP-1700) to appropriately prevent [deploy failure](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/1556/) |

1. Load a form.
2. Verify required fields have red " (required)" (and not an asterisk).
3. Verify all fields are 100% width **except**:
    - checkbox
    - radio
    - date
    - time
4. Verify field height is based on pointer accuracy.
    ([Test device with touch control versus without.](https://developer.chrome.com/docs/devtools/device-mode/#type))
    - touch-controlled device should have **tall** fields
    - **not**-touch-controlled device should have **short** fields

## Screenshots

| Desktop i.e. No Touch | Mobile i.e. Touch |
| - | - |
| ![TUP-285 Desktop i e  No Touch](https://user-images.githubusercontent.com/62723358/175103180-a7a3a1ce-20f8-4c2c-9cb1-85d1ba2f22b3.jpeg) | ![TUP-285 Mobile i e  Touch](https://user-images.githubusercontent.com/62723358/175103182-4e63563c-7067-4904-b8ca-5498ad3c8366.jpeg) |

## Notes

The missing space below footer is a known issue. It is solved in v3.7.0 (not deployed) but also has a bug to fix (not started).