### PR TITLE
fix(settings): TUP-321 make LDAP_ENABLED work

### DIFF
--- a/taccsite_cms/_settings/auth.py
+++ b/taccsite_cms/_settings/auth.py
@@ -1,0 +1,41 @@
+"""Configure django authentication"""
+
+########################
+# DJANGO
+# https://docs.djangoproject.com/en/2.2/ref/settings/#auth
+########################
+
+# To disable LDAP:
+#
+# 1. In custom or local settings, duplicate the AUTHENTICATION_BACKENDS setting.
+# 2. Remove the '...LDAPBackend' entry.
+# 3. If 'INCLUDES_CORE_PORTAL = False', remove '...CorePortalAuthBackend' entry.
+#
+# RFE: Use INCLUDES_CORE_PORTAL to toggle '...CorePortalAuthBackend'.
+
+# Requires django-auth-ldap ≥ 2.0.0
+LDAP_ENABLED = True
+
+AUTHENTICATION_BACKENDS = [
+    "django.contrib.auth.backends.ModelBackend",
+    "taccsite_cms.remote_cms_auth.CorePortalAuthBackend",
+    "django_auth_ldap.backend.LDAPBackend"
+]
+
+AUTH_LDAP_SERVER_URI = "ldap://ldap.tacc.utexas.edu"
+AUTH_LDAP_CONNECTION_OPTIONS = {ldap.OPT_REFERRALS: 0}
+AUTH_LDAP_START_TLS = True
+AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = True
+AUTH_LDAP_BIND_DN = ""
+AUTH_LDAP_BIND_PASSWORD = ""
+AUTH_LDAP_AUTHORIZE_ALL_USERS = True
+
+AUTH_LDAP_USER_SEARCH = LDAPSearch(
+    "ou=People,dc=tacc,dc=utexas,dc=edu", ldap.SCOPE_SUBTREE, "(uid=%(user)s)"
+)
+
+AUTH_LDAP_USER_ATTR_MAP = {
+    "first_name": "givenName",
+    "last_name": "sn",
+    "email": "mail",
+}

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -59,27 +59,31 @@ DATABASES = {
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     "taccsite_cms.remote_cms_auth.CorePortalAuthBackend",
-    "django_auth_ldap.backend.LDAPBackend"
 ]
 
 ''' LDAP Auth Settings '''
-AUTH_LDAP_SERVER_URI = "ldap://ldap.tacc.utexas.edu"
-AUTH_LDAP_CONNECTION_OPTIONS = {ldap.OPT_REFERRALS: 0}
-AUTH_LDAP_START_TLS = True
-AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = True
-AUTH_LDAP_BIND_DN = ""
-AUTH_LDAP_BIND_PASSWORD = ""
-AUTH_LDAP_AUTHORIZE_ALL_USERS = True
+if LDAP_ENABLED:
+    AUTHENTICATION_BACKENDS += [
+        "django_auth_ldap.backend.LDAPBackend"
+    ]
 
-AUTH_LDAP_USER_SEARCH = LDAPSearch(
-    "ou=People,dc=tacc,dc=utexas,dc=edu", ldap.SCOPE_SUBTREE, "(uid=%(user)s)"
-)
+    AUTH_LDAP_SERVER_URI = "ldap://ldap.tacc.utexas.edu"
+    AUTH_LDAP_CONNECTION_OPTIONS = {ldap.OPT_REFERRALS: 0}
+    AUTH_LDAP_START_TLS = True
+    AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = True
+    AUTH_LDAP_BIND_DN = ""
+    AUTH_LDAP_BIND_PASSWORD = ""
+    AUTH_LDAP_AUTHORIZE_ALL_USERS = True
 
-AUTH_LDAP_USER_ATTR_MAP = {
-    "first_name": "givenName",
-    "last_name": "sn",
-    "email": "mail",
-}
+    AUTH_LDAP_USER_SEARCH = LDAPSearch(
+        "ou=People,dc=tacc,dc=utexas,dc=edu", ldap.SCOPE_SUBTREE, "(uid=%(user)s)"
+    )
+
+    AUTH_LDAP_USER_ATTR_MAP = {
+        "first_name": "givenName",
+        "last_name": "sn",
+        "email": "mail",
+    }
 
 SITE_ID = 1
 

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -16,6 +16,7 @@ from django_auth_ldap.config import LDAPSearch, GroupOfNamesType
 
 from django.utils.translation import gettext_lazy as _
 
+from taccsite_cms._settings.auth import *
 from taccsite_cms._settings.form_plugin import *
 from taccsite_cms._settings.form_plugin import (
     _INSTALLED_APPS as form_plugin_INSTALLED_APPS
@@ -35,9 +36,6 @@ DEBUG = True       # False for Prod.
 # ALLOWED_HOSTS = ['hostname.tacc.utexas.edu', 'host.ip.v4.address', '0.0.0.0', 'localhost', '127.0.0.1']   # In production.
 ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']   # In development.
 
-# Requires django-auth-ldap ≥ 2.0.0
-LDAP_ENABLED = True
-
 # Default portal authorization verification endpoint.
 CEP_AUTH_VERIFICATION_ENDPOINT = 'localhost'  # 'https://0.0.0.0:8000'
 
@@ -56,34 +54,9 @@ DATABASES = {
     }
 }
 
-AUTHENTICATION_BACKENDS = [
-    "django.contrib.auth.backends.ModelBackend",
-    "taccsite_cms.remote_cms_auth.CorePortalAuthBackend",
-]
-
-''' LDAP Auth Settings '''
-if LDAP_ENABLED:
-    AUTHENTICATION_BACKENDS += [
-        "django_auth_ldap.backend.LDAPBackend"
-    ]
-
-    AUTH_LDAP_SERVER_URI = "ldap://ldap.tacc.utexas.edu"
-    AUTH_LDAP_CONNECTION_OPTIONS = {ldap.OPT_REFERRALS: 0}
-    AUTH_LDAP_START_TLS = True
-    AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = True
-    AUTH_LDAP_BIND_DN = ""
-    AUTH_LDAP_BIND_PASSWORD = ""
-    AUTH_LDAP_AUTHORIZE_ALL_USERS = True
-
-    AUTH_LDAP_USER_SEARCH = LDAPSearch(
-        "ou=People,dc=tacc,dc=utexas,dc=edu", ldap.SCOPE_SUBTREE, "(uid=%(user)s)"
-    )
-
-    AUTH_LDAP_USER_ATTR_MAP = {
-        "first_name": "givenName",
-        "last_name": "sn",
-        "email": "mail",
-    }
+########################
+# (some) CMS SETTINGS
+########################
 
 SITE_ID = 1
 


### PR DESCRIPTION
## Overview

Make the `LDAP_ENABLED` setting actually do something.

<details>I did not find when it lost its effect (or if it ever had effect), but Jake and I suspect it does nothing. I do not see the setting used anywhere in Core-CMS code. But H.P. can login to tup-cms with her LDAP creds, even though we disabled that (for sure).</details>

## Related

None.

## Changes

- use `LDAP_ENABLED` to conditionally update and set settings

## Testing

(I'm not familiar enough with LDAP nor Django to test this locally. I am not focused enough to write better remote testing steps.)

1. Deploy on a server: https://dev.tup.tacc.utexas.edu/
2. Try to login with LDAP credentials.
3. Verify you cannot login.

## UI

N/A
