### PR TITLE
fix: fp-1782 form plugin file upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ djangocms-blog = "1.1.1"
 djangocms-bootstrap4 = "2.0.0"
 djangocms-column = "1.11.0"
 djangocms-file = "3.0.0"
-djangocms-forms-maintained = { git = "https://github.com/avryhof/djangocms-forms", rev = "eaa6415efeefc8a3018450d0ca7b864e0e4b9dd2" }
+djangocms-forms-maintained = { git = "https://github.com/avryhof/djangocms-forms", rev = "d8a69efd2f447ee2f940c7b6f5b8b088c9cb79ed" }
 djangocms-googlemap = "2.0.0"
 djangocms-icon = "2.0.0"
 djangocms-link = "3.0.0"

--- a/taccsite_cms/_settings/form_plugin.py
+++ b/taccsite_cms/_settings/form_plugin.py
@@ -70,15 +70,6 @@ DJANGOCMS_FORMS_FIELDSETS = (
             ),
         },
     ),
-    (
-        _('Limitations ⚠️'),
-        {
-            'description': '<ol>\
-                <li>File upload is not supported.</li>\
-            </ol>',
-            'fields': ()
-        },
-    ),
 )
 
 DJANGOCMS_FORMS_FORMAT_CHOICES = (

--- a/taccsite_cms/_settings/form_plugin.py
+++ b/taccsite_cms/_settings/form_plugin.py
@@ -3,17 +3,6 @@
 from django.utils.translation import gettext_lazy as _
 
 ########################
-# KNOWN ISSUES
-########################
-
-# Unable to export to Excel nor YAML
-# (No success hiding those formats from editor)
-# https://github.com/avryhof/djangocms-forms/issues/8
-
-# Unable to submit files
-# https://github.com/avryhof/djangocms-forms/issues/14
-
-########################
 # DJANGO_RECAPTCHA
 # https://github.com/avryhof/django-recaptcha/
 ########################


### PR DESCRIPTION
## Overview

Ensure file upload works i.e. install form plugin at https://github.com/avryhof/djangocms-forms/commit/d8a69ef.

## Related

- [FP-1782](https://jira.tacc.utexas.edu/browse/FP-1782)

## Changes

- remove comment about known issue that had been fixed
- remove comment about known issue that is recently fixed i.e. https://github.com/avryhof/djangocms-forms/issues/14
- remove warning about feature limitations

## Testing

Not yet remotely deployed.

1. Create form plugin instance.
2. Add field for "File Upload".
3. Submit form.
4. In "Site administration", open "Form submissions".
5. Open your submission there.
6. Confirm uploaded file is listed (as a link).
7. Confirm you can open/download the file.

## UI

| my local form | list uploaded file | view uploaded file |
| - | - | - |
| ![form](https://user-images.githubusercontent.com/62723358/185460923-7e34b210-67b0-4f59-946a-004927642b9a.png) | ![uploaded](https://user-images.githubusercontent.com/62723358/185460925-32415576-d3d3-4522-a711-e82b7f8baa2e.png) | ![view](https://user-images.githubusercontent.com/62723358/185460926-1e4db249-4bee-4f2c-a92b-5a6a0b8fcda3.png) |

