### PR TITLE
fix(templates): programatic current year in footer

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -76,7 +76,7 @@
   {% block footer %}
 
     {% static_placeholder "footer-content" or %}
-    <p>©2020 Texas Advanced Computing Center, The University of Texas at Austin, Office of the Vice President for Research.</p>
+    <p>©{% now "Y" %} Texas Advanced Computing Center, The University of Texas at Austin, Office of the Vice President for Research.</p>
     {% endstatic_placeholder %}
 
   {% endblock footer %}


### PR DESCRIPTION
## Overview

Auto-updated current year for __default__ footer.

_This is a minimal fix. If admin add s custom content too footer, admin must still keep year up to date._

## Related

N/A

## Changes

- replace manual year with template logic to get current year

## Testing

1. Load a CMS that this branch and no content in its footer.
2. Confirm footer shows default text and current year.

## UI

![Screen Shot 2022-08-15 at 11 07 34](https://user-images.githubusercontent.com/62723358/184672195-be3a0349-2559-47ef-b101-9ecdcfadedd7.png)

