### PR TITLE
feat(core-styles): install tup-ui package tarball

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.8.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "^0.7.0-beta",
+        "@tacc/core-styles": "https://github.com/TACC/tup-ui/blob/test/core-styles-tarball-install/libs/core-styles/tacc-core-styles-0.7.0-test.tgz?raw=true",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -62,10 +62,11 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.7.0-beta",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.7.0-beta.tgz",
-      "integrity": "sha512-OnD6qlrYe9a+GS1qV34U4ikhutFX/mhqmNDOkxMc9Hj2Nk7Tpl2cxPY3uprmOVackObeVtJ5h4BX4wBCf+VTJg==",
+      "version": "0.7.0-test",
+      "resolved": "https://github.com/TACC/tup-ui/blob/test/core-styles-tarball-install/libs/core-styles/tacc-core-styles-0.7.0-test.tgz?raw=true",
+      "integrity": "sha512-kkde4M3ovr3b66npJlVn8okC/fynHXwuGL46E0UALTHvyfdrjjbVgeSzZihOHLKEHB/Fli9pCB0NyUx/DBYM/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -3937,9 +3938,8 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.7.0-beta",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.7.0-beta.tgz",
-      "integrity": "sha512-OnD6qlrYe9a+GS1qV34U4ikhutFX/mhqmNDOkxMc9Hj2Nk7Tpl2cxPY3uprmOVackObeVtJ5h4BX4wBCf+VTJg==",
+      "version": "https://github.com/TACC/tup-ui/blob/test/core-styles-tarball-install/libs/core-styles/tacc-core-styles-0.7.0-test.tgz?raw=true",
+      "integrity": "sha512-kkde4M3ovr3b66npJlVn8okC/fynHXwuGL46E0UALTHvyfdrjjbVgeSzZihOHLKEHB/Fli9pCB0NyUx/DBYM/g==",
       "dev": true,
       "requires": {
         "commander": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "^0.7.0-beta",
+    "@tacc/core-styles": "https://github.com/TACC/tup-ui/blob/test/core-styles-tarball-install/libs/core-styles/tacc-core-styles-0.7.0-test.tgz?raw=true",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",


### PR DESCRIPTION
## Overview

This proves we can install an NPM package from a sub-directory.

## Related

N/A

## Changes

- install @tacc/core-styles directly from [TACC/tup-ui:libs/core-styles at some commit/branch/tag](https://github.com/TACC/tup-ui/tree/test/core-styles-tarball-install/libs/core-styles).

## Testing

1. `npm ci`
2. Verify the installed `@tacc/core-styles` is version `0.7.1-test`.

## UI

<img width="1280" alt="Screen Shot 2022-07-27 at 18 23 48" src="https://user-images.githubusercontent.com/62723358/181389188-f97ab817-81ea-4438-8ad2-039028783a3d.png">

