### PR TITLE
V3.4.0/fp 1439 yearly site theme for texascale

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -226,10 +226,9 @@ TEMPLATES = [
                 'django_settings_export.settings_export'
             ],
             'libraries': {
-                # NOTE: These are an unnecessary alternative config, because taccsite_cms is in INSTALLED_APPS, but are comfortably explicit
-                # SEE: https://docs.djangoproject.com/en/3.1/howto/custom-template-tags/#code-layout
                 'custom_portal_settings': 'taccsite_cms.templatetags.custom_portal_settings',
                 'tacc_uri_shortcuts': 'taccsite_cms.templatetags.tacc_uri_shortcuts',
+                'get_url_match': 'taccsite_cms.templatetags.get_url_match',
             },
             'loaders': [
                 'django.template.loaders.filesystem.Loader',

--- a/taccsite_cms/templatetags/get_url_match.py
+++ b/taccsite_cms/templatetags/get_url_match.py
@@ -1,0 +1,43 @@
+import re
+
+from django import template
+from urllib.parse import urlparse
+
+register = template.Library()
+
+@register.filter
+def get_url_match(path, pattern):
+    """
+    Custom Template Filter `get_url_match`
+    Use: Render string that matches given pattern from current page URL.
+    Load custom filter into template:
+        {% load get_url_match %}
+    Template inline usage:
+        {# given path '.../2019/...', does nothing #}
+        {% if path|get_url_match:"/20\d\d/" %}
+            {# condition evaluates to False #}
+        {% endif %}
+        {# given path '.../2020/...', does something #}
+        {% if path|get_url_match:"/20\d\d/" %}
+            {# condition evaluates to True #}
+        {% endif %}
+        {# given path '.../2021/...', prints complete match #}
+        {% with year_path=path|get_url_match:"/20\d\d/" %}
+            <pre>{{ year_path }}</pre> {# prints complete match #}
+        {% endwith %}
+        {# given path '.../2022/...', prints matched content #}
+        {% with year_slug=path|get_url_match:"/(20\d\d)/" %}
+            <pre>{{ year_slug }}</pre> {# prints match within the (…) #}
+        {% endwith %}
+    """
+    result = re.search(pattern, path)
+
+    if result:
+        try:
+            match = result.group(1)
+        except IndexError:
+            match = result[0]
+    else:
+        match = False
+
+    return match


### PR DESCRIPTION
## Overview

Add `get_url_match` filter to render string that matches given pattern from current page URL.

This supports annual stylesheets for Texascale.

<details><summary>✓ To Do</summary>

- [~~FP-1652~~](https://jira.tacc.utexas.edu/browse/FP-1652) — _do without for now_
- [x] local testing & screenshots
- [x] remote testing & screenshots

</details>

## Related

- [FP-1439](https://jira.tacc.utexas.edu/browse/FP-1439)
- required by https://github.com/TACC/Core-CMS-Resources/pull/148
- mirrors https://github.com/TACC/Core-CMS/pull/490

## Changes

- add `get_url_match` template filter
- have texascale use `get_url_match` i.e. [TACC/Core-CMS-Resources#148](https://github.com/TACC/Core-CMS-Resources/pull/148)

## Testing

### Prep

**Local**. Have two pages that use Texascale templates and each has a year in it's url, e.g.:
* http://localhost:8000/texascale/2019/
* http://localhost:8000/texascale/2018/

**Remote**. Use existing pages:
* https://texascale-dev.tacc.utexas.edu/2019/
* https://texascale-dev.tacc.utexas.edu/2018/

If site is blocked for security (expired cert), follow [instructions to bypass security](https://superuser.com/a/1610584/1479769).

### Steps

1. Load a page with 2019 (or any year 2019—2029) in its slug/path.
2. Verify the following `<link>` **IS** added to `<head>`:
    ```
    <link rel="stylesheet" href="texascale-org/css/build/site.2019.css" data-year_slug="2019">
    ```
    (No such file exists, intentionally. I will create the stylesheet in a future PR. For _now_, just making sure I _can_.)
3. Load a page with 2018 (or any year earlier than 2019) in its slug/path.
4. Verify the following `<link>` is **NOT** added to `<head>`:
    ```
    <link rel="stylesheet" href="texascale-org/css/build/site.2019.css" data-year_slug="2018">
    ```

## Screenshots

<details><summary>✓ Local</summary>

| 2019 | 2018 |
| - | - |
| <img width="1104" alt="Local 2019 v3 4 0" src="https://user-images.githubusercontent.com/62723358/176749415-231faf59-c30c-4255-b807-aa6aff263216.png"> | <img width="1104" alt="Local 2018 v3 4 0" src="https://user-images.githubusercontent.com/62723358/176749425-76d66ad6-2f16-4ae1-91d3-7e51937aac91.png"> |

</details>
<details><summary>✓ Remote</summary>

| 2019 | 2018 |
| - | - |
| ![Remote 2019 v3 4 0](https://user-images.githubusercontent.com/62723358/176754307-76f33dde-3a32-4b04-b5c8-0a1010181207.png) | ![Remote 2018 v3 4 0](https://user-images.githubusercontent.com/62723358/176754340-2ddbfb93-9adb-4e63-aff4-62bc6f492a81.png) |

</details>

## Notes

Based off of v3.4.0 because Texascale can't even handle v3.5.0 until [CEPWMA-680](https://jira.tacc.utexas.edu/browse/CEPWMA-680).