### PR TITLE
feat(settings): wysiwyg should not force <p> tags

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -570,6 +570,11 @@ META_USE_OG_PROPERTIES = True
 META_USE_TWITTER_PROPERTIES = True
 META_USE_SCHEMAORG_PROPERTIES = True
 
+# https://github.com/django-cms/djangocms-text-ckeditor
+CKEDITOR_SETTINGS = {
+    'autoParagraph': False
+}
+
 ########################
 # IMPORT & EXPORT
 ########################


### PR DESCRIPTION
## Overview

Make "Text" plugin instance allow inline elements outside `<p>` tags. ([Source](https://stackoverflow.com/a/24701004/11817077))

## Related

Many new CMS components for TACC should work off of HTML elements, but having them wrapped in `<p>` tags ruins the benefit of markup based styling.

## Changes

- added `autoParagraph: False` to new `CKEDITOR_SETTINGS` settings entry

## Testing

1. Create a Text plugin instance.
2. Be on a line that does not have a block level element yet (no `<p>`, no `<h1>`):
    1. Delete any existing content.
    2. Press backspace again to remove empty block-level element (e.g. `<h1>`, `<p>`).
3. Choose an inline element from the Styles dropdown e.g. "Big".
4. Save Text content.
5. Confirm rendered markup does **not** wrap the inline element with a `<p>` tag.

## UI

https://user-images.githubusercontent.com/62723358/207127739-024c854c-380e-4382-b0c2-aa7e1f692571.mov

https://user-images.githubusercontent.com/62723358/207127779-a97c3191-8f84-47c5-93d2-072311795993.mov

