### PR TITLE
fix: tup-340 portal nav not loading

### DIFF
--- a/taccsite_cms/urls.py
+++ b/taccsite_cms/urls.py
@@ -39,16 +39,20 @@ if getattr(settings, 'INCLUDES_CORE_PORTAL', True):
         url(r'^remote/login/$', remote_cms_auth.verify_and_auth, name='verify_and_auth'),
     ]
 
+# Let custom CMS apps override any URLs below
 try:
     from .urls_custom import custom_urls
     urlpatterns += custom_urls
 except ImportError:
     pass
 
-urlpatterns += [
-    # To provide markup when Portal is missing
-    url(r'^core/markup/nav/$', TemplateView.as_view(template_name='nav_portal.raw.html'), name='portal_nav_markup'),
+if getattr(settings, 'INCLUDES_PORTAL_NAV', True):
+    urlpatterns += [
+        # To provide markup when Portal is missing
+        url(r'^core/markup/nav/$', TemplateView.as_view(template_name='nav_portal.raw.html'), name='portal_nav_markup'),
+    ]
 
+urlpatterns += [
     # The Django CMS urls
     url(r'^', include('cms.urls')),
 ]


### PR DESCRIPTION
## Overview

Only set CMS "core/portal/nav" URL if "INCLUDES_PORTAL_NAV = True".

<details><summary><strong>Background</strong></summary>

1. Portal's intercepts "core/markup/nav/" URL.
2. CMS (via new "feature") intercepts "core/markup/nav/" URL.﹡
3. CMS’s takes precedence (instead of Portal’s, as I planned).
4. CMS Portal nav template is (intentionally) empty.
5. Login button (i.e. Portal nav) is not visible.

﹡Intended as a fallback for when Portal is not present. Source: #557

</details>

## Related

- fixes https://github.com/TACC/Core-CMS/pull/557

## Changes

- add a comment
- **add condition for CMS portal nav URL**

## Testing

1. Test CMS with a local Portal instance.
    <sup>See wiki article [Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes) sections "Via …  on Local Portal", or teach me a simpler way.</sup>
2. Update CMS tag.
    <sup>Because using `:latest` does not load latest, even with `docker compose … build --no-cache` and `docker compose … up cms --force-recreate`.</sup>
    1. Change [.../docker-compose-dev.all.debug.yml](https://github.com/TACC/Core-Portal/blob/07967dc/server/conf/docker/docker-compose-dev.all.debug.yml#L7) from `taccwma/core-cms:latest` to `taccwma/core-cms:0cde4e3`.
    2. Run `docker-compose -f ./server/conf/docker/docker-compose-dev.all.debug.yml up cms --force-recreate`.
3. Open the Portal instance of the CMS in a browser.
    <sup>I.e. [`https://cep.test/`](https://cep.test/).</sup>
4. Verify certain setting combinations have expected result.
    <sup>CMS settings can be put in `server/conf/cms/secrets.py` (or `server/conf/cms/settings_local.py` if that is being read… mine was not).</sup>

| # | CMS Setting | Expectations |
| - | - | - |
| 1 | `INCLUDES_CORE_PORTAL = True`<br />`INCLUDES_PORTAL_NAV = True` | • _cms_: **has** space for search / portal nav<br />• _cms_: **has** portal nav<br />• _portal_: **has** header |
| 2 | `INCLUDES_CORE_PORTAL = False`<br />`INCLUDES_PORTAL_NAV = False` | • _cms_: **has** space for search / portal nav<br />• _cms_: **no**  portal nav<br />• _portal_: **no** header |
| 3 | `INCLUDES_CORE_PORTAL = True`<br />`INCLUDES_PORTAL_NAV = False` | • _cms_: **has** space for search / portal nav<br />• _cms_: **no**  portal nav<br />• _portal_: **has** header |
| 4 | `INCLUDES_CORE_PORTAL = False`<br />`INCLUDES_PORTAL_NAV = True` | • _cms_: **has** space for search / portal nav<br />• _cms_: **has**  portal nav<br />• _portal_: **no** header |

<details>

- By "portal nav", I mean login button, username dropdown, and portal dropdown.
- There is also an `INCLUDES_SEARCH_BAR` setting.
    - It [defaults to `True` (indirectly)](https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/settings.py#L238-L240) that is why:
        - search bar is always present
        - CMS always "has space for search / portal nav"
- To make cms **not** have space for search / portal nav:

       ```
        INCLUDES_PORTAL_NAV = False
        INCLUDES_SEARCH_BAR = False
        ```

        <sup>Other combinations are not well tested, because use cases do not exist yet.</sup>

</details>

## UI

<details><summary>Example</summary>

<img width="1280" alt="Core-CMS PR 561 Fix Sample" src="https://user-images.githubusercontent.com/62723358/199125560-bb3bcc67-c973-4576-8334-166cd8952084.png">

</details>

## Notes

I use `INCLUDES_PORTAL_NAV` not `INCLUDES_CORE_PORTAL`, because a CMS (e.g. [`tup-cms`](https://github.com/TACC/tup-ui/tree/main/apps/tup-cms)) _accurately_ sets `INCLUDES_CORE_PORTAL = False` and [creates its own Portal nav](https://github.com/TACC/tup-ui/pull/58/files#diff-84c70e40babc66dbb92e44eaa202ef9b125f01a91fb8463317fb9b2cee8b89f2).