### PR TITLE
fix(ckeditor): full-height edit plugin inside text

### DIFF
--- a/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
+++ b/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
@@ -4,3 +4,14 @@
 
 /* https://github.com/django-cms/djangocms-text-ckeditor/pull/590 */
 textarea.cke_source { max-height: inherit; }
+
+/* To stretch plugin editor content height */
+.cke_reset_all/* ← for specificiity */ .cke_dialog_ui_vbox {
+    position: relative;
+}
+.cke_dialog_ui_vbox table {
+    position: absolute;
+    height: 100%;
+    left: 0;
+    top: 0;
+}

--- a/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
+++ b/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
@@ -2,6 +2,7 @@
 
 @import url("https://combinatronics.com/django-cms/djangocms-text-ckeditor/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/css/cms.ckeditor.css");
 
+/* To stretch source editor textarea height */
 /* https://github.com/django-cms/djangocms-text-ckeditor/pull/590 */
 textarea.cke_source { max-height: inherit; }
 

--- a/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
+++ b/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
@@ -1,6 +1,7 @@
 /* IMPORTANT: Unnecessary if we use djangocms-text-ckeditor@5.0.0 */
 
-@import url("https://combinatronics.com/django-cms/djangocms-text-ckeditor/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/css/cms.ckeditor.css");
+/* To replicate load of external URL */
+@import url("https://raw.githubusercontent.com/django-cms/djangocms-text-ckeditor/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/css/cms.ckeditor.css");
 
 /* To stretch source editor textarea height */
 /* https://github.com/django-cms/djangocms-text-ckeditor/pull/590 */


### PR DESCRIPTION
## Overview

Fix Plugin editor height being too small (when within Text plugin editor).

## Related

- [FP-1949](https://jira.tacc.utexas.edu/browse/FP-1949)

## Changes

- changed remote URL to revert [#541](https://github.com/TACC/Core-CMS/pull/541) "fix"
- added comment about [#540](https://github.com/TACC/Core-CMS/pull/540) fix
- **added CSS to fix height of editor**

## Testing

1. Open CMS page in Edit mode.
2. Add Text plugin instance.
3. While in Text plugin instance, add any Plugin (via 🧩 icon).
4. Verify height of plugin editor window is as tall as containing element.

## UI

| Before | After |
| - | - |
| ![actual](https://user-images.githubusercontent.com/62723358/206763337-95a4151c-99ec-4e3b-b06d-47994b575e69.png) | ![expected](https://user-images.githubusercontent.com/62723358/206763364-b90de5f6-dcf8-4527-9f8e-e6772c8d8170.png) |