### PR TITLE
fix(djangocms_blog): article media overflow

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.multimedia.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.multimedia.css
@@ -75,6 +75,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
     right: 0;
 
     height: var(--media-height);
+    overflow-y: hidden;
 }
 :--multimedia-page header {
     /* FAQ: Content must move to show image which is out of flow */


### PR DESCRIPTION
## Overview

Do not let Multimedia article main image height exceed 680px.

## Related

- fixes #572

## Changes

- added `overflow-y: hidden`

## Testing

0. Follow #572 to set up an article.
1. Add custom image (#582) that is taller than 680px.
2. Confirm image does not show taller than 680px (bottom will get cut off).

## UI

| avoid this | do this |
| - | - |
| ![avoid this](https://user-images.githubusercontent.com/62723358/212160724-6d4c2ee6-aae2-4310-8987-62f76fbf8fdf.png) | ![do this](https://user-images.githubusercontent.com/62723358/212160749-16a54351-c747-4d47-a053-dfa43f7c58ff.png) |
