### PR TITLE
feat(core-styles): install 0.8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.13",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles",
+        "@tacc/core-styles": "^0.8.6",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -259,10 +259,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.8.2",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#c26ebf007ab661d25e7df2abef184691528e108d",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.8.6.tgz",
+      "integrity": "sha512-cxM+6/NjckDp6p1bOO4GHU4loEcy8KHqsaS2s4xfGN30gYAf62kT2U5KCeAaqLrLA4gUR5tPrBxWsch+3lTOmg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",
@@ -10190,9 +10190,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#c26ebf007ab661d25e7df2abef184691528e108d",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.8.6.tgz",
+      "integrity": "sha512-cxM+6/NjckDp6p1bOO4GHU4loEcy8KHqsaS2s4xfGN30gYAf62kT2U5KCeAaqLrLA4gUR5tPrBxWsch+3lTOmg==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles",
       "requires": {
         "commander": "^9.0.0",
         "cssnano": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.13",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles",
+    "@tacc/core-styles": "^0.8.6",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",


### PR DESCRIPTION
## Overview & Changes

install [TACC/Core-Styles](https://github.com/TACC/Core-Styles) via node package [@tacc/core-styles](https://www.npmjs.com/package/@tacc/core-styles) at newly-released v0.8.6 (instead of repo at `main` branch).

## Related & Testing & UI

N/A

## Notes

This is a noop, because I just installed latest main before the release.