### PR TITLE
feat: fp-1837 limit nav menu item visibility by group

### DIFF
--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -1,10 +1,13 @@
 {% load menu_tags tacc_uri_shortcuts %}
 
-{# TODO: GL-36/GL-44: Implement dropdown to support more than one tier #}
 {# NOTE: This template content is copied from a third-party plugin that we do not use nor need #}
 {# SEE: https://github.com/jrief/djangocms-bootstrap/blob/aa74994/cms_bootstrap/templates/bootstrap4/menu/navbar.html #}
+
 {% spaceless %}
 {% for child in children %}
+{% limit_visibility_in_menu child as can_view %}
+{% if can_view %}
+
 <li class="nav-item{% if child.selected or child.ancestor %} active{% endif %}{% if child.children %} dropdown{% endif %}">
   {% if child.children %}
     <a
@@ -20,10 +23,15 @@
     <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown">
       {# Bootstrap4 does not support submenus, so nor do we (and other users). See https://github.com/twbs/bootstrap/pull/6342. #}
       {% for grandchild in child.children %}
+      {% limit_visibility_in_menu grandchild as can_view %}
+      {% if can_view %}
+
       <a class="dropdown-item{% if grandchild.selected %} active{% endif %}" href="{{ grandchild|get_menu_uri }}" role="menuitem" {% target_blank grandchild|get_menu_uri %}>
         {{ grandchild.get_menu_title|safe }}
         {% if grandchild.selected %}<span class="sr-only">(current)</span>{% endif %}
       </a>
+
+      {% endif %}
       {% endfor %}
   {% else %}
   <a class="nav-link" href="{{ child|get_menu_uri }}" {% target_blank child|get_menu_uri %}>
@@ -32,5 +40,7 @@
   </a>
   {% endif %}
 </li>
+
+{% endif %}
 {% endfor %}
 {% endspaceless %}

--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -1,4 +1,4 @@
-{% load menu_tags tacc_uri_shortcuts %}
+{% load menu_tags tacc_uri_shortcuts limit_visibility_in_menu %}
 
 {# NOTE: This template content is copied from a third-party plugin that we do not use nor need #}
 {# SEE: https://github.com/jrief/djangocms-bootstrap/blob/aa74994/cms_bootstrap/templates/bootstrap4/menu/navbar.html #}

--- a/taccsite_cms/templatetags/limit_visibility_in_menu.py
+++ b/taccsite_cms/templatetags/limit_visibility_in_menu.py
@@ -55,6 +55,7 @@ def limit_visibility_in_menu(context, menu_item):
     # FAQ: Example Logic
     #
     # if (
+    #     user.is_superuser or
     #     page_id == 'certain_groups_only_page' and has_certain_groups(user) or
     #     page_id == 'some_group_only_page' and is_specific_group(user) or
     #     not bool(page_id)

--- a/taccsite_cms/templatetags/limit_visibility_in_menu.py
+++ b/taccsite_cms/templatetags/limit_visibility_in_menu.py
@@ -1,0 +1,66 @@
+from django import template
+from urllib.parse import urlparse
+from django.utils.html import format_html
+from django.contrib import auth as auth
+
+register = template.Library()
+
+# NOTE: This file, in Core CMS, is an example.
+# REQUIRES: Registering simple_tag "limit_visibility_in_menu" that returns True.
+# EXAMPLE USAGE: https://github.com/TACC/Core-CMS-Custom/pull/45
+
+# INSTRUCTIONS
+# (only for a Core-CMS-Custom app)
+#
+# 1. Clone this file into the app's matching directory.
+# 2. The CMS should add Page IDs and User Groups as needed.
+# 3. The example functions and example logic may be built upon or replaced
+
+# FAQ: Example Functions
+#
+# def has_certain_groups(user):
+#     for group in user.groups.all():
+#         if group.name in ['SOME_GROUP', 'ANOTHER_GROUP', 'YET_ANOTHER']:
+#             return True
+#     return False
+#
+# def is_specific_group(user):
+#     return user.groups.filter(name='SOME_GROUP').exists()
+
+@register.simple_tag(takes_context=True)
+def limit_visibility_in_menu(context, menu_item):
+    """
+    Custom Template Tag `limit_visibility_in_menu`
+
+    Use: Return (boolean) whether given menu item is visible by current user.
+
+    Load custom tag into template:
+        {% load limit_visibility_in_menu %}
+
+    Template inline usage:
+        {# (renders `True` or `False`) #}
+        {% limit_visibility_in_menu menu_item %}
+
+        {# (renders "A" or "B") #}
+        {% limit_visibility_in_menu menu_item as can_view %}
+        {% if can_view %} A {% else %} B {% endif %}
+
+    Example:
+        ../templates/cms_menu.html
+    """
+    request = context['request']
+    user = request.user
+    page_id = menu_item.attr['reverse_id']
+
+    # FAQ: Example Logic
+    #
+    # if (
+    #     page_id == 'certain_groups_only_page' and has_certain_groups(user) or
+    #     page_id == 'some_group_only_page' and is_specific_group(user) or
+    #     not bool(page_id)
+    # ):
+    #     return True
+    # else:
+    #     return False
+
+    return True

--- a/taccsite_cms/templatetags/limit_visibility_in_menu.py
+++ b/taccsite_cms/templatetags/limit_visibility_in_menu.py
@@ -14,7 +14,7 @@ register = template.Library()
 #
 # 1. Clone this file into the app's matching directory.
 # 2. The CMS should add Page IDs and User Groups as needed.
-# 3. The example functions and example logic may be built upon or replaced
+# 3. The example functions and example logic may be built upon or replaced.
 
 # FAQ: Example Functions
 #


### PR DESCRIPTION
## Overview

Feature﹡ to limit menu visibility for pages based on user group.

<sup>﹡ Actually, a noop example implementation and expected usage.</sup>

## Related

- [FP-1837](https://jira.tacc.utexas.edu/browse/FP-1837)
- required by https://github.com/TACC/Core-CMS-Custom/pull/46

## Changes

- use new template tag to make menu item render conditional
- add new template tag with example menu view permission logic

## Testing & UI

### Core CMS

1. Have a local CMS with pages in navigation.
2. Checkout this branch.
3. Load CMS.
4. Verify all your pages that have been visible in menu before this branch are still visible in menu.

### APCD CMS

See https://github.com/TACC/Core-CMS-Custom/pull/46.

## Notes

Documentation: [Django CMS - Developer Guide - Limit Menu Visibility per User Group](https://confluence.tacc.utexas.edu/display/~wbomar/Django+CMS+-+Developer+Guide+-+Limit+Menu+Visibility+per+User+Group)