### PR TITLE
feat: "multimedia" articles use media placeholder

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -252,6 +252,8 @@ CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'
 
 TACC_BLOG_SHOW_CATEGORIES = True
 TACC_BLOG_SHOW_TAGS = True
+# To make any "Multimedia" (`multimedia`) category post require custom media
+# TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'
 
 ########################
 # CLIENT BUILD SETTINGS
@@ -622,5 +624,6 @@ SETTINGS_EXPORT = [
     'GOOGLE_ANALYTICS_PROPERTY_ID',
     'GOOGLE_ANALYTICS_PRELOAD',
     'TACC_BLOG_SHOW_CATEGORIES',
-    'TACC_BLOG_SHOW_TAGS'
+    'TACC_BLOG_SHOW_TAGS',
+    'TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY'
 ]

--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -9,7 +9,7 @@
 
 {# /TACC #}
 {# TACC (define whether this is a multimedia post): #}
-{% blog_post_is_multimedia post as is_multimedia_post %}
+{% blog_post_is_multimedia post settings.TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY as is_multimedia_post %}
 {# /TACC #}
 <article id="post-{{ post.slug }}" class="post-item post-detail">
     <header>

--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -1,10 +1,60 @@
-{# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/post_detail.html #}
 {% extends "djangocms_blog/post_detail.html" %}
-{% load cms_tags %}
+{% load i18n easy_thumbnails_tags cms_tags blog_post_is_multimedia %}
 
-{% block content_blog %}
+{% block content_blog %}{% spaceless %}
+{# TACC (wrap and add breadcrumbs): #}
+
 <section class="container">
-    {% include "nav_cms_breadcrumbs.html" %}
-    {{ block.super }}
+{% include "nav_cms_breadcrumbs.html" %}
+
+{# /TACC #}
+{# TACC (define whether this is a multimedia post): #}
+{% blog_post_is_multimedia post as is_multimedia_post %}
+{# /TACC #}
+<article id="post-{{ post.slug }}" class="post-item post-detail">
+    <header>
+        <h2>{% render_model post "title" %}</h2>
+        {% if post.subtitle %}
+            <h3>{% render_model post "subtitle" %}</h3>
+        {% endif %}
+        {% block blog_meta %}
+            {% include "djangocms_blog/includes/blog_meta.html" %}
+        {% endblock %}
+    </header>
+    {# TACC (multimedia styles are incompatible with thumbnail): #}
+    {# {% if not post.main_image_id %} #}
+    {% if is_multimedia_post or not post.main_image_id %}
+    {# /TACC #}
+        <div class="blog-visual">{% render_placeholder post.media %}</div>
+    {% else %}
+    <div class="blog-visual">
+        {% thumbnail post.main_image post.full_image_options.size crop=post.full_image_options.crop upscale=post.full_image_options.upscale subject_location=post.main_image.subject_location  as thumb %}
+        <img src="{{ thumb.url }}" alt="{{ post.main_image.default_alt_text }}" width="{{ thumb.width }}" height="{{ thumb.height }}" />
+    </div>
+    {% endif %}
+    {# TACC (do not let source end spaceless-ness prematurely): #}
+    {# {% endspaceless %} #}
+    {# /TACC #}
+    {% if post.app_config.use_placeholder %}
+        <div class="blog-content">{% render_placeholder post.content %}</div>
+    {% else %}
+        <div class="blog-content">{% render_model post "post_text" "post_text" "" "safe" %}</div>
+    {% endif %}
+    {% if view.liveblog_enabled %}
+        {% include "liveblog/includes/post_detail.html" %}
+    {% endif %}
+    {% if post.related.exists %}
+        <section class="post-detail-list">
+        {% for related in post.related.all %}
+            {% include "djangocms_blog/includes/blog_item.html" with post=related image="true" TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
+        {% endfor %}
+        </section>
+    {% endif %}
+</article>
+{# TACC (end wrap and end spaceless-ness later than source): #}
+
 </section>
+{% endspaceless %}
+
+{# /TACC #}
 {% endblock content_blog %}

--- a/taccsite_cms/templatetags/blog_post_is_multimedia.py
+++ b/taccsite_cms/templatetags/blog_post_is_multimedia.py
@@ -3,7 +3,7 @@ from django import template
 register = template.Library()
 
 @register.simple_tag
-def blog_post_is_multimedia(post=None):
+def blog_post_is_multimedia(post=None, category_slug=''):
     """
     Custom Template Tag `blog_post_is_multimedia`
 
@@ -14,18 +14,19 @@ def blog_post_is_multimedia(post=None):
 
     Template inline usage:
         {# (renders `True` or `False`) #}
-        {% blog_post_is_multimedia post %}
+        {% blog_post_is_multimedia post 'multimedia' %}
 
         {# (renders "A" or "B") #}
-        {% blog_post_is_multimedia post as is_multimedia %}
+        {% blog_post_is_multimedia post 'multimedia' as is_multimedia %}
         {% if is_multimedia %} A {% else %} B {% endif %}
 
     Example:
         ../templates/djangocms_blog/post_detail.html
     """
+    is_multimedia = False
     if post.categories.exists:
         for cat in post.categories.all():
-            if cat.slug == "multimedia":
+            if cat.slug == category_slug:
                 is_multimedia = True
 
     return is_multimedia

--- a/taccsite_cms/templatetags/blog_post_is_multimedia.py
+++ b/taccsite_cms/templatetags/blog_post_is_multimedia.py
@@ -1,0 +1,31 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag
+def blog_post_is_multimedia(post=None):
+    """
+    Custom Template Tag `blog_post_is_multimedia`
+
+    Use: Return (boolean) whether given blog post is a "Multimedia"-type post.
+
+    Load custom tag into template:
+        {% load blog_post_is_multimedia %}
+
+    Template inline usage:
+        {# (renders `True` or `False`) #}
+        {% blog_post_is_multimedia post %}
+
+        {# (renders "A" or "B") #}
+        {% blog_post_is_multimedia post as is_multimedia %}
+        {% if is_multimedia %} A {% else %} B {% endif %}
+
+    Example:
+        ../templates/djangocms_blog/post_detail.html
+    """
+    if post.categories.exists:
+        for cat in post.categories.all():
+            if cat.slug == "multimedia":
+                is_multimedia = True
+
+    return is_multimedia


### PR DESCRIPTION
## Overview

Enable Media placeholder on "Multimedia"-type posts as defined by new category slug setting.

## Related

- [TUP-258](https://jira.tacc.utexas.edu/browse/TUP-258)

## Changes

- added setting to define which category posts are multimedia posts
- added template tag to identify multimedia blog posts
- added more code from plugin source `post-detail.html`
- changed post template to use media placeholder if post is multimedia

## Testing

0. Have working News/Blog.
1. Add/Have blog category "Multimedia".
2. Add/Have blog post in category "Multimedia".
3. Add/Have image to that blog post.
4. Load blog post.
5. Verify that blog post uses its image as main image.
6. Add setting `TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'`.
7. Load blog post.
8. Verify that blog post does not use its image as main image.
9. Verify that blog post has a "Media" placeholder.

## UI

https://user-images.githubusercontent.com/62723358/211947692-4ca20ee4-359b-4ee5-83af-0b7d19e06a2b.mov