### PR TITLE
feat: add CSS from Core-Styles & Frontera

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.css
@@ -1,0 +1,241 @@
+/* WARNING: This stylesheet is only for Frontera, which needs a proper module */
+/*
+(Deprecated) Article List
+
+A list of article previews. Content __must__ use the tags defined by the example markup.
+
+Markup: s-article-list.html
+
+Styleguide Trumps.Deprecated.Scopes.ArticleList
+*/
+@import url('@tacc/core-styles/src/lib/_imports/tools/x-truncate.css');
+@import url('@tacc/core-styles/src/lib/_imports/tools/x-layout.css');
+@import url('@tacc/core-styles/src/lib/_imports/tools/x-article-link.css');
+
+
+
+
+
+/* Block */
+
+[class*="s-article-list--"] {
+  /* … */
+}
+
+
+
+
+
+/* Children */
+
+
+
+/* Children: All */
+
+/* Not "Title" & Not "See More" */
+.s-article-list--layout-e > :not(h2):not(p:last-child) {
+  /* To shrink heading */
+  flex-grow: 1;
+}
+
+
+
+/* Children: Title */
+
+.s-article-list--layout-a > h2,
+.s-article-list--layout-b > h2,
+.s-article-list--layout-c > h2,
+.s-article-list--layout-d > h2 {
+  /* To span all columns */
+  grid-column-start: 1;
+  grid-column-end: -1;
+}
+
+[class*="s-article-list--"] > h2 {
+  margin-top: 0; /* overwrite Bootstrap */
+  margin-bottom: 3.0rem; /* overwrite Bootstrap */
+
+  color: var(--global-color-accent--normal);
+
+  font-size: 1.6rem;
+  font-weight: var(--bold);
+  text-transform: uppercase;
+
+  @extend .x-truncate--one-line;
+}
+/* Add a fake short border above title */
+[class*="s-article-list--"] > h2 {
+  position: relative;
+  padding-top: 1em;
+}
+[class*="s-article-list--"] > h2::before {
+  content: '';
+  display: block;
+
+  position: absolute;
+  top: 0;
+  height: 0.5em;
+  width: 2.5em;
+
+  background-color: var(--global-color-accent--normal);
+}
+
+
+
+/* Children: "See More" */
+
+/* Anchor */
+
+.s-article-list--layout-a > p:last-child,
+.s-article-list--layout-b > p:last-child,
+.s-article-list--layout-c > p:last-child,
+.s-article-list--layout-d > p:last-child {
+  /* To span all columns */
+  grid-column-start: 1;
+  grid-column-end: -1;
+}
+
+[class*="s-article-list--"] > p:last-child {
+  border-top-width: var(--global-border-width--thick);
+  border-top-style: solid;
+
+  margin-top: 3.0rem; /* GH-99: Use standard spacing value */
+  margin-bottom: -1.0rem; /* to "undo" space added from `padding-bottom` */
+
+  font-size: 1.2rem;
+  font-weight: var(--bold);
+}
+[class*="s-article-list--"] > p:last-child a {
+  display: inline-block;
+
+  padding-top: 1.0rem;
+  padding-bottom: 1.0rem;
+  padding-right: 1.0rem;
+
+  @extend .x-truncate--one-line;
+  max-width: 100%; /* SEE: https://stackoverflow.com/a/44521595 */
+}
+/* Dark section */
+.o-section--style-dark[class*="s-article-list--"] > p:last-child,
+.o-section--style-dark [class*="s-article-list--"] > p:last-child {
+  border-color: var(--global-color-primary--xx-light);
+}
+.o-section--style-dark[class*="s-article-list--"] > p:last-child a,
+.o-section--style-dark [class*="s-article-list--"] > p:last-child a {
+  color: var(--global-color-primary--xx-light);
+}
+/* Light section */
+.o-section--style-light[class*="s-article-list--"] > p:last-child,
+.o-section--style-light [class*="s-article-list--"] > p:last-child {
+  border-color: var(--global-color-primary--xx-dark);
+}
+.o-section--style-light[class*="s-article-list--"] > p:last-child a,
+.o-section--style-light [class*="s-article-list--"] > p:last-child a {
+  color: var(--global-color-primary--xx-dark);
+}
+
+/* Icon */
+
+[class*="s-article-list--"] > p:last-child a::before {
+  font-family: "Font Awesome 5 Free";
+  content: "\f35a";
+  margin-right: 10px;
+
+  font-size: 1.4rem;
+  vertical-align: middle;
+
+  /* To hide the `text-decoration: underline` of the anchor */
+  /* SEE: https://stackoverflow.com/a/15688237/11817077 */
+  display: inline-block;
+}
+
+
+
+
+
+/* Modifiers */
+
+
+
+/* Modifiers: Links */
+
+.s-article-list--links {
+  font-size: 1.4rem;
+  color: var(--global-color-primary--xx-dark);
+}
+.s-article-list--links p:not(:last-child) {
+  margin: 0; /* Overwrite Bootstrap and browser */
+}
+.s-article-list--links p:not(:last-child) a {
+  font-weight: var(--bold);
+  color: var(--global-color-primary--xx-dark);
+}
+
+/* Expand link to cover its container */
+.s-article-list--links p:not(:last-child) { position: relative; }
+.s-article-list--links p:not(:last-child) a::before {
+  content: '';
+
+  @extend .x-article-link-stretch;
+}
+.s-article-list--layout-gapless.s-article-list--links p:not(:last-child) a::before {
+  @extend .x-article-link-stretch--gapless;
+}
+/* Give link state (pseudo-class) feedback */
+.s-article-list--links p:not(:last-child) a:hover::before {
+  @extend .x-article-link-hover;
+}
+.s-article-list--layout-gapless.s-article-list--links p:not(:last-child) a:hover::before {
+  @extend .x-article-link-hover--gapless;
+}
+
+
+/* Modifiers: Layout */
+
+.s-article-list--layout-a { @extend .x-layout--a; }
+.s-article-list--layout-b { @extend .x-layout--b; }
+.s-article-list--layout-c { @extend .x-layout--c; }
+.s-article-list--layout-d { @extend .x-layout--d; }
+.s-article-list--layout-e { @extend .x-layout--e; }
+
+/* Modifiers: Layout: Column-Based */
+
+.s-article-list--layout-a,
+.s-article-list--layout-b,
+.s-article-list--layout-c,
+.s-article-list--layout-d {
+  column-gap: 3.0rem; /* GH-99: Use standard spacing value */
+}
+
+/* Modifiers: Layout: Row-Based */
+
+.s-article-list--layout-e {
+  /* … */
+}
+
+/* Modifiers: Layout: Options */
+
+.s-article-list--layout-gapless {
+  gap: 0;
+}
+
+.s-article-list--layout-compact > p:last-child {
+  margin-top: 0;
+}
+
+.s-article-list--layout-divided > :not(h2):not(p:last-child) {
+  padding-top: 0.8rem;
+
+  border-width: var(--global-border-width--normal) 0 0;
+  border-style: solid;
+}
+/* Dark section */
+.o-section--style-dark.s-article-list--layout-divided > :not(h2):not(p:last-child),
+.o-section--style-dark .s-article-list--layout-divided > :not(h2):not(p:last-child) {
+  border-color: var(--global-color-primary--light);
+}
+/* Light section */
+.o-section--style-light.s-article-list--layout-divided > :not(h2):not(p:last-child),
+.o-section--style-light .s-article-list--layout-divided > :not(h2):not(p:last-child) {
+  border-color: var(--global-color-primary--dark);
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-list.html
@@ -1,0 +1,16 @@
+<article class="s-article-list">
+  <h2>News &amp; Stuff</h2>
+  <article>Article Placeholder</article>
+</article>
+
+<!-- TODO: Create a component (requires a plugin) -->
+<!--
+<article class="c-article-list">
+  <h2 class="c-article-list__title">
+    News &amp; Stuff
+  </h2>
+  <article class="c-article-list__item">
+    Article Placeholder
+  </article>
+</article>
+-->

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.css
@@ -1,0 +1,254 @@
+/* WARNING: This stylesheet is only for Frontera, which needs a proper module */
+/*
+(Deprecated) Article Preview
+
+A preview of an article (to be used in a `s-article-list`). Content __must__ come in the order and use the tags defined by the example markup.
+
+Markup: s-article-preview.html
+
+Styleguide Trumps.Deprecated.Scopes.ArticlePreview
+*/
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-truncate.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-article-link.css");
+
+
+
+
+
+/* Block */
+
+.s-article-preview {
+  position: relative; /* for absolutely positioned "Children: Link" */
+
+  display: flex;
+  flex-direction: column;
+}
+
+
+
+
+
+/* Children */
+
+
+
+/* Children: Media */
+
+.s-article-preview p:first-child {
+  order: 1;
+
+  overflow: hidden;
+
+  margin-bottom: 0.8rem; /* overwrite Bootstrap */
+}
+.s-article-preview p:first-child > img {
+  /* To center image within container */
+  position: relative;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+.s-article-preview p:first-child > img.img-fluid {
+  /* To ensure super wide or tall image do not have negative space / gaps */
+  width: 100%;
+  object-fit: cover;
+  height: 100%; /* overwrite `.img-fluid` *//* NOTE: Sould this be standard? */
+}
+/* (List) News */
+.s-article-list--news .s-article-preview p:first-child {
+  height: 180px;
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview p:first-child {
+  height: 10.0rem;
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview p:first-child {
+  display: none;
+}
+
+
+/* Children: Title */
+
+.s-article-preview h3 {
+  order: 3;
+
+  margin-top: 0; /* overwrite Bootstrap and browser */
+  margin-bottom: 0.8rem; /* overwrite Bootstrap and browser */
+
+  font-size: 1.8rem;
+  font-weight: var(--bold);
+  line-height: 2.4rem;
+}
+/* (List) */
+[class*="s-article-list--"] .s-article-preview h3 {
+  @extend %x-truncate--one-line;
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview h3 {
+  font-size: 1.6rem;
+  font-weight: var(--bold);
+  color: inherit;
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview h3 {
+  font-size: 1.4rem;
+}
+
+
+
+/* Children: Abstract */
+
+.s-article-preview p:not(:first-child):not(:last-child) {
+  order: 4;
+
+  margin-bottom: 0; /* overwrite Bootstrap and browser */
+
+  font-size: 1.6rem;
+  line-height: 2.4rem;
+}
+/* (List) */
+[class*="s-article-list--"] .s-article-preview p:not(:first-child):not(:last-child) {
+  @extend %x-truncate--many-lines;
+  --lines: 3;
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview p:not(:first-child):not(:last-child) {
+  display: none;
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview p:not(:first-child):not(:last-child) {
+  font-size: 1.4rem;
+  color: var(--global-color-primary--xx-dark);
+}
+
+
+
+/* Children: Metadata */
+
+.s-article-preview ul {
+  order: 2;
+
+  display: flex;
+  flex-direction: column;
+
+  list-style: none;
+  padding-left: 0; /* overwrite `site.css` and browser */
+
+  margin-bottom: 0.8rem; /* overwrite Bootstrap */
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview ul {
+  order: 5;
+}
+
+/* Children: Metadata: Date */
+
+.s-article-preview ul > li:nth-child(1) {
+  order: 2;
+
+  font-weight: var(--medium);
+
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+/* (List) News */
+.s-article-list--news .s-article-preview ul > li:nth-child(1) {
+  margin-bottom: 0.8rem; /* overwrite Bootstrap */
+  font-size: 1.0rem;
+}
+.s-article-list--news .s-article-preview ul > li:nth-child(1)::before {
+  content: 'Published: ';
+  white-space: pre;
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview ul > li:nth-child(1) {
+  font-size: 1.4rem;
+  color: var(--global-color-accent--normal);
+}
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview ul > li:nth-child(1) {
+  font-size: 1.6rem;
+}
+.s-article-list--allocations .s-article-preview ul > li:nth-child(1)::before {
+  content: 'Submission Deadlines: ';
+  white-space: pre;
+}
+
+/* Children: Metadata: Type */
+
+.s-article-preview ul > li:nth-child(2) {
+  order: 1;
+
+  font-size: 1.2rem;
+  font-weight: var(--bold);
+  text-transform: uppercase;
+}
+/* (List) Events */
+.s-article-list--events .s-article-preview ul > li:nth-child(2),
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview ul > li:nth-child(2) {
+  display: none;
+}
+
+/* Children: Metadata: Author */
+
+.s-article-preview ul > li:nth-child(3) {
+  order: 3;
+}
+/* (List) News */
+.s-article-list--news .s-article-preview ul > li:nth-child(3),
+/* (List) Events */
+.s-article-list--events .s-article-preview ul > li:nth-child(3),
+/* (List) Allocations */
+.s-article-list--allocations .s-article-preview ul > li:nth-child(3) {
+  display: none;
+}
+
+
+
+/* Children: Link */
+
+.s-article-preview p:last-child {
+  margin-bottom: 0; /* overwite Bootstrap and browser */
+}
+
+/* Expand link to cover its container */
+.s-article-preview p:last-child {
+  z-index: 1; /* ensure Link appears over Media */
+}
+.s-article-preview p:last-child > a {
+  color: transparent; /* ensure Link _text_ is invisible (allow decoration) */
+
+  @extend .x-article-link-stretch;
+}
+.s-article-list--layout-gapless .s-article-preview p:last-child > a {
+  @extend .x-article-link-stretch--gapless;
+}
+/* Give link state (pseudo-class) feedback */
+.s-article-preview p:last-child > a:hover {
+  @extend .x-article-link-hover;
+}
+.s-article-list--layout-gapless .s-article-preview p:last-child > a:hover {
+  @extend .x-article-link-hover--gapless;
+}
+
+
+
+
+
+/* Modifiers */
+
+
+
+/* Modifiers: (List) News, Allocations, Evetns, etc. */
+/* SEE: All "Children" styles */
+
+
+
+/* Modifiers: (List) Layout: Options */
+
+.s-article-list--layout-compact .s-article-preview > * {
+  margin-bottom: 0; /* overwrite `.s-article-preview > …` */
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.html
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-article-preview.html
@@ -1,0 +1,29 @@
+<article class="s-article-preview">
+  <p><img src="…" alt="…" /></p>
+  <h3>A Long or Short Title of Article</h3>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua.
+  </p>
+  <ul>
+    <li>July 7</li>
+    <li>Science News</li>
+    <li>Wesley Bomar</li>
+  </ul>
+</article>
+
+<!-- TODO: Create a component (requires a plugin) -->
+<!--
+<article class="c-article-preview">
+  <img class="c-article-preview__media" src="…" alt="…" />
+  <h3 class="c-article-preview__title">
+    A Long or Short Title of Article
+  </h3>
+  <p class="c-article-preview__abstract">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  </p>
+  <time class="c-article-preview__date" datetime="2018-07-07">July 7</time>
+  <small class="c-article-preview__type">Science News</small>
+  <small class="c-article-preview__author">Wesley Bomar</small>
+</article>
+-->

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-home.frontera.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-home.frontera.css
@@ -7,10 +7,10 @@ Markup: https://frontera-portal.tacc.utexas.edu/
 
 Styleguide Trumps.Scopes.Home.Frontera
 */
-@import url("_imports/tools/x-truncate.css");
-@import url("_imports/tools/x-overlay.css");
-@import url("_imports/tools/x-center.css");
-@import url("_imports/tools/media-queries.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-truncate.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-overlay.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-center.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/media-queries.css");
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-home.frontera.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/trumps/s-home.frontera.css
@@ -1,0 +1,275 @@
+/*
+Home Page - Frontera-Style
+
+Styles for elements on a homepage that looks like Frontera.
+
+Markup: https://frontera-portal.tacc.utexas.edu/
+
+Styleguide Trumps.Scopes.Home.Frontera
+*/
+@import url("_imports/tools/x-truncate.css");
+@import url("_imports/tools/x-overlay.css");
+@import url("_imports/tools/x-center.css");
+@import url("_imports/tools/media-queries.css");
+
+
+
+
+
+/* Banner */
+/* Introduction */
+
+.s-home__banner,
+.s-home__intro {
+  --banner-margin-horz: 25px;
+}
+
+
+
+
+
+/* Banner */
+
+
+
+/* Container */
+
+.s-home__banner {
+  position: relative; /* for `position: absolute` children */
+}
+@media (--medium-and-below) {
+  .s-home__banner { height: auto; }
+}
+@media (--medium-and-above) {
+  .s-home__banner { height: 55.5rem; }
+}
+
+.s-home__banner .o-section__banner-overlay {
+  --spacing: 1.5rem;
+
+  /* To avoid the need to add placeholder markup for empty column */
+  /* FAQ: The `.o-section__banner-image` is not part of the grid */
+  grid-column-start: 2;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  min-height: 0; /* allow grid item to shrink shorter than content */
+
+  font-size: 2.4rem;
+  font-weight: var(--bold);
+
+  padding: var(--spacing); /* GH-99: Use standard spacing value */
+}
+/* To reduce width of banner when it only sits on right-side of banner */
+@media (--medium-and-above) {
+  .s-home__banner .o-section__banner-overlay {
+    margin: 0 var(--banner-margin-horz);
+  }
+}
+
+/* To style the overlay */
+.s-home__banner .o-section__banner-overlay {
+  @extend %x-overlay--curtain;
+}
+.o-section--style-dark .s-home__banner .o-section__banner-overlay {
+  --color-bkgd-rgb: var(--global-color-primary--x-dark-rgb);
+}
+.o-section--style-light .s-home__banner .o-section__banner-overlay {
+  --color-bkgd-rgb: var(--global-color-primary--x-light-rgb);
+}
+
+
+
+/* Children */
+
+/* Text */
+.s-home__banner .o-section__banner-overlay > p {
+  /* NOTE: Design did not request truncation; Dev added it for safety */
+  @extend %x-truncate--many-lines;
+  /* WARNING: Using `!important` to fix unclear specifity issue */
+  --lines: 6 !important;
+
+  /* FAQ: The top margin is N lines × 1.4 line-height (from `body`) */
+  margin: calc(var(--margin-lines, 0) * 1.4em) var(--spacing) var(--spacing);
+}
+@media (--wide-and-above) {
+  .s-home__banner .o-section__banner-overlay > p { --margin-lines: 2; }
+}
+@media (--medium-and-above) and (--wide-and-below) {
+  .s-home__banner .o-section__banner-overlay > p { --margin-lines: 1; }
+}
+
+/* Image */
+.s-home__banner .o-section__banner-image {
+  /* To overwrite `.o-section__banner-image` */
+  /* To align and size image to match design (as close as possible) */
+  top: calc(50% - 9.5%);
+  left: calc(50% - 13%);
+  width: 124.5vw;
+}
+
+/* List */
+.s-home__banner .o-section__banner-overlay section {
+  flex-grow: 0;
+
+  display: flex;
+  padding-left: 0;
+  list-style-type: none;
+  border-top: 1px solid var(--global-color-primary--xx-light);
+}
+
+
+
+/* Articles */
+
+.s-home__banner .o-section__banner-overlay article {
+  padding: var(--spacing);
+}
+@media (--x-narrow-and-below) {
+  .s-home__banner .o-section__banner-overlay section { flex-wrap: wrap; }
+  .s-home__banner .o-section__banner-overlay article {
+    flex-shrink: 0;
+    flex-basis: 100%;
+  }
+  /* To reduce space between articles */
+  .s-home__banner .o-section__banner-overlay article + article {
+    margin-top: calc(-1 * var(--spacing));
+  }
+}
+@media (--x-narrow-and-above) {
+  .s-home__banner .o-section__banner-overlay section { flex-wrap: nowrap; }
+  .s-home__banner .o-section__banner-overlay article {
+    flex-shrink: 1;
+    flex-basis: 50%;
+  }
+  /* To add line between articles */
+  .s-home__banner .o-section__banner-overlay article + article {
+    border-left: 1px solid var(--global-color-primary--xx-light);
+  }
+}
+
+/* Image */
+.s-home__banner .o-section__banner-overlay article p:first-child {
+  margin-bottom: 0;
+}
+.s-home__banner .o-section__banner-overlay article p:first-child img {
+  height: 200px;
+  transform: unset;
+  top: unset;
+  left: unset;
+  border: 1px solid var(--global-color-primary--xx-light);
+}
+
+/* Caption */
+.s-home__banner .o-section__banner-overlay article ul {
+  position: absolute;
+  bottom: var(--spacing);
+  left: var(--spacing);
+  right: var(--spacing);
+  /* Ensure caption shows above image (in Firefox) */
+  /* FAQ: Because `order` is ineffectual due to `position: absolute` */
+  /* SEE: https://css-tricks.com/flexbox-and-absolute-positioning/ */
+  z-index: 1;
+
+  padding: 7px var(--spacing);
+  /* To overwrite `s-article-preview` */
+  /* To let image border show through */
+  margin: 1px;
+
+  background-color: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(30px) brightness(115%);
+
+
+  font-weight: 700;
+}
+/* Caption: Title */
+.s-home__banner .s-article-preview h3 {
+  @extend %x-truncate--many-lines;
+  --lines: 3;
+
+  /* To ensure consistent height of three lines */
+  /* FAQ: The `2.4rem` line-height was copied from `s-article-preview` */
+  height: calc(2.4rem * var(--lines));
+
+  margin-bottom: 0;
+
+  font-size: 1.6rem;
+}
+/* Caption: Type */
+.s-home__banner .s-article-preview ul > li:nth-child(2) {
+  font-size: 1.0rem;
+}
+/* Caption: Link */
+.s-home__banner .s-article-preview p:last-child > a:hover {
+  outline-color: var(--global-color-primary--xx-light);
+  outline-offset: calc(-1 * var(--spacing));
+}
+
+
+
+
+
+/* Introduction */
+
+.s-home__intro p {
+  font-size: 1.8rem;
+  font-weight: var(--bold);
+}
+@media (--wide-and-above) {
+  .s-home__intro p {
+    /* Forces width to match design */
+    padding-right: 3.0rem; /* GH-99: Use standard spacing value */
+  }
+}
+
+.s-home__intro .s-system-monitor {
+  align-self: center;
+
+  display: flex;
+  align-items: center;
+  justify-items: center;
+
+  overflow-x: auto;
+}
+@media (--narrow-and-below) {
+  .s-home__intro .s-system-monitor {
+    padding-top: 0.5rem; /* GH-99: Use standard spacing value */
+    padding-bottom: 0.5rem; /* GH-99: Use standard spacing value */
+  }
+}
+@media (--narrow-and-above) {
+  .s-home__intro div {
+    /* Forces smaller width, like design */
+    /* Uses consistent space, unlike design */
+    padding: 1.0rem; /* GH-99: Use standard spacing value */
+
+    margin: 0 var(--banner-margin-horz);
+  }
+}
+
+
+
+/* News */
+
+.s-home__news {
+  padding-top: 2.0rem;
+  padding-bottom: 2.5rem;
+}
+.s-home__news article {
+  margin-bottom: 3.0rem;
+}
+
+
+
+/* Other */
+
+.s-home__other [class*="s-article-list--"] {
+  min-height: 45.0rem;
+}
+
+/* To make user guides links take entire row when layout is 50/50 */
+@media (--narrow-to-medium), (--x-narrow-to-narrow) {
+  .s-home__other > :first-child { grid-column: 1 / -1; }
+}


### PR DESCRIPTION
## Status

> **Warning**
> The [TACC/Core-CMS-Resources](https://github.com/TACC/Core-CMS-Resources) `main` branch has changed drastically since the work was started. Resolving merge conflicts in https://github.com/TACC/Core-CMS-Resources/pull/153 may be difficult.

## Overview

Add CMS stylesheets that Frontera used, and update Frontera to use them from CMS instead.

### Why?

1. Non-Core CMS's may not have build process in the future.
    - So what they use must come from Core-CMS.
2. Adapting to the above reason simplifies the CSS of non-Core CMS's.

## Related

- [TUP-250](https://jira.tacc.utexas.edu/browse/TUP-250)
- requires https://github.com/TACC/Core-CMS-Resources/pull/153
- used by https://github.com/TACC/tup-cms/pull/3
- ~~causes https://github.com/TACC/tup-ui/pull/33~~
   causes https://github.com/TACC/Core-CMS/pull/518

## Changes

- Bring back CMS-specific stylesheets from Core-Styles.
- Promote Frontera-style homepage styles from Frontera to CMS.
- Simplify Frontera stylesheets.

## Testing

Build the CMS with https://github.com/TACC/tup-cms/pull/3.

_**No** need for `git submodule` commands. **No** need to symlink Frontera `settings_custom.py`._

## Screenshots

(skipped)