### PR TITLE
fix: add multimedia post custom media setting

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -252,8 +252,8 @@ CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'
 
 TACC_BLOG_SHOW_CATEGORIES = True
 TACC_BLOG_SHOW_TAGS = True
-# To make any "Multimedia" (`multimedia`) category post require custom media
-# TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'multimedia'
+# To make "Multimedia" (e.g. `multimedia`) category post require custom media
+TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'sample-value-…-_mutlimedia_-makes-sense'
 
 ########################
 # CLIENT BUILD SETTINGS


### PR DESCRIPTION
## Overview

The `TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY ` setting must exist, or it cannot be exported, thus server crash.

## Related

- fixes #582

## Changes

- add `TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY` setting default value

## Testing

1. Confirm site does not crash (with the error in the "UI" table "before" column).

## UI

| before | after |
| - | - |
| ![before](https://user-images.githubusercontent.com/62723358/212163284-577d7f36-0481-43e7-a950-f3c1e978d003.png) | ![after](https://user-images.githubusercontent.com/62723358/212163775-b186a572-e237-420c-b72d-645725ecdbc3.png) |

## Notes

Alternatively, add ternary logic (export if exists), but unrealistic value is simpler.
