### PR TITLE
fix(settings): fp-1823 do not support email server by default

### DIFF
--- a/taccsite_cms/_settings/email.py
+++ b/taccsite_cms/_settings/email.py
@@ -7,12 +7,19 @@
 
 # Development, Staging, Production
 # https://confluence.tacc.utexas.edu/x/coR9E
-# EMAIL_HOST = "relay.tacc.utexas.edu"
+# !!!: Do NOT enable on a local computer!
+#      Misue will trigger a security alert,
+#      and your computer will be confiscated!
+# EMAIL_HOST = "..."
 # DEFAULT_FROM_EMAIL = 'no-reply@...' # where ... is project's production domain
 
 # Debugging
 # https://docs.djangoproject.com/en/2.1/topics/email/#configuring-email-for-development
-# EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# !!!: Do NOT enable on a local computer!
+#      Misue will trigger a security alert,
+#      and your computer will be confiscated!
+# EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # EMAIL_HOST = 'localhost'
 # EMAIL_PORT = 1025
 # DEFAULT_FROM_EMAIL = 'no-reply@localhost'


### PR DESCRIPTION
## Overview

1. Do not add default e-mail settings to use a remote mail server.
2. Warn others not to accidentally do the same.

## Related

- [FP-1823](https://jira.tacc.utexas.edu/browse/FP-1823)
- required by https://github.com/TACC/Core-CMS-Resources/pull/165
- required by https://github.com/TACC/Core-CMS-Custom/pull/7

## Changes

- remove hard-coded remote e-mail server from a comment
- change default e-mail setting to send mail content to console
- warn developer about misuse of e-mail settings

## Testing

1. Clone repo [TACC/Core-CMS] **or** [TACC/Core-CMS-Custom].
2. Set it up to run a CMS configured for APCD.
    - For [TACC/Core-CMS], follow its `/README.md`.
    - For [TACC/Core-CMS-Custom], follow its `/apcd-cms/README.md`.
3. Create a form using the Form plugin.
4. Configure the form to send an e-mail upon submission.
5. Submit the form.
6. Verify form submission success message appears.
7. Verify CMS docker container logs mail content that would be sent.

## UI

<details><summary>Video</summary>

https://user-images.githubusercontent.com/62723358/187781347-58101466-ac33-4b5f-86b9-97604a94aa2d.mov

</details>
<details><summary>Screenshot</summary>

![FP-1823](https://user-images.githubusercontent.com/62723358/187781349-03e8ae6b-b8fe-48a7-a32d-a86f5078fa83.png)

</details>

[TACC/Core-CMS-Resources]: https://github.com/TACC/Core-CMS-Resources
[TACC/Core-CMS-Custom]: https://github.com/TACC/Core-CMS-Custom/tree/main/apcd-cms
[TACC/Core-CMS]: https://github.com/TACC/Core-CMS