### PR TITLE
fix(taccsite_ui): do not let django serve patterns

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -198,12 +198,6 @@ TACC_BLOG_SHOW_CATEGORIES = True
 TACC_BLOG_SHOW_TAGS = True
 
 ########################
-# TACC: UI PATTERN DEMO
-########################
-
-TACC_UI_ROOT = os.path.join(DATA_DIR, 'taccsite_ui')
-
-########################
 # CLIENT BUILD SETTINGS
 ########################
 

--- a/taccsite_cms/urls.py
+++ b/taccsite_cms/urls.py
@@ -43,8 +43,6 @@ try:
 except ImportError:
     pass
 
-urlpatterns += static('/ui-patterns/', document_root=settings.TACC_UI_ROOT)
-
 urlpatterns += [
     url(r'^', include('cms.urls')),
 ]


### PR DESCRIPTION
## Overview

Do **not** let Django serve UI patterns demo.

⚠️ Do not merge until we have another solution. Instead, cherry-pick from here before deploying other `task/fp-1499-cms-pattern-library--` branches (and revert when done deploying). (Yes, it's a mess.)

<details>

Letting Django server the demo files **might** have been the cause of a performance issue. And, they should be served with a dedicated static file server anyway.

<details>

## Related

- [FP-1499](https://jira.tacc.utexas.edu/browse/FP-1499)

## Changes

Remove Django-based static file hosting (not "staticfiles" but independent static assets).

## Testing

I deployed this on pprd.ecep.tacc.utexas.edu. The UI pattern library demo was unavailable (so any potential performance issue cannot occur).

## Screenshots

N/A