### PR TITLE
fix(django): implement djangocms-text-ckeditor#568

### DIFF
--- a/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
+++ b/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
@@ -1,0 +1,6 @@
+/* IMPORTANT: Unnecessary if we use djangocms-text-ckeditor@5.0.0 */
+
+@import url("https://raw.githubusercontent.com/django-cms/djangocms-text-ckeditor/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/css/cms.ckeditor.css");
+
+/* https://github.com/django-cms/djangocms-text-ckeditor/pull/590 */
+textarea.cke_source { max-height: inherit; }


### PR DESCRIPTION
## Overview

Implement the #568 fix from PR #590 until we update our ckeditor to v5.

This will save H.P. (main CMS admin/designer) so many tiny bits of time, because she must resize a modal every time she wants to edit source, which is many times everyday.

## Related

N/A

## Changes

- extend `djangocms-text-ckeditor` css
- duplicate the relevant fix

## Testing

1. Be logged into CMS as admin.
2. Add a Text plugin instance.
3. Edit Text plugin instance content as source (the "[<>] Source" button, top-right).
4. Confirm the textarea (in which to edit source markup) fills available vertical space.

## UI

<img width="868" alt="Screen Shot 2022-08-15 at 19 25 03" src="https://user-images.githubusercontent.com/62723358/184758124-108729a5-75e2-44a8-b360-a88679c23a1e.png">

<sub>I am using Dark Reader browser extension; that is why it is dark gray, not white.</sub>