### PR TITLE
Task/ecepweb 209 news pages accessibility

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -116,6 +116,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 }
 :--article-item h4::before { content: ': ' }
 :--article-item h3 a {
+  display: block; /* to prevent grid blowout */
   color: var(--global-color-primary--xx-dark);
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -102,9 +102,11 @@ Styleguide Components.DjangoCMS.Blog.App.Item
   margin-block: unset; /* overwrite html-elements.css */
   font-size: var(--global-font-size--large);
 }
+:--article-item h3 a, /* truncate a not h3 so :focus-visible is not cropped */
 :--article-item h4 {
   @extend %x-truncate--one-line;
-
+}
+:--article-item h4 {
   text-transform: none; /* overwrite html-elements.css */
 
   /* To style subtitle differently than title */

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -99,12 +99,12 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 :--article-item h3,
 :--article-item h4 {
-  @extend %x-truncate--one-line;
-
   margin-block: unset; /* overwrite html-elements.css */
   font-size: var(--global-font-size--large);
 }
 :--article-item h4 {
+  @extend %x-truncate--one-line;
+
   text-transform: none; /* overwrite html-elements.css */
 
   /* To style subtitle differently than title */

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -114,7 +114,9 @@ Styleguide Components.DjangoCMS.Blog.App.Item
   transform: translateY(2px); /* HACK: tweak vertical alignment */
   font-weight: var(--regular);
 }
-:--article-item h4::before { content: ': ' }
+:--article-item h4::before {
+  content: ': ';
+}
 :--article-item h3 a {
   display: block; /* to prevent grid blowout */
   color: var(--global-color-primary--xx-dark);

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -14,9 +14,12 @@
       [ ...document.querySelectorAll('.pagination a') ].forEach( a => {
         a.innerText = a.innerText.replace('«', '<').replace('»', '>');
       });
-      /* HACK: To remove " »" from "read more »" */
+      /* HACK: To manipulate "read more" link */
       [ ...document.querySelectorAll('.read-more a') ].forEach( a => {
+        /* To remove " »" from "read more »" */
         a.innerText = a.innerText.replace(' »', '');
+        /* To disallow focus (because article header link is ample) */
+        a.tabIndex = -1;
       });
     </script>
 </div>


### PR DESCRIPTION
## Overview

Fix accessibility issues for (ECEP) News [list](https://prod.ecep.tacc.utexas.edu/news/).

## Related

- [ECEPWEB-209](https://jira.tacc.utexas.edu/browse/ECEPWEB-209)
- accompanies https://github.com/TACC/Core-CMS/pull/530
- accompanies https://github.com/TACC/Core-CMS/pull/528

## Changes & Testing & UI

Local: https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes
Remote: https://prod.ecep.tacc.utexas.edu/news
Branch: `site/ecep/main`

<details><summary>blog post title: truncate title without hiding focus ui a1bd165 + 077693c + 49508f2</summary>

1. Open [news list](https://prod.ecep.tacc.utexas.edu/news/).*
2. Use [tab] key to highlight the title of an article.
3. Verify that there is a clearly visible focus box around the title.†

<sub>* If testing locally, use a list page that has articles that have subtitles.</sub>
<sub>† The dotted line is irrelevant. That is a different kind of focus. I still await link state designs.</sub>

| unchanged ui | before fix | after fix |
| - | - | - |
| ![before narrow focus](https://user-images.githubusercontent.com/62723358/182713244-2ac61ce2-f58b-40c3-bb30-e9db1bc48e02.png) | ![after narrow focus](https://user-images.githubusercontent.com/62723358/182713246-3a5575d3-9cd9-4374-96d5-dec9a53c7182.png) |
| ![before wide focus](https://user-images.githubusercontent.com/62723358/182713251-cc17787a-970f-4b0f-86d5-26eaa70b1c0f.png) | ![after wide focus](https://user-images.githubusercontent.com/62723358/182713249-65ca6bed-6b86-44ed-bbd4-1624c9ed6dc6.png) |

</details>

<details><summary>blog post read more: no focus fd86a84</summary>

1. Open [news list](https://prod.ecep.tacc.utexas.edu/news/).
2. Use [tab] key to highlight an article link.
3. Use [tab] key to highlight the next link on the page.
4. Verify that the next link is the next title (not a box around the article).

| before fix | after fix |
| - | - |
![before - read more focus (has)](https://user-images.githubusercontent.com/62723358/182509965-77747071-4b26-43ed-87e9-45711571727a.png) | ![after - read more focus (none)](https://user-images.githubusercontent.com/62723358/182509968-6b09ab15-9479-4f61-a5a3-cd10b4bd52e7.png) |
| one _**can**_ focus on a box around an article | one _can **not**_ focus on a box around an article |

</details>
