### PR TITLE
feat(css): fp-1828 move apcd styles to core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.13",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#task/fp-1828-move-apcd-styles-to-core",
+        "@tacc/core-styles": "github:TACC/Core-Styles#df656f8",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -511,7 +511,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.9.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#fe846f62c908ab7d13006db9d0d4872f4e4187e9",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#df656f835f4bfaf29288ef82b0c82086e575b5d1",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9498,9 +9498,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#fe846f62c908ab7d13006db9d0d4872f4e4187e9",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#df656f835f4bfaf29288ef82b0c82086e575b5d1",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/fp-1828-move-apcd-styles-to-core",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#df656f8",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.13",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#75ea79c0",
+        "@tacc/core-styles": "github:TACC/Core-Styles#task/fp-1828-move-apcd-styles-to-core",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -511,7 +511,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.9.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#75ea79c047d17c2eb1554ce5e18b704bcc302928",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#fe846f62c908ab7d13006db9d0d4872f4e4187e9",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9498,9 +9498,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#75ea79c047d17c2eb1554ce5e18b704bcc302928",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#fe846f62c908ab7d13006db9d0d4872f4e4187e9",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#75ea79c0",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/fp-1828-move-apcd-styles-to-core",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.13",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#task/fp-1828-move-apcd-styles-to-core",
+    "@tacc/core-styles": "github:TACC/Core-Styles#df656f8",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.13",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#75ea79c0",
+    "@tacc/core-styles": "github:TACC/Core-Styles#task/fp-1828-move-apcd-styles-to-core",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
@@ -33,23 +33,13 @@ Styleguide Components.DjangoCMS.Forms
   ul, /* FAQ: Lists already have margin-bottom */
   label /* FAQ: Labels already have margin-bottom */
 ) + .help-text {
-    margin-top: 0.3em; /* mimic Bootstrap _reboot.css label margin-bottom *\/
+    margin-top: 0.3em; /* mimic Bootstrap _reboot.css label margin-bottom */
 }
 /* To prevent help text font-style from affecting any tags */
 /* FAQ: Help text can contain inline elements like <samp> */
 /* FAQ: Help text can be (ab)used to add headings between form fields */
 .help-text > :not(details, a, samp) {
   font-style: initial;
-}
-
-
-
-/* Labels */
-
-.help-text .field-wrapper:first-child label {
-  /* To mimic .field-wrapper `margin-bottom: 2rem` */
-  /* IDEA: Change .field-wrapper margin to be on top except for first */
-  margin-top: 2rem;
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
@@ -15,23 +15,46 @@ Styleguide Components.DjangoCMS.Forms
 
 
 
-/* Content */
+/* Title & Description */
 
 .description {
   margin-block: 25px;
 }
 
+
+
+/* Help Text */
+
 .help-text {
   font-size: var(--global-font-size--small);
   font-style: italic;
 }
-:not(ul) + .help-text {
-  margin-top: 0.3em; /* mimic Bootstrap _reboot.css label { margin-bottom } */
+:not(
+  ul, /* FAQ: Lists already have margin-bottom */
+  label /* FAQ: Labels already have margin-bottom */
+) + .help-text {
+    margin-top: 0.3em; /* mimic Bootstrap _reboot.css label margin-bottom *\/
+}
+/* To prevent help text font-style from affecting any tags */
+/* FAQ: Help text can contain inline elements like <samp> */
+/* FAQ: Help text can be (ab)used to add headings between form fields */
+.help-text > :not(details, a, samp) {
+  font-style: initial;
 }
 
 
 
-/* Field */
+/* Labels */
+
+.help-text .field-wrapper:first-child label {
+  /* To mimic .field-wrapper `margin-bottom: 2rem` */
+  /* IDEA: Change .field-wrapper margin to be on top except for first */
+  margin-top: 2rem;
+}
+
+
+
+/* Fields */
 
 .field-wrapper {
   margin-bottom: 2rem; /* mimic <p> `margin-bottom` */
@@ -40,21 +63,6 @@ Styleguide Components.DjangoCMS.Forms
 .field-wrapper:not(.checkboxinput) {
   display: flex;
   flex-direction: column;
-}
-.field-wrapper:not(
-  .dateinput,
-  .timeinput,
-  .radioselect,
-  .checkboxinput
-) {
-  align-items: stretch;
-}
-.field-wrapper:is(
-  .dateinput,
-  .timeinput,
-  .radioselect
-) {
-  align-items: start;
 }
 .field-wrapper:not(.checkboxinput) > .field-errors {
   order: 1; /* i.e. move to end */
@@ -90,21 +98,49 @@ ul.checkboxselectmultiple li:last-child label {
   margin-bottom: 0; /* overwrite forms.css label */
 }
 
-.asterisk {
+/* Field: Required, Asterisk, Important */
+
+.field-wrapper.required label {
+  font-weight: var(--bold);
+}
+.field-wrapper.required .asterisk {
+  font-weight: var(--regular);
+}
+
+/* To not render space from markup between label and asterisk */
+/* FAQ: The `:has(sup, sub)` prevents a <sup>7</sup> from being too high/low */
+.field-wrapper.required:has(label .asterisk) label:has(sub, sup) {
+  display: flex;
+  align-items: center;
+}
+
+.field-wrapper .asterisk {
   margin-left: 0.5em;
+}
+.field-wrapper.required .asterisk {
   color: var(--global-color-danger--dark);
 }
-/* To replace markup text "*" with new text "(required)" */
-.asterisk {
+.field-wrapper:not(.required) .asterisk
+/* NOTE: Manual markup ONLY; form plugin can't render non-required asterisk */ {
+  color: var(--global-color-warning--dark);
+}
+/* To replace asterisk character with text */
+.field-wrapper .asterisk {
   width: 0;
   display: inline-block;
   visibility: hidden;
   line-height: 0;
 }
-.asterisk::after {
-  content: '(required)';
+.field-wrapper .asterisk::after {
   visibility: visible;
   line-height: initial;
+}
+.field-wrapper.required .asterisk::after {
+  content: '(required)';
+}
+.field-wrapper:not(.required) .asterisk::after
+/* NOTE: Manual markup ONLY; form plugin can't render non-required asterisk */ {
+  content: '(important)';
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.forms.css
@@ -90,10 +90,10 @@ ul.checkboxselectmultiple li:last-child label {
 
 /* Field: Required, Asterisk, Important */
 
-.field-wrapper.required label {
+.field-wrapper.required > label {
   font-weight: var(--bold);
 }
-.field-wrapper.required .asterisk {
+.field-wrapper.required > label .asterisk {
   font-weight: var(--regular);
 }
 

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -51,3 +51,4 @@
 @import url("_imports/trumps/s-blockquote.css");
 @import url("_imports/trumps/u-empty.css");
 @import url("@tacc/core-styles/src/lib/_imports/trumps/u-mailto-text-replace.css");
+@import url("@tacc/core-styles/src/lib/_imports/trumps/s-affixed-input-wrapper.css");


### PR DESCRIPTION
## Overview

Add APCD styles (for Django form plugin classes).

## Related

- [FP-1828](https://jira.tacc.utexas.edu/browse/FP-1828)
- requires https://github.com/TACC/Core-Styles/pull/56
- required by https://github.com/TACC/Core-CMS-Custom/pull/42

## Changes

- feat: load [related Core Styles](https://github.com/TACC/Core-Styles/pull/56)
- fix: no `.help-text` margin if after a label
- fix: allow `.help-text` child elements' to retain their font style
- chore: remove unnecessary .`field-wrapper` item alignment
- feat: style "asterisk" text for required **and** _not_-required fields

## Testing & UI

See https://github.com/TACC/Core-CMS-Custom/pull/42.