### PR TITLE
fix(plugins): prevent wysiwyg css side effect

### DIFF
--- a/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
+++ b/taccsite_cms/static/djangocms_text_ckeditor/css/cms.ckeditor.css
@@ -11,7 +11,7 @@ textarea.cke_source { max-height: inherit; }
 .cke_reset_all/* ← for specificiity */ .cke_dialog_ui_vbox {
     position: relative;
 }
-.cke_dialog_ui_vbox table {
+.cke_dialog_ui_vbox > table {
     position: absolute;
     height: 100%;
     left: 0;


### PR DESCRIPTION
## Overview

Table descendants (like in `ckeditor`'s Link edit window) were affected. These styles should only affect direct table child.

## Related

- fixes https://github.com/TACC/Core-CMS/pull/574

## Changes

- added direct selector syntax to ckeditor CSS to limit scope of styles

## Testing

1. In a Text plugin instance.
2. Create a link (using the link icon, not plugin dropdown Link).
3. Open "Advanced" tab.
4. **Verify layout is legible (no overlapping text).**
5. Create a Link (using plugin dropdown Link, not the link icon).
6. **Verify edit area fills pop up window (i.e. re-test [#574](https://github.com/TACC/Core-CMS/pull/574)).**

## UI

| Status | Screenshot |
| - | - |
| Before | <img width="762" alt="Before" src="https://user-images.githubusercontent.com/62723358/207387717-b73b5dd9-b0da-488d-8fad-1dd962e0b17e.png"> |
| After | <img width="762" alt="After" src="https://user-images.githubusercontent.com/62723358/207387714-e0025604-838d-4243-b8fc-a8296b653da6.png"> |
| #574 Still Works | <img width="762" alt="#574 Still Works" src="https://user-images.githubusercontent.com/62723358/207387678-d46bd644-b097-4ab9-b8ba-e8a220a6b35b.png"> | 
