### PR TITLE
feat: ecep-215 o-float-content--left|right

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.7.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#1d7e7c595dd1b8b88e4bebe2be758cddf1ce1eeb",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#2a5bc4fcac66c803a8bf0fe2e3a973a2fe87002b",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3937,7 +3937,7 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#1d7e7c595dd1b8b88e4bebe2be758cddf1ce1eeb",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#2a5bc4fcac66c803a8bf0fe2e3a973a2fe87002b",
       "dev": true,
       "from": "@tacc/core-styles@github:TACC/Core-Styles#task/ecepweb-215-o-float-content",
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.8.0",
       "license": "MIT",
       "devDependencies": {
-        "@tacc/core-styles": "^0.7.0-beta",
+        "@tacc/core-styles": "github:TACC/Core-Styles#task/ecepweb-215-o-float-content",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -62,10 +62,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.7.0-beta",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.7.0-beta.tgz",
-      "integrity": "sha512-OnD6qlrYe9a+GS1qV34U4ikhutFX/mhqmNDOkxMc9Hj2Nk7Tpl2cxPY3uprmOVackObeVtJ5h4BX4wBCf+VTJg==",
+      "version": "0.7.1",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#1d7e7c595dd1b8b88e4bebe2be758cddf1ce1eeb",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -3937,10 +3937,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.7.0-beta",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.7.0-beta.tgz",
-      "integrity": "sha512-OnD6qlrYe9a+GS1qV34U4ikhutFX/mhqmNDOkxMc9Hj2Nk7Tpl2cxPY3uprmOVackObeVtJ5h4BX4wBCf+VTJg==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#1d7e7c595dd1b8b88e4bebe2be758cddf1ce1eeb",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/ecepweb-215-o-float-content",
       "requires": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.13",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^0.8.0",
+        "@tacc/core-styles": "github:TACC/Core-Styles#3439611",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -260,8 +260,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.8.0.tgz",
-      "integrity": "sha512-I0B04HHXS/LjrOasZlUYdZQ/3jba5iXHawxQRHPqhh4srPfbvMkrAz2nml95tvP0WtELCPEjZeK+9TAybXQUCA==",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#3439611a1304ac8272dfd4c5a8ef2ac1a7227afc",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10054,11 +10053,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.8.0.tgz",
-      "integrity": "sha512-I0B04HHXS/LjrOasZlUYdZQ/3jba5iXHawxQRHPqhh4srPfbvMkrAz2nml95tvP0WtELCPEjZeK+9TAybXQUCA==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#3439611a1304ac8272dfd4c5a8ef2ac1a7227afc",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/ecepweb-215-o-float-content",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#3439611",
       "requires": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "^8.5.5"
   },
   "devDependencies": {
-    "@tacc/core-styles": "^0.7.0-beta",
+    "@tacc/core-styles": "github:TACC/Core-Styles#task/ecepweb-215-o-float-content",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.13",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^0.8.0",
+    "@tacc/core-styles": "github:TACC/Core-Styles#3439611",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -24,6 +24,7 @@
 
 /* OBJECTS */
 @import url("_imports/objects/o-grid.css");
+@import url("_imports/objects/o-float-content.css");
 @import url("_imports/objects/o-offset-content.css");
 @import url("_imports/objects/o-section.css");
 


### PR DESCRIPTION
## Overview

Load a Core-Styles that has `o-float-content--left|right`.

## Related

- [ECEP-215](https://jira.tacc.utexas.edu/browse/ECEP-215)
- requires https://github.com/TACC/Core-Styles/pull/42

## Changes

- load core-styles that has the new class

## Testing

1. Load test pages:
    - https://prod.ecep.tacc.utexas.edu/resources/toolkits-guides/landscape-reports-image-test/ (clears float)
    - https://prod.ecep.tacc.utexas.edu/resources/toolkits-guides/landscape-reports-image/ (does not clear float)
    - https://prod.ecep.tacc.utexas.edu/resources/models-state-change/how-change-state/
2. Verify narrow screen shows full width image.
3. Verify medium screen shows floated image.

## UI

| | 1680px | 992px | 768px |
| - | - | - | - |
| test  1 | ![test 1 1680px](https://user-images.githubusercontent.com/62723358/184014708-dc76730f-76f1-4c45-83f1-4995839109b2.png) | ![test 1 992px](https://user-images.githubusercontent.com/62723358/184014706-f2227708-b7ea-495f-a6c7-f0f1390e8a21.png) | ![test 1 768px](https://user-images.githubusercontent.com/62723358/184014710-92edfe4b-4977-4366-a8c2-a1b1efa5d6e6.png) |
| test 2 | ![test 2 768px](https://user-images.githubusercontent.com/62723358/184014773-a504ef7e-367a-49e4-a7e4-bb3cdd509e59.png) | ![test 2 992px](https://user-images.githubusercontent.com/62723358/184014776-a74938e6-793d-489b-9ded-b25e55b0c40c.png) | ![test 2 1680px](https://user-images.githubusercontent.com/62723358/184014782-6cbea274-321f-44e2-abbe-2854a9681a5b.png) |
