### PR TITLE
fix(templatetags): limit visibility + cms news = crash

### DIFF
--- a/taccsite_cms/templatetags/limit_visibility_in_menu.py
+++ b/taccsite_cms/templatetags/limit_visibility_in_menu.py
@@ -50,7 +50,8 @@ def limit_visibility_in_menu(context, menu_item):
     """
     request = context['request']
     user = request.user
-    page_id = menu_item.attr['reverse_id']
+    has_page_id = ('reverse_id' in menu_item.attr)
+    page_id = menu_item.attr['reverse_id'] if has_page_id else ''
 
     # FAQ: Example Logic
     #


### PR DESCRIPTION
## Overview

The CMS News menu children do/can not have a `reverse_id`. So when `limit_visibility_in_menu.py` looks for it in one of those, a fatal error occurrs.

## Related

- [TUP-118](https://jira.tacc.utexas.edu/browse/TUP-118)
    <sub>I found the bug while implementing CMS News on TUP.</sub>

## Changes

- check for `reverse_id` before using it

## Testing

1. [Install CMS News.](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=265425804)
2. [Add an article.](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=182911007#UserGuideBlog/NewsInstructions-FromanEmptyCMS)
3. Load any CMS page (not the admin interface).

## UI

![news +  menu visibility fix](https://user-images.githubusercontent.com/62723358/206044641-22aac06a-1c08-4040-8ef4-00890e2af6c7.png)