### PR TITLE
feat(server): fp-1952 tighter ES network settings

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,8 +41,9 @@ services:
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - core_cms_es_data:/usr/share/elasticsearch/data
     container_name: core_cms_elasticsearch
-    ports:
-      - 9201:9200
+    # To enable debugging of Elasticsearch outside containers, set ports
+    # ports:
+    #   - 9201:9200
     networks:
       - core_cms_net
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - .:/code
     ports:
-      - 8000:8000
+      - 127.0.0.1:8000:8000
     command: ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
     container_name: core_cms
     hostname: core_cms
@@ -41,9 +41,8 @@ services:
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - core_cms_es_data:/usr/share/elasticsearch/data
     container_name: core_cms_elasticsearch
-    # To enable debugging of Elasticsearch outside containers, set ports
-    # ports:
-    #   - 9201:9200
+    ports:
+      - 127.0.0.1:9201:9200
     networks:
       - core_cms_net
 

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -2,7 +2,7 @@
 #More info: https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
 #
 cluster.name: es-dev
-network.host: 0.0.0.0
+network.host: _local_
 #network.publish_host: hostname
 node.name: es01
 #minimum_master_nodes need to be explicitly set when bound on a public IP

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -2,7 +2,7 @@
 #More info: https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
 #
 cluster.name: es-dev
-network.host: _local_
+network.host: 0.0.0.0
 #network.publish_host: hostname
 node.name: es01
 #minimum_master_nodes need to be explicitly set when bound on a public IP


### PR DESCRIPTION
## Overview

Set up Elasticsearch network to limit exposure of the software on the network.

## Related

- [FP-1952](https://jira.tacc.utexas.edu/browse/FP-1952)
- mimics https://github.com/TACC/Core-Portal/pull/752

## Changes

- limit network to only localhost

## Testing

1. Run development environment using these new settings.
2. Test that Elasticsearch still works:
    1. Add a CMS page **and** confirm re-index occurs and is accurate.[^1]
    2. Publish a CMS page **and** confirm re-index occurs and is accurate.[^1]
    4. Delete a CMS page **and** confirm re-index occurs and is accurate.[^1]
    5. Add text to a CMS page and verify page appears in a search.

[^1]: You can check container logs for a message saying that re-index has occurred. You can check http://localhost:9201/cms-dev-cms/_search to confirm search index has expected page content.

## UI

Skipped.

## Notes

<details><summary>Archived</summary>

Elasticsearch [**Networking** reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#modules-network) suggests [**`network.host`**](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#common-network-settings) should be [`_local_`](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#network-interface-values) instead of `0.0.0.0`.

**Update**: But doing so would interfere with Docker cross-container communication.
</details>