### PR TITLE
fix: pattern demo repair suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.13",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^0.10.0",
+        "@tacc/core-styles": "github:TACC/Core-Styles#fix/bugs-found-in-client-demo",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -511,9 +511,9 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.10.0.tgz",
-      "integrity": "sha512-cNhacIPz04qSkPZ+Ro0yf0LkTzoWJQsVS0GZdqkD322o/dCzJBJ4Xv4yn4EagwmmIbsHs9UUggs7nzWPQ74aGw==",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#445a5e5736777f4b08bda7eaf82720047af21cf2",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -9675,10 +9675,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.10.0.tgz",
-      "integrity": "sha512-cNhacIPz04qSkPZ+Ro0yf0LkTzoWJQsVS0GZdqkD322o/dCzJBJ4Xv4yn4EagwmmIbsHs9UUggs7nzWPQ74aGw==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#445a5e5736777f4b08bda7eaf82720047af21cf2",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#fix/bugs-found-in-client-demo",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.13",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^0.10.0",
+    "@tacc/core-styles": "github:TACC/Core-Styles#fix/bugs-found-in-client-demo",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
@@ -1,9 +1,6 @@
 @import url("@tacc/core-styles/src/lib/_imports/components/c-button.css");
 @import url("../settings/font.css");
 
-.c-button {
-  --max-width: unset;
-}
 .c-button:not(.c-button--as-link) {
   font-size: var(--global-font-size--small);
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
@@ -3,6 +3,7 @@
 
 .c-button {
   --max-width: unset;
-
+}
+.c-button:not(.c-button--as-link) {
   font-size: var(--global-font-size--small);
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/irregular-link.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/irregular-link.css
@@ -1,0 +1,13 @@
+/* Allow making all hyperlinks "irregular" styles */
+
+@import url("_imports/tools/x-link.css");
+
+a {
+  @extend .x-link--irregular;
+}
+a:hover {
+  @extend .x-link--irregular--hover;
+}
+a:active {
+  @extend .x-link--irregular--active;
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
@@ -2,26 +2,8 @@
 
 :root {
 
-  /* Accent */
-  /* CAVEAT: A standard accent color definition is pending more designs */
-  /* NOTE: The new Frontera and TACC designs both have brown and blue accents */
-
-  --global-color-accent--x-light: #F2DFBD; /* originally #e3d7fd */
-  --global-color-accent--light: #BDA374;   /* originally #a387ed */
-  --global-color-accent--normal: #877453;  /* originally #784fe8 */
-  --global-color-accent--dark: #64563E;    /* originally #6039cc */
-  --global-color-accent--x-dark: #403014;  /* originally #3d189b */
-
-  --global-color-accent--alt: #E0D8C9;     /* originally #d2cce7 */
-  --global-color-accent--weak: #9D702140;  /* originally #6039cc40 */
-
-
-
   /* Link */
-
-  /* CAVEAT: Not accessible within paragraph text (edge case as of 2021-08) */
-  --global-color-link-on-light--normal: #003399;
-  /* WARNING: This color is from Dev not Design (not rendered as of 2021-08) */
-  --global-color-link-on-dark--normal: #0088FF;
+  --global-color-link-on-light--normal: var(--global-color-accent--normal);
+  --global-color-link-on-dark--normal: var(--global-color-accent--xxx-light);
 
 }

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -3,6 +3,14 @@
 /* Organize via ITCSS */
 /* SEE: https://confluence.tacc.utexas.edu/x/IAA9Cw */
 
+/* FAQ: File paths are functional, but not consistent:
+        - Local files are prepended with `./imports/`.
+        - Remote files are prepended with `@tacc/core-styles/src/lib/_imports/`.
+        - Automatic file locators are prepended with `_imports/`.﹡
+
+        ﹡ Files is first searched for locally, then remotely.
+*/
+
 /* SETTINGS */
 @import url("_imports/settings/border.css");
 @import url("_imports/settings/max-width.css");
@@ -19,6 +27,8 @@
 /* Bootstrap performs much of this */
 @import url("@tacc/core-styles/src/lib/_imports/elements/html-elements.cms.css");
 @import url("@tacc/core-styles/src/lib/_imports/elements/form.cms.css");
+@import url("@tacc/core-styles/src/lib/_imports/elements/links.css");
+@import url("@tacc/core-styles/src/lib/_imports/elements/table.css");
 /* Load custom element styles within custom element, not here */
 
 /* OBJECTS */
@@ -35,8 +45,9 @@
 @import url("_imports/components/c-footer.css");
 @import url("_imports/components/c-recognition.css");
 @import url("_imports/components/c-see-all-link.css");
-@import url("_imports/components/bootstrap.container.css");
+@import url("@tacc/core-styles/src/lib/_imports/components/bootstrap.container.css");
 @import url("_imports/components/bootstrap.figure.css");
+@import url("@tacc/core-styles/src/lib/_imports/components/bootstrap.modal.css");
 /* Unique to CMS */
 @import url("./_imports/components/c-button.css");
 @import url("./_imports/components/django.cms.css");
@@ -49,6 +60,7 @@
 @import url("_imports/trumps/s-breadcrumbs.css");
 @import url("_imports/trumps/s-footer.css");
 @import url("_imports/trumps/s-blockquote.css");
+@import url("@tacc/core-styles/src/lib/_imports/trumps/s-irregular-links.css");
 @import url("_imports/trumps/u-empty.css");
 @import url("@tacc/core-styles/src/lib/_imports/trumps/u-mailto-text-replace.css");
 @import url("@tacc/core-styles/src/lib/_imports/trumps/s-affixed-input-wrapper.css");

--- a/taccsite_ui/fractal.config.js
+++ b/taccsite_ui/fractal.config.js
@@ -15,9 +15,10 @@ let cmsName = 'core-cms';
 let projName = args['project'] || '';
     projName = ( projName !== cmsName ) ? projName : '';
 // (stylesheet)
-const cmsCSSFile = 'cms/site.css';
+const escapeDemoDir = '/../..'; // i.e. back out of '/static/ui'
+const cmsCSSFile = `${escapeDemoDir}/static/site_cms/css/build/site.css`;
 const projCSSFile = ( projName )
-  ? `projects/${projName}/static/${projName}/css/build/site.css`
+  ? `${escapeDemoDir}/static/${projName}/css/build/site.css`
   : null;
 
 // Set source paths
@@ -28,13 +29,11 @@ fractal.components.set('path', __dirname + '/patterns');
 fractal.components.set('default.context', {
   styles: {
     shouldSkipBase: true, // true, because site.css includes components
-    internal: {
-      global: [ cmsCSSFile ].concat( ( projCSSFile ) ? [ projCSSFile ] : [] )
-    },
     external: {
       global: [
-        'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css'
-      ]
+        'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
+        cmsCSSFile,
+      ].concat( ( projCSSFile ) ? [ projCSSFile ] : [] )
     }
   }
 });
@@ -44,14 +43,7 @@ if ( projCSSFile ) {
 }
 
 // Set website paths
-/*
-fractal.web.set('static.path',
-  path.dirname( require.resolve('@tacc/core-styles')) +
-  '/..' + // exits 'src/' which is at the end of what require.resolve returns
-  '/dist'
-);
-*/
-fractal.web.set('static.path', __dirname + '/styles');
+fractal.web.set('static.path', __dirname + '/../node_modules/@tacc/core-styles/build');
 fractal.web.set('builder.dest', __dirname + '/dist');
 
 // Customize theme

--- a/taccsite_ui/styles/cms
+++ b/taccsite_ui/styles/cms
@@ -1,1 +1,0 @@
-../../taccsite_cms/static/site_cms/css/build

--- a/taccsite_ui/styles/projects
+++ b/taccsite_ui/styles/projects
@@ -1,1 +1,0 @@
-../../taccsite_custom/


### PR DESCRIPTION
## Overview

- Many major and minor fixes to demo.
- Load a few new patterns.

## Related

- requires https://github.com/TACC/Core-Styles/pull/66

## Changes

- feat(css): allow making all hyperlinks irregular
- fix(css): rely on core styles colors 
- fix(css): c-button font size to ignore --as-link 
- fix(css): let core-styles control c-button max-width ([it got fixed](https://github.com/TACC/Core-Styles/commit/369b5a1))
- feat(core-styles): load newly added or documented patterns 
- fix(taccsite_ui): build & load core-styles to fix broken paths in demo
- fix(core-styles): load relevant fixes

## Testing & UI

See https://github.com/TACC/Core-Styles/pull/66.
