### PR TITLE
feat: fp-1500 serve ui pattern lib (as static files)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "build": "npm run build:css && npm run build:css-demo",
     "build:css": "bin/build-css.js --project=$npm_config_project --build-id=$npm_config_build_id",
     "postbuild": "cp -r node_modules/@tacc/core-styles/src/lib/fonts/* taccsite_cms/static/site_cms/fonts",
-    "start:css-demo": "cd taccsite_ui && npx serve dist",
     "build:css-demo": "cd taccsite_ui && fractal build --project=$npm_config_project"
   },
   "homepage": "https://github.com/TACC/Core-CMS"

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -270,7 +270,9 @@ STATICFILES_DIRS = (
     # os.path.join(BASE_DIR, 'taccsite_cms', 'en', 'static'),
 ) + tuple(glob(
     os.path.join(BASE_DIR, 'taccsite_custom', '*', 'static')
-))
+)) + (
+    ('ui', os.path.join(BASE_DIR, 'taccsite_ui', 'dist')),
+)
 
 # User Uploaded Files Location.
 MEDIA_URL = '/media/'


### PR DESCRIPTION
## Overview

Serve the Pattern Library as static files.﹡

<sup>﹡ Until WMA can provide a solution that is better (see "Notes").</sup>

## Related

- [FP-1500](https://jira.tacc.utexas.edu/browse/FP-1500)

## Changes

- feat: serve ui pattern library as static files (3e85136)
- fix: remove alternate local server for pattern library (00c0f66)

## Testing

Remote: https://dev.tup.tacc.utexas.edu/static/ui/index.html

1. Load CMS.
2. Open `/static/ui/index.html`.
3. See Pattern Library.

## UI

| Localhost | TUP CMS |
| - | - |
| ![fp-1500](https://user-images.githubusercontent.com/62723358/199261054-8f0872f5-8591-4039-8416-2e9841249d0d.png) | ![fp-1500 on tup](https://user-images.githubusercontent.com/62723358/199265961-4d72ba01-c144-440e-b410-cff789669150.png) |

## Notes

<details><summary>My <strong>complaints</strong> (I accept for now) about this solution...</summary>

- an ugly URL
- a possibly unnecessary coupling to Django
- no shared header﹡

<sup>﹡ I tried really hard the weekend before last to make this happen. I don't think it is possible, even with custom apps, without an iframe. Please prove me wrong.</sup>

</details>

<details><summary>Why <strong>remove</strong> <code>start:css-demo</code> (not serve library locally)?</summary>

So we have only one way to serve the library, to:
- prevent confusion for new devs
- prevent test mistake (i.e. "worked on this server, but not that server")

</details>