### PR TITLE
Task/ecepweb 209 news pages responsive design

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -32,6 +32,7 @@ Styleguide Components.DjangoCMS.Blog.App
 /* FAQ: Avoiding changing blog templates to limit app upgrade maintenance */
 @custom-selector :--article article;
 @custom-selector :--article-page article.post-detail;
+@custom-selector :--article-list .blog-list;
 @custom-selector :--article-item .blog-list article;
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -242,7 +242,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
     margin-bottom: 15px;
   }
   :--article-item .blog-visual img {
-    width: 100%;
+    width: 100%; /* CAVEAT: artifically enlarges image */
     height: auto;
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -239,17 +239,18 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 /* To support vertical layouts at narrow viewports */
 @media (--narrow-and-below) {
   :--article-item .blog-visual:not(:empty) {
+    height: 140px; /* for consistent image height */
     margin-bottom: 15px;
   }
   :--article-item .blog-visual img {
-    width: 100%; /* CAVEAT: artifically enlarges image */
-    height: auto;
+    max-width: 100%; /* to prevent overflow if column is narrower */
+    height: auto; /* to maintain aspect ratio if width changes */
   }
 }
 /* To support horizontal layouts at wide viewports */
 @media (--narrow-and-above) {
   :--article-item .blog-visual:not(:empty) {
-    width: 255px; /* for consistent image width (as per design) */
+    width: 255px; /* for consistent image width */
     margin-right: 50px;
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -10,34 +10,70 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 @import url("@tacc/core-styles/src/lib/_imports/tools/x-article-link.css");
 @import url("@tacc/core-styles/src/lib/_imports/tools/x-truncate.css");
 
+@import url("_imports/tools/media-queries.css");
 @import url("_imports/tools/selectors.css");
 
 
 
 
 
-/* (Structure) */
+/* List */
+
+/* To have two columns at certain viewport widths */
+@media (--xx-narrow-to-x-narrow), (--x-narrow-to-narrow) {
+  :--article-list {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    column-gap: 40px;
+  }
+  :--article-list > :where(header, nav) {
+    grid-column: 1 / -1;
+  }
+}
+
+
+
+
+
+/* Item */
+
+
+
+/* Item (Structure) */
 
 :--article-item {
   display: grid;
 
-  grid-template-areas:
-    'media head'
-    'media desc';
+  border-bottom: var(--global-border-width--normal) solid var(--global-color-primary--dark);
+  margin-bottom: var(--blog-item-buffer);
+  padding-bottom: var(--blog-item-buffer);
+}
 
-  /* To have shrinkwrapped media and flexible text content */
-  grid-template-columns: minmax(0, max-content) 1fr;
+/* To have vertical layout for narrow viewports */
+@media (--narrow-and-below) {
+  :--article-item {
+    grid-template-areas:
+      'media'
+      'head'
+      'desc';
+    /* To prevent content from overflowing cell */
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+/* To have horizontal layout for wide viewports */
+@media (--narrow-and-above) {
+  :--article-item {
+    grid-template-areas:
+      'media head'
+      'media desc';
+    /* To have shrinkwrapped media and flexible text content */
+    grid-template-columns: minmax(0, max-content) 1fr;
+  }
 }
 :--article-item header        { grid-area: head }
 :--article-item .blog-visual  { grid-area: media }
 :--article-item .blog-lead    { grid-area: desc }
 
-/* FAQ: `:--article-item + :--article-item` ≠ `:--article-item + article` */
-:--article-item + article {
-  margin-top: var(--blog-item-buffer);
-  border-top: var(--global-border-width--normal) solid var(--global-color-primary--dark);
-  padding-top: var(--blog-item-buffer);
-}
 
 
 
@@ -191,20 +227,31 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 /* Visual */
 
 :--article-item .blog-visual:not(:empty) {
-  /* Design requires same-width image boxes */
-  /* IDEA: Should we import a Django setting for image width? */
-  width: 255px; /* should be equal to max width of "MAIN IMAGE THUMBNAIL" */
-
-  margin-right: 50px;
-
-  /* To align any image inside */
-  /* FAQ: Images SHOULD use cropped thumbnail option, which makes this moot,
-          but user MIGHT instead use thumbnail option with inconsistent width */
+  /* To align any small image inside (useless with some image sizes) */
   display: grid;
+  align-items: center;
   justify-items: center;
 }
 :--article-item .blog-visual:empty {
   display: none;
+}
+
+/* To support vertical layouts at narrow viewports */
+@media (--narrow-and-below) {
+  :--article-item .blog-visual:not(:empty) {
+    margin-bottom: 15px;
+  }
+  :--article-item .blog-visual img {
+    width: 100%;
+    height: auto;
+  }
+}
+/* To support horizontal layouts at wide viewports */
+@media (--narrow-and-above) {
+  :--article-item .blog-visual:not(:empty) {
+    width: 255px; /* for consistent image width (as per design) */
+    margin-right: 50px;
+  }
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -64,14 +64,25 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* Media & Content - Media */
 
-:--article-page .blog-visual {
-  float: left;
-  margin-right: var(--blog-page-main-image-buffer);
-}
 /* To mimic Bootstrap `.img-fluid` */
 :--article-page .blog-visual img {
   max-width: 100%;
   height: auto;
+}
+/* To support vertical layouts at narrow viewports */
+@media (--x-narrow-and-below) {
+  :--article-page .blog-visual {
+    display: grid;
+    justify-content: center;
+    margin-bottom: var(--blog-page-main-image-buffer);
+  }
+}
+/* To support horizontal layouts at wide viewports */
+@media (--x-narrow-and-above) {
+  :--article-page .blog-visual {
+    float: left;
+    margin-right: var(--blog-page-main-image-buffer);
+  }
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/media-queries.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/media-queries.css
@@ -1,0 +1,5 @@
+@import url("@tacc/core-styles/src/lib/_imports/tools/media-queries.css");
+
+@custom-media --xx-narrow-and-below (width < 380px);
+@custom-media --xx-narrow-and-above (width >= 380px);
+@custom-media --xx-narrow-to-x-narrow (380px <= width < 576px);


### PR DESCRIPTION
## Overview

Support narrow viewport layouts for (ECEP) News [list](https://prod.ecep.tacc.utexas.edu/news/) and [article (sample)](https://prod.ecep.tacc.utexas.edu/news/2021/11/09/2021-state-computer-science-education-report-released/).

## Related

- [ECEPWEB-209](https://jira.tacc.utexas.edu/browse/ECEPWEB-209)
- accompanies https://github.com/TACC/Core-CMS/pull/529
- accompanies https://github.com/TACC/Core-CMS/pull/528

## Changes

- responsive design for news list e4b395d + 0e5e443
- responsive design for news article 9e67cbe
- add new media query ranges as xxx-narrow bd6853f *


<sub>* <380, 380+, 380–575 (added to [Shared UI - Constants - Breakpoints / Media Queries](https://confluence.tacc.utexas.edu/x/b4AZCg))</sub>

## Testing & UI

Local: https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes
Remote: https://prod.ecep.tacc.utexas.edu/news
Branch: `site/ecep/main`

<details><summary>responsive design for news list e4b395d + 0e5e443</summary>

1. Open [news list](https://prod.ecep.tacc.utexas.edu/news/).
2. Review layout at different sizes: <380, 576, 768+.

| | before fix | after fix |
| - | - | - |
| **still** 1 column,<br />**now** picture on top | ![before - 379](https://user-images.githubusercontent.com/62723358/182670602-4b19bbed-8f16-4636-87c0-5b98d5617ec5.png) | ![after - 379](https://user-images.githubusercontent.com/62723358/182676981-84031388-ea3e-4ea0-8b79-b31ef68c710f.png) |
| **now** 2 columns,<br />**now** picture on top | ![before - 575](https://user-images.githubusercontent.com/62723358/182670657-303743e1-91ce-4240-8dc9-2c967891d0bc.png) | ![after - 575](https://user-images.githubusercontent.com/62723358/182676956-03e76ea4-a27d-4638-9c83-25c6e668d143.png) |
| **still** 1 column,<br />**still** picture on side | ![before 768](https://user-images.githubusercontent.com/62723358/182670718-b2b13eb1-a2e9-4095-ad3c-d43f631c2693.png) | ![after - 768](https://user-images.githubusercontent.com/62723358/182676926-9874651e-7141-470d-8426-0df7f21db2f4.png) |

</details>

<details><summary>responsive design for news article 9e67cbe</summary>

1. Open [news article (sample)](https://prod.ecep.tacc.utexas.edu/news/2021/11/09/2021-state-computer-science-education-report-released/).
2. Review layout at different sizes: below 576, above 576.

| | before fix | after fix |
| - | - | - |
| viewport > 576px, text **still** wraps around image | ![before - 768](https://user-images.githubusercontent.com/62723358/182641435-52c3d059-2641-45e6-95f1-0a9767b8772c.png) | ![after - 768](https://user-images.githubusercontent.com/62723358/182641890-c6fc04ee-7388-499c-abad-f06ebbc73129.png) |
| viewport < 576px, text **now** falls to below image | ![before - 380](https://user-images.githubusercontent.com/62723358/182641449-33582d27-5936-4d59-8bf5-f5058b471cbc.png) | ![after - 380](https://user-images.githubusercontent.com/62723358/182641865-fb030ef1-53a3-415c-a2e5-5d22bdb14029.png) |

</details>

## Notes

<details><summary>I have design approval.</summary>

References:
- [adobe xd tup news](https://xd.adobe.com/view/297fa738-77c6-4674-b3e5-1af2e44f8f06-7c2c/screen/30512b30-f7cb-4a18-bc8c-5758a251a7e8/specs/)
- [frontera homepage (scroll to news)](https://frontera-portal.tacc.utexas.edu/)

Approval:
![design approval](https://user-images.githubusercontent.com/62723358/182690610-99447400-96a3-4ac3-b7d0-d2c590bc946a.png)

</details>