### PR TITLE
fix: load fa icons even if no portal

### DIFF
--- a/taccsite_cms/templates/assets_site_delayed.html
+++ b/taccsite_cms/templates/assets_site_delayed.html
@@ -18,7 +18,5 @@ Consider asset load via `assets_site`, not `assets_site_delayed`:
 
 <!-- Site Assets (Delayed): Font Icons -->
 {# FAQ: Not loaded in `assets_font.html` because these is NOT font for content which should avoid FOUT, FOIT, FOFT; but decorative, thus superfluous, icons #}
-{% if settings.INCLUDES_CORE_PORTAL %}
 <!-- FP-526: Stop using Font Awesome icons; start using Cortal icons -->
 <link id="css-portal-font" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" />
-{% endif %}


### PR DESCRIPTION
## Overview

Support icons even if Portal is not active.

## Related

- [FP-1706](https://jira.tacc.utexas.edu/browse/FP-1706)

## Changes

- in template, remove portal conditional around icon load

## Testing

0. Have setting `INCLUDES_CORE_PORTAL` set to `False`.
1. Use a Font Awesome icon on a page.
2. Verify icon shows.

## Screenshots

![FP-1706](https://user-images.githubusercontent.com/62723358/175966547-3eec29f5-42ba-408d-a175-89ae5cedc4ed.png)

## Notes

We do not want FA icons, but there is at least one usage.

Usage: Frontera homepage, "(→) See All News"
