### PR TITLE
feat(css): fp-1808 warning, unsupported form field

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
@@ -8,9 +8,10 @@ Reference:
 - [Django CMS Form Default Template](https://github.com/avryhof/djangocms-forms/blob/master/djangocms_forms/templates/djangocms_forms/form_template/default.html)
 - [TACC's Django CMS Form Default Template](https://github.com/TACC/Core-CMS/blob/master/taccsite_cms/templates/djangocms_forms/form_template/default.html)
 
-Styleguide Components.DjangoCMS.Forms.App
+Styleguide Components.DjangoCMS.Forms
 */
 @import url("@tacc/core-styles/src/lib/_imports/components/c-button.css");
+@import url("./django.cms.forms.hacks.css");
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.hacks.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.hacks.css
@@ -1,0 +1,55 @@
+/*
+Django CMS Form Hacks
+
+Render temporary messages to warn users and admins about unsupported feature(s) of the Django CMS Form plugin.
+
+Reference:
+
+- [FP-1808](https://jira.tacc.utexas.edu/browse/FP-1808)
+
+Styleguide Components.DjangoCMS.Forms.Hacks
+*/
+@import url("_imports/tools/selectors.css");
+/* TACC/Core-CMS#531: When merged, import and extend `.c-message(...)` */
+/* @import url("@tacc/core-styles/src/lib/_imports/components/c-message.css"); */
+
+@custom-selector :--problem-field
+  .field-wrapper.checkboxselectmultiple.required;
+
+/* HACK: Messages about a required multi-checkbox field */
+:--problem-field > label::after {
+  display: block;
+  margin-top: 0.5em;
+
+  /* To mimic c-message */
+  /* https://github.com/TACC/tup-ui/blob/main/libs/core-styles/src/lib/_imports/components/c-message.css */
+  padding: 15px 20px;
+  border: var(--global-border--thick);
+  font-size: var(--global-font-size--small);
+  /* TACC/Core-CMS#531: When merged, import and extend `.c-message(...)` */
+  /* @extend .c-message; */
+}
+/* To give error to admin */
+html:--cms-edit-mode :--problem-field > label::after {
+  content: 'A multi checkbox field that is required is not well implemented. Do not require this field or replace it with multiple required Yes/No radio fields.';
+
+  /* To mimic c-message c-message-error */
+  /* https://github.com/TACC/tup-ui/blob/main/libs/core-styles/src/lib/_imports/components/c-message.css */
+  color: var(--global-color-danger--dark);
+  background-color: var(--global-color-danger--weak);
+  border-color: var(--global-color-danger--normal);
+  /* TACC/Core-CMS#531: When merged, import and extend `.c-message(...)` */
+  /* @extend .c-message--error; */
+}
+/* To give warning to user */
+html:not(:--cms-edit-mode) :--problem-field > label::after {
+  content: 'This field is not well implemented. Select all boxes to bypass the error with this field.';
+
+  /* To mimic c-message c-message-warning */
+  /* https://github.com/TACC/tup-ui/blob/main/libs/core-styles/src/lib/_imports/components/c-message.css */
+  color: var(--global-color-warning--dark);
+  background-color: var(--global-color-warning--weak);
+  border-color: var(--global-color-warning--normal);
+  /* TACC/Core-CMS#531: When merged, import and extend `.c-message(...)` */
+  /* @extend .c-message--warning; */
+}


### PR DESCRIPTION
## Overview

Temporary solution for unsupported field configuration of the Django CMS Form plugin. For a Multi Checkbox field that is Required, render a message to alarm admins (so they do not use this broken combination) and a message to warn users (in case admin ignored error), so users know how to bypass the problem.

## Related

- [FP-1808](https://jira.tacc.utexas.edu/browse/FP-1808)
- relied on by https://github.com/TACC/Core-CMS-Custom/pull/8

## Changes

- import new hack stylesheet
- author messages for user and admin about unsupported form field

## Testing

Remote: https://apcd-qa.tacc.utexas.edu/test/fp-1773-e-mail-test/
or Local: https://localhost:8000

0. Log in to CMS running off this branch.
2. Create form on a Django CMS page with a Multi-Checkbox field.
3. Ensure the Multi-Checkbox field you add is required. (Check the box "Required".)
4. Save the form.
5. Verify an error (red) appears for that field:
    > A multi checkbox field that is required is not well implemented. [...]
6. Verify a warning (yellow) message does not appear.
7. Publish the page change.
8. Verify a warning (yellow) appears for that field:
    > This field is not well implemented. [...]
9. Verify an error (red) message does not appear.

## UI

| Admin Error | User Warning |
| - | - |
| ![Admin Error](https://user-images.githubusercontent.com/62723358/187943821-9224026d-1613-47bb-a2fb-709e739797aa.jpeg) | ![User Warning](https://user-images.githubusercontent.com/62723358/187943827-9947ba77-4b53-4804-b894-da61429945c9.jpeg) |

## Notes

The yellow warning does not look great, but it does match Portal. [TUP-175](https://jira.tacc.utexas.edu/browse/TUP-175) will provide new colors later via Core-Styles.