### PR TITLE
After/tup 271  fp 1666 frontera header hidden

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "^0.6.0-beta",
+        "@tacc/core-styles": "^0.6.0-beta.2",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.tgz",
-      "integrity": "sha512-y8AGbm5LnPxsBBJCwnV9fTDpGthAidkKD2n/BUIziUnB4c9zHI1WKdKI3a2lM5dNq3vzOFVgGWmhW0xEZFnk+Q==",
+      "version": "0.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.2.tgz",
+      "integrity": "sha512-aJ6KENhJdBfHdDaXLZznspFwg6yuvkB+gE8mleXXzEDQsIh5sNXs3ltIkX0R0HjfCRlFoTBgpIsFANgFd2GPxQ==",
       "dev": true,
       "dependencies": {
         "commander": "^9.0.0",
@@ -3937,9 +3937,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.tgz",
-      "integrity": "sha512-y8AGbm5LnPxsBBJCwnV9fTDpGthAidkKD2n/BUIziUnB4c9zHI1WKdKI3a2lM5dNq3vzOFVgGWmhW0xEZFnk+Q==",
+      "version": "0.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0-beta.2.tgz",
+      "integrity": "sha512-aJ6KENhJdBfHdDaXLZznspFwg6yuvkB+gE8mleXXzEDQsIh5sNXs3ltIkX0R0HjfCRlFoTBgpIsFANgFd2GPxQ==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "^0.6.0-beta",
+    "@tacc/core-styles": "^0.6.0-beta.2",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -17,7 +17,8 @@
 
 /* ELEMENTS */
 /* Bootstrap performs much of this */
-@import url("_imports/elements/figure.css");
+/* FP-1663: removed 'elements/figure.css' from @tacc/core-styles@0.6.0-beta.1 */
+/* @import url("_imports/elements/figure.css"); */
 @import url("_imports/elements/html-elements.css");
 /* Load custom element styles within custom element, not here */
 


### PR DESCRIPTION
## Overview

Fix accidentally hiding Frontera header underneath its homepage banner.

I.e. Updates `.o-section--banner` and `main` styles in `o-section.css` from Core Styles.

## Related

- [FP-1666](https://jira.tacc.utexas.edu/browse/FP-1666)
- builds off https://github.com/TACC/Core-CMS/pull/495
- requires https://github.com/TACC/tup-ui/pull/19
  __<sup>please review even if merged;</sup>__ <sup>it is a beta version change merged into a testing branch<sup>[^2]

## Changes

- load core-styles at https://github.com/TACC/tup-ui/pull/19
- prevent styles build error / do **not** load file that is deleted by @tacc/core-styles@0.6.0-beta.1

## Testing & Screenshots

| server | page |
| - | - |
| frontera | https://dev.fronteraweb.tacc.utexas.edu/ |
| cep | https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/o-section/ |

<details><summary>1. Verify banner does not cover header on Frontera homepage.</summary>

| before | after |
| - | - |
| ![frontera home page - v3 7 0](https://user-images.githubusercontent.com/62723358/176029661-8c46afe1-e0f6-40e4-b236-366d6b525390.jpeg) | ![frontera home page - fp-1666](https://user-images.githubusercontent.com/62723358/176029656-24839120-b502-47fd-b835-b68b45aa1905.jpeg) |


</details>
<details><summary>2. Verify O-Section patterns span full width of Core pattern page and Frontera home page.</summary>

1. Core [dev](https://dev.cep.tacc.utexas.edu/design-system/ui-patterns/o-section/) pattern render is unchanged from [prod](https://cep.tacc.utexas.edu/design-system/ui-patterns/o-section/) pattern render.
    - The spacing between text and sections may have changed. That is not because of this branch.
2. Verify Frontera [home](https://dev.fronteraweb.tacc.utexas.edu/) has expected styles for targeted markup:
    - the element `<main>` has style `overflow-x: clip`
    - the element `<section class="... o-section--banner ...">` has style `overflow-y: clip`

| usage | screenshot |
| - | - |
| core pattern test page | [core section patterns - fp-1666 (very tall screenshot)](https://user-images.githubusercontent.com/62723358/176029732-cf5a2424-724c-4d07-b251-df5d904bab69.jpeg) |
| frontera pattern home | [frontera home sections - fp-1666 (tall screenshot)](https://user-images.githubusercontent.com/62723358/176031201-77f345eb-b1c1-4d48-a161-dd772aa888f5.jpeg) |

The sections on Frontera are between header and footer: 1, dark grey; 2, dark grey; 3, white.

</details>

[^2]: I haven't mastered versioning `core-styles`, yet. Expected to be discussed in architecture meeting on 2022-07-29.