### PR TITLE
fix(core-styles, frontera, utrc): fp-1723 section banner overflow mgmt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.11",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
+        "@tacc/core-styles": "^0.7.0-beta",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -62,11 +62,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.6.0",
-      "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
-      "integrity": "sha512-ei6Gsi61sZnAXPDfMOkwEGX4DhgEcgpZMrDbOSfg34US+yKC3qew+ya8qonggBfNM3Iw5MENzGAYTvFax2Ya9w==",
+      "version": "0.7.0-beta",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.7.0-beta.tgz",
+      "integrity": "sha512-OnD6qlrYe9a+GS1qV34U4ikhutFX/mhqmNDOkxMc9Hj2Nk7Tpl2cxPY3uprmOVackObeVtJ5h4BX4wBCf+VTJg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -3938,8 +3937,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
-      "integrity": "sha512-ei6Gsi61sZnAXPDfMOkwEGX4DhgEcgpZMrDbOSfg34US+yKC3qew+ya8qonggBfNM3Iw5MENzGAYTvFax2Ya9w==",
+      "version": "0.7.0-beta",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.7.0-beta.tgz",
+      "integrity": "sha512-OnD6qlrYe9a+GS1qV34U4ikhutFX/mhqmNDOkxMc9Hj2Nk7Tpl2cxPY3uprmOVackObeVtJ5h4BX4wBCf+VTJg==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.7.11",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "^0.6.0",
+        "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -63,9 +63,10 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0.tgz",
-      "integrity": "sha512-qNfPtpta3k4Jmff4xt5JRvkOPD85VX10r/ip24f7ATXqDNZUMe/3v1+sAf1O6tiHcLqp7UdPnINRf0NrME7fnQ==",
+      "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
+      "integrity": "sha512-KOIBCKVGX3y3c5kZu2nzHLClfg5RTy8M9x93OlTBnXyVToRxxVJ2ZH2xJeAW/idrFwIyGRFQ8dE4imJWSCx60w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -3937,9 +3938,8 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.6.0.tgz",
-      "integrity": "sha512-qNfPtpta3k4Jmff4xt5JRvkOPD85VX10r/ip24f7ATXqDNZUMe/3v1+sAf1O6tiHcLqp7UdPnINRf0NrME7fnQ==",
+      "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
+      "integrity": "sha512-KOIBCKVGX3y3c5kZu2nzHLClfg5RTy8M9x93OlTBnXyVToRxxVJ2ZH2xJeAW/idrFwIyGRFQ8dE4imJWSCx60w==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
     "node_modules/@tacc/core-styles": {
       "version": "0.6.0",
       "resolved": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
-      "integrity": "sha512-KOIBCKVGX3y3c5kZu2nzHLClfg5RTy8M9x93OlTBnXyVToRxxVJ2ZH2xJeAW/idrFwIyGRFQ8dE4imJWSCx60w==",
+      "integrity": "sha512-ei6Gsi61sZnAXPDfMOkwEGX4DhgEcgpZMrDbOSfg34US+yKC3qew+ya8qonggBfNM3Iw5MENzGAYTvFax2Ya9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3939,7 +3939,7 @@
     },
     "@tacc/core-styles": {
       "version": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
-      "integrity": "sha512-KOIBCKVGX3y3c5kZu2nzHLClfg5RTy8M9x93OlTBnXyVToRxxVJ2ZH2xJeAW/idrFwIyGRFQ8dE4imJWSCx60w==",
+      "integrity": "sha512-ei6Gsi61sZnAXPDfMOkwEGX4DhgEcgpZMrDbOSfg34US+yKC3qew+ya8qonggBfNM3Iw5MENzGAYTvFax2Ya9w==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "^0.6.0",
+    "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "https://gitpkg.now.sh/TACC/tup-ui/libs/core-styles?bug/fp-1723-frontera-header-hidden-in-safari",
+    "@tacc/core-styles": "^0.7.0-beta",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",


### PR DESCRIPTION
## Overview / Changes

Load CSS changes to fix overflow management on section banners:
- fix from core-styles (tup-ui)
- adapt to new markup from taccsite_custom (Core-CMS-Resources)

---

⚠️ This fix requires changing markup via CMS admin. I will do so on prod immediately after deploy. See "Notes". ⚠️

---

## Related

- [FP-1723](https://jira.tacc.utexas.edu/browse/FP-1723)
- requires https://github.com/TACC/tup-ui/pull/29
- requires https://github.com/TACC/Core-CMS-Resources/pull/152

## Testing / UI

### Frontera

1. Open [frontera (pre-prod)](https://pprd.frontera-portal.tacc.utexas.edu); see **no** banner overflow.
1. Open [frontera (dev)](https://dev.fronteraweb.tacc.utexas.edu); see **no** banner overflow.
1. Compare **responsive design**[^1] to [frontera (prod)](https://frontera-portal.tacc.utexas.edu); see **no** difference.

### UTRC

1. Open [utrc (pre-prod)](https://pprd.utrc.tacc.utexas.edu); see **no** banner overflow.
1. Compare **responsive design**[^1] to [utrc (prod)](https://utrc.tacc.utexas.edu); see **no** difference.

## Notes

<details><summary>This fix required changing the markup. I must repeat change on prod (Frontera, UTRC).</summary>

**Frontera**
```html
<!-- from: -->
<section class="container s-home__banner  o-section o-section--style-dark o-section--layout-a o-section--banner">

<!-- to: -->
<section class="o-section o-section--style-dark o-section--banner">
    <div class="container o-section--layout-a  s-home__banner">
```

**UTRC**
```html
<!-- from: -->
<section class="container s-home__banner  o-section o-section--style-light o-section--layout-a o-section--banner">

<!-- to: -->
<section class="o-section o-section--style-light o-section--banner">
    <div class="container s-home__banner">
```

</details>

<details><summary>I do not like the markup change, but FP-1462 will come.</summary>

- The markup changes adds a wrapper solely for styling (a "separation of concerns" failure).
- The `s-home__banner` is intended to be on the same element as `o-section--banner`, but now it is **not**.
- The `o-section--layout-a` is designed to be on the same element as `o-section`, but now it is **not**.
- Banners will be refactored in [FP-1462](https://jira.tacc.utexas.edu/browse/FP-1462) (so TUP can use and expand them).

</details>

[^1]: The images and text may be different. but their behavior on the layout at different screen widths should not differ. *Also*, the responsive design has bugs (on prod, too). I am not intending to fix them with this PR. I intend to fix them in [FP-1462](https://jira.tacc.utexas.edu/browse/FP-1462).