### PR TITLE
After/tup 271  fp 1663 system spec figure styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Sign your commits ([see this link](https://help.github.com/en/github/authenticat
 
 
 <!-- Link Aliases -->
- 
+
 [Core Portal Deployments]: https://github.com/TACC/Core-Portal-Deployments
 [Camino]: https://github.com/TACC/Camino
 [Core CMS]: https://github.com/TACC/Core-CMS

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Sign your commits ([see this link](https://help.github.com/en/github/authenticat
 
 
 <!-- Link Aliases -->
-
+ 
 [Core Portal Deployments]: https://github.com/TACC/Core-Portal-Deployments
 [Camino]: https://github.com/TACC/Camino
 [Core CMS]: https://github.com/TACC/Core-CMS

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "^0.6.0-beta",
+        "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -63,9 +63,10 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.tgz",
-      "integrity": "sha512-y8AGbm5LnPxsBBJCwnV9fTDpGthAidkKD2n/BUIziUnB4c9zHI1WKdKI3a2lM5dNq3vzOFVgGWmhW0xEZFnk+Q==",
+      "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
+      "integrity": "sha512-mKHInCb1UIWhnlbny1BrtVqHLo1zckDtEqW+uAW8r3ReCa8e6W/7xYMb1yZnRFI/SzxUT51VrRgQ0gFMJm8sBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -3937,9 +3938,8 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.tgz",
-      "integrity": "sha512-y8AGbm5LnPxsBBJCwnV9fTDpGthAidkKD2n/BUIziUnB4c9zHI1WKdKI3a2lM5dNq3vzOFVgGWmhW0xEZFnk+Q==",
+      "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
+      "integrity": "sha512-mKHInCb1UIWhnlbny1BrtVqHLo1zckDtEqW+uAW8r3ReCa8e6W/7xYMb1yZnRFI/SzxUT51VrRgQ0gFMJm8sBg==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?after/styles-version-bump--fp-1663-system-spec-figure-styles",
+        "@tacc/core-styles": "^0.6.0-beta.1",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -62,11 +62,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.6.0-beta",
-      "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?after/styles-version-bump--fp-1663-system-spec-figure-styles",
-      "integrity": "sha512-aod8ldBP40ZhOtB+GwDMvodiJfGJ5yIhFYFHgYChowvfuk3nfprYHkXh200nvMBn6q0xcTMiEBga6SRw0RQiag==",
+      "version": "0.6.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.1.tgz",
+      "integrity": "sha512-QJ0fMG2lBk46LOoKhkdFjaoPQGwKuzk6ExxkR8mfq5wYD0QqngbkJ5xt7/haYhS7Sgv2No0zekaWOWaLEO/K4Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -3938,8 +3937,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?after/styles-version-bump--fp-1663-system-spec-figure-styles",
-      "integrity": "sha512-aod8ldBP40ZhOtB+GwDMvodiJfGJ5yIhFYFHgYChowvfuk3nfprYHkXh200nvMBn6q0xcTMiEBga6SRw0RQiag==",
+      "version": "0.6.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.1.tgz",
+      "integrity": "sha512-QJ0fMG2lBk46LOoKhkdFjaoPQGwKuzk6ExxkR8mfq5wYD0QqngbkJ5xt7/haYhS7Sgv2No0zekaWOWaLEO/K4Q==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
+        "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?after/styles-version-bump--fp-1663-system-spec-figure-styles",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -63,8 +63,8 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.6.0-beta",
-      "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
-      "integrity": "sha512-kA9Etyd+mdJsxjbGwB9B2RvIwPeqyb8h1UUMzolmKh7z6KGXEF7YST+5TpT/qVapv6xM5p2pd85PSzNCzp3aYQ==",
+      "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?after/styles-version-bump--fp-1663-system-spec-figure-styles",
+      "integrity": "sha512-aod8ldBP40ZhOtB+GwDMvodiJfGJ5yIhFYFHgYChowvfuk3nfprYHkXh200nvMBn6q0xcTMiEBga6SRw0RQiag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3938,8 +3938,8 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
-      "integrity": "sha512-kA9Etyd+mdJsxjbGwB9B2RvIwPeqyb8h1UUMzolmKh7z6KGXEF7YST+5TpT/qVapv6xM5p2pd85PSzNCzp3aYQ==",
+      "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?after/styles-version-bump--fp-1663-system-spec-figure-styles",
+      "integrity": "sha512-aod8ldBP40ZhOtB+GwDMvodiJfGJ5yIhFYFHgYChowvfuk3nfprYHkXh200nvMBn6q0xcTMiEBga6SRw0RQiag==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
     "node_modules/@tacc/core-styles": {
       "version": "0.6.0-beta",
       "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
-      "integrity": "sha512-mKHInCb1UIWhnlbny1BrtVqHLo1zckDtEqW+uAW8r3ReCa8e6W/7xYMb1yZnRFI/SzxUT51VrRgQ0gFMJm8sBg==",
+      "integrity": "sha512-kA9Etyd+mdJsxjbGwB9B2RvIwPeqyb8h1UUMzolmKh7z6KGXEF7YST+5TpT/qVapv6xM5p2pd85PSzNCzp3aYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3939,7 +3939,7 @@
     },
     "@tacc/core-styles": {
       "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
-      "integrity": "sha512-mKHInCb1UIWhnlbny1BrtVqHLo1zckDtEqW+uAW8r3ReCa8e6W/7xYMb1yZnRFI/SzxUT51VrRgQ0gFMJm8sBg==",
+      "integrity": "sha512-kA9Etyd+mdJsxjbGwB9B2RvIwPeqyb8h1UUMzolmKh7z6KGXEF7YST+5TpT/qVapv6xM5p2pd85PSzNCzp3aYQ==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?after/styles-version-bump--fp-1663-system-spec-figure-styles",
+    "@tacc/core-styles": "^0.6.0-beta.1",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "^0.6.0-beta",
+    "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/0.6.0-beta--fp-1663-system-spec-figure-styles",
+    "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?after/styles-version-bump--fp-1663-system-spec-figure-styles",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -17,7 +17,6 @@
 
 /* ELEMENTS */
 /* Bootstrap performs much of this */
-@import url("_imports/elements/figure.css");
 @import url("_imports/elements/html-elements.css");
 /* Load custom element styles within custom element, not here */
 


### PR DESCRIPTION
## Overview

Prevent `<figure>` element styles from bleeding into other patterns e.g. `.s-system-specs`.

## Related

- [FP-1663](https://jira.tacc.utexas.edu/browse/FP-1663)
- builds off https://github.com/TACC/Core-CMS/pull/495
- requires https://github.com/TACC/tup-ui/pull/17
  __<sup>please review even if merged;</sup>__ <sup>it is a beta version change merged into a testing branch<sup>[^2]

## Changes

- do not load `<figure>` element styles
- load core-styles at https://github.com/TACC/tup-ui/pull/17

## Testing & Screenshots

| server | page |
| - | - |
| frontera | https://dev.fronteraweb.tacc.utexas.edu/system/ |
| cep | https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/c-callout/ |
| cep | https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/bootstrap-figure/ |

<details><summary>1. Verify System Monitor <code>&lt;figure&gt;</code> does <strong>not</strong> receive TACC styles.</summary>

_The System Monitor is within a `<figcaption>` for the server rack image which is within a `<figure>`._

1. Load [frontera system page].
2. Find the System Monitor (at the bottom of the server rack image).
3. Verify it does **not** receive TACC styles for Bootstrap Figure caption[^1].

![elements stand-alone](https://user-images.githubusercontent.com/62723358/175698711-a714a64b-3379-4566-8083-2bf0fd148f60.png)

</details>
<details><summary>2. Verify stand-alone Bootstrap Figure plugin <strong>still</strong> receives TACC styles.</summary>

_TACC now styles the Bootstrap Figure, but not bare `<figure>` elements._

1. Load [cep bootstrap figure page].
3. Verify `.figure` and `.figure-caption` markup receive TACC styles for Bootstrap Figure caption[^1].

![bootstrap stand-alone](https://user-images.githubusercontent.com/62723358/175698749-c2069470-d07b-4fae-9d69-fd7f59cfdcd6.png)

</details>
<details><summary>3. Verify Callout plugin instance using <code>&lt;figure&gt;</code> does <strong>not</strong> receive TACC styles.</summary>

_The Callout plugin supports visual via: Image, Picture, `<img>`, `<figure>`._

1. Load [cep callout page].
3. Verify the following patterns do **not** receive TACC styles for Bootstrap Figure caption[^1]:
    - "Link ▸ Image w/ Caption (Wide) + Text"
    - "Link ▸ Image w/ Caption (Tall) + Text"

<sup><strong>⚠️ Ugliness expected.</strong> Designers do not think they want figure captions in Callouts, so I never styled this instance further.</sup>

![elements within pattern](https://user-images.githubusercontent.com/62723358/175698780-0d1e3eef-ea0e-4155-808e-a66eb2a68836.png)

</details>
<details><summary>4. Verify Callout plugin instance using Bootstrap Figure plugin <strong>still</strong> receives TACC styles.</summary>

_The Callout plugin supports visual via `<img>` and `<figure>`._

1. Load [cep callout page].
2. Find "Media via Bootstrap Figure Plugin" pattern.
3. Verify `.figure` and `.figure-caption` markup receive TACC styles for Bootstrap Figure caption[^1].

<sup><strong>⚠️ Ugliness expected.</strong> This test is to confirm Bootstrap Figure still receives styles, in any context (even unsupported ones).</sup>

![bootstrap within pattern](https://user-images.githubusercontent.com/62723358/175698799-df1b09ea-ae25-429d-9afb-1315225e3162.png)

</details>

[^1]: The TACC styles for Bootstrap figure captions are gray text, space above text, border above space, space above border.
[^2]: I haven't mastered versioning `core-styles`, yet. Expected to be discussed in architecture meeting on 2022-07-29.

[frontera system page]: https://dev.fronteraweb.tacc.utexas.edu/system/
[cep callout page]: https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/c-callout/
[cep bootstrap figure page]: https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/bootstrap-figure/