### PR TITLE
Task/ecepweb 210 members pages accessibility

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/targetSiblingHider.js
+++ b/taccsite_cms/static/site_cms/js/modules/targetSiblingHider.js
@@ -78,6 +78,11 @@ export default class TargetSiblingHider {
           // Fix only seems necessary for first event, so clean up
           this.disableScrollFix();
         }
+
+        // To restore focus to targets whose focus is lost on successive toggles
+        if ( document.activeElement !== target ) {
+          target.focus();
+        }
       }
     });
   }

--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -1,7 +1,9 @@
 {% load cms_tags staticfiles sekizai_tags cache i18n meta %}
+{% get_current_language as lang_code %}
 <!doctype html>
 <html
   id="page-{{ request.current_page.id }}"
+  lang="{{ lang_code }}"
   {# FAQ: Only available if set in page's "Advanced" settings #}
   data-page-id="{{ request.current_page.reverse_id }}"
   class="{% block template_class %}{% endblock template_class %}">


### PR DESCRIPTION
## Overview

Fix accessibility issues for [ECEP Alliance Members](https://prod.ecep.tacc.utexas.edu/alliance-members/) page.

## Related

- [ECEPWEB-210](https://jira.tacc.utexas.edu/browse/ECEPWEB-210)

## Changes

- restore focus to state heading after navigation (first time worked, successive navigation did not) 7719bb6
- set `<html lang="…">` 1fc3b26

## Testing & UI

Local: https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes
Remote: https://prod.ecep.tacc.utexas.edu/alliance-members

<details><summary>restore focus 7719bb6</summary>

1. Open page.
2. Click blank space above nav sidebar.
3. Press [tab] to focus on any state name in nav sidebar.
4. Press [enter] to navigate to state (and thus hide others).
    - State heading should have a focus outline. (This was always the case.)
6. Hold [shift] and press [tab] multiple times to navigate back to nav sidebar.
7. Press [enter] to navigate to any other state (and thus hide others).
    - State heading should have a focus outline. (This is the fix.)

| before fix | after fix |
| - | - |
| ![Screen Shot 2022-08-02 at 18 25 50](https://user-images.githubusercontent.com/62723358/182493193-2245f526-cf21-4278-8df7-ac7ffdcc5f70.png) | ![Screen Shot 2022-08-02 at 18 25 28](https://user-images.githubusercontent.com/62723358/182493123-7ae1277c-6b98-4001-b182-1e34d5694f99.png) |

</details>

<details><summary>set html lang attribute 1fc3b26</summary>

1. Open page.
2. Inspect elements (via dev tools) or view source.
3. Verify `<html>` tag has `lang` attribute equal to `en`.

| before fix | after fix |
| - | - |
| ![Screen Shot 2022-08-02 at 18 49 46](https://user-images.githubusercontent.com/62723358/182495675-c66c676d-58f9-4d73-98dc-e4a8e6ecd7c5.png) | ![Screen Shot 2022-08-02 at 18 49 34](https://user-images.githubusercontent.com/62723358/182495676-d26944df-81f1-46a9-aff0-4e9a6c5a3224.png) |

</details>
