### PR TITLE
fix(templates): djangcms_picture, alignment issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#8876a8c",
+        "@tacc/core-styles": "github:TACC/Core-Styles#bugfix/picture-plugin-template-annoyances",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -511,7 +511,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#8876a8c12680ef14f6a144963167667f3a38cd93",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#e8231f2860a98f5c6aeb74802148a6aa36ce9006",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9458,9 +9458,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#8876a8c12680ef14f6a144963167667f3a38cd93",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#e8231f2860a98f5c6aeb74802148a6aa36ce9006",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#8876a8c",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#bugfix/picture-plugin-template-annoyances",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#8876a8c",
+    "@tacc/core-styles": "github:TACC/Core-Styles#bugfix/picture-plugin-template-annoyances",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -7,6 +7,8 @@ Reference:
 
 Styleguide Components.DjangoCMS.Blog.App.Page
 */
+@import url("@tacc/core-styles/src/lib/_imports/objects/o-offset-content.css");
+
 @import url("./django.cms.blog.app.page.multimedia.css");
 
 
@@ -107,4 +109,48 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 /* FAQ: Use case is list items with as much text as a paragraph */
 :--article-page .blog-content li + li {
   margin-top: 0.5em;
+}
+
+
+
+/* Media & Content - Alignment */
+
+:--article-page .blog-content .align-left {
+  @extend .o-offset-content--left;
+}
+:--article-page .blog-content .align-right {
+  @extend .o-offset-content--right;
+}
+:--article-page .blog-content .align-center {
+  max-width: 100%; /* overwrite @tacc/core-styles/…/components/align.css */
+}
+
+/* To remove margin on narrow screens */
+/* To overwrite @tacc/core-styles/…/components/align.css */
+@media (--narrow-and-below) {
+  :--article-page .blog-content .align-center,
+  :--article-page .blog-content .align-right,
+  :--article-page .blog-content .align-left {
+    max-width: unset;
+  }
+  :--article-page .blog-content .align-right,
+  :--article-page .blog-content .align-left {
+    float: unset;
+    margin-bottom: unset;
+  }
+  :--article-page .blog-content .align-right {
+    margin-left: unset;
+  }
+  :--article-page .blog-content .align-left {
+    margin-right: unset;
+  }
+}
+
+/* To reduce image width on medium screens */
+@media (--narrow-and-above) and (--medium-and-below) {
+  :--article-page .blog-content .align-center,
+  :--article-page .blog-content .align-right,
+  :--article-page .blog-content .align-left {
+    max-width: 50%;
+  }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -5,3 +5,34 @@
 /* Try to auto-clear image floats */
 .align-right + *:not(img) { clear: right }
 .align-left + *:not(img) { clear: left }
+
+/* To apply djangocms-bootstrap4/…_picture class styles from parent to image */
+/* FAQ: TACC/Core-CMS moves (side effect) Picture classes to <figure> or <a> */
+/* SEE: taccsite_cms/templates/djangocms_picture/default/picture.html */
+:is(figure, a).img-fluid img {
+  max-width: 100%;
+  height: auto;
+}
+:is(figure, a).img-thumbnail img {
+  padding: 0.25rem;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 1rem; /* NOTE: Bootstrap used 0.25rem */
+  max-width: 100%;
+  height: auto;
+}
+:is(figure, a).rounded {
+  /* NOTE: Bootstrap used 0.25rem */
+  border-radius: 1rem !important; /* overwrite Bootstrap (uses !important) */
+}
+/* To undo some djangocms-bootstrap4/…_picture class styles on parent */
+/* FAQ: The duplicate styles on parent tags look odd or are unnecessary */
+:is(figure, a).img-thumbnail {
+  padding: unset;
+  background-color: unset;
+  border: unset;
+  border-radius: unset;
+}
+:is(figure, a).rounded {
+  border-radius: unset !important; /* overwrite Bootstrap (uses !important) */
+}

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -3,8 +3,11 @@
 @import url("@tacc/core-styles/src/lib/_imports/components/align.css");
 
 /* Try to auto-clear image floats */
+/* WARNING: The commented solution clears float BUT also negates float */
+/*
 .align-right + *:not(img) { clear: right }
 .align-left + *:not(img) { clear: left }
+*/
 
 /* To apply djangocms-bootstrap4/…_picture class styles from parent to image */
 /* FAQ: TACC/Core-CMS moves (side effect) Picture classes to <figure> or <a> */

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -26,19 +26,13 @@
 
 /* ELEMENTS */
 /* Bootstrap performs much of this */
-@import url("@tacc/core-styles/src/lib/_imports/elements/html-elements.cms.css");
-@import url("@tacc/core-styles/src/lib/_imports/elements/form.cms.css");
+/* Core-Styles provides much of this */
 @import url("@tacc/core-styles/src/lib/_imports/elements/links.css");
 @import url("@tacc/core-styles/src/lib/_imports/elements/table.css");
 /* Load custom element styles within custom element, not here */
 
 /* OBJECTS */
-@import url("_imports/objects/o-grid.css");
-@import url("_imports/objects/o-float-content.css");
-@import url("_imports/objects/o-offset-content.css");
-@import url("_imports/objects/o-section.css");
-@import url("@tacc/core-styles/src/lib/_imports/objects/o-fixed-header-table.css");
-@import url("@tacc/core-styles/src/lib/_imports/objects/o-table-wrap.css");
+/* Core-Styles provides much of this */
 
 /* COMPONENTS */
 @import url("@tacc/core-styles/src/lib/_imports/components/c-button.css");

--- a/taccsite_cms/templates/djangocms_picture/default/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/default/picture.html
@@ -1,0 +1,101 @@
+{# https://github.com/django-cms/djangocms-picture/blob/3.0.0/djangocms_picture/templates/djangocms_picture/default/picture.html #}
+{# TACC (mimic v3.0.0 to v4.0.0 changes): #}
+{# {% load thumbnail %} #}
+{% load thumbnail l10n %}
+{# /TACC #}
+
+{% if picture_link %}
+    <a href="{{ picture_link }}"
+    {% if instance.link_target %} target="{{ instance.link_target }}"{% endif %}
+    {# TACC (assign attributes to parent): #}
+    {{ instance.attributes_str }}
+    {# /TACC #}
+    {{ instance.link_attributes_str }}>
+{% endif %}
+
+{# start render figure/figcaption #}
+{% if instance.caption_text %}
+    {# TACC (assign attributes to parent): #}
+    {# <figure> #}
+    <figure {{ instance.attributes_str }}>
+    {# /TACC #}
+{% endif %}
+{# end render figure/figcaption #}
+
+
+{# TACC (mimic v3.0.0 to v4.0.0 changes): #}
+{% localize off %}
+{# /TACC #}
+<img src="{{ instance.img_src }}"
+    alt="{% if instance.attributes.alt %}{{ instance.attributes.alt }}{% elif instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% endif %}"
+    {% if instance.width %} width="{{ instance.width }}"{% endif %}
+    {% if instance.height %} height="{{ instance.height }}"{% endif %}
+    {% if img_srcset_data %}
+        srcset="
+            {% for size, thumb in img_srcset_data %}
+                {{ thumb.url }} {{ size }}w,
+            {% endfor %}
+            {{ instance.img_src }} {{ picture_size.size.0 }}w
+        "
+        sizes="
+            {% for size, thumb in img_srcset_data %}
+                (max-width: {{ size }}px) {{ size }}px,
+            {% endfor %}
+            {{ picture_size.size.0 }}px
+        "
+    {% endif %}
+    {# TACC (assign attributes to parent): #}
+    {% if not instance.caption_text and not picture_link %}
+    {{ instance.attributes_str }}
+    {% endif %}
+    {# /TACC #}
+>
+{# TACC (mimic v3.0.0 to v4.0.0 changes): #}
+{% endlocalize %}
+{# /TACC #}
+
+{# start render figure/figcaption #}
+{% if instance.caption_text %}
+        <figcaption>{{ instance.caption_text }}</figcaption>
+    </figure>
+{% endif %}
+{# end render figure/figcaption #}
+
+{% if picture_link %}
+    </a>
+{% endif %}
+
+{% comment %}
+    # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
+    # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
+    # https://github.com/divio/django-filer/blob/master/filer/models/imagemodels.py
+    # http://easy-thumbnails.readthedocs.io/en/2.1/usage/#templates
+    {{ instance.picture }}
+    # Available variables:
+    {{ instance.img_src }}
+    {{ instance.width }}
+    {{ instance.height }}
+    {{ instance.alignment }}
+    {{ instance.caption_text }}
+    {{ instance.img_srcset_data }} or {{ img_srcset_data }}
+    {{ instance.attributes_str }}
+    # picture helper
+    {{ instance.get_size }} or {{ picture_size }}
+    # link settings
+    {{ instance.link_url }}
+    {{ instance.link_page }}
+    {{ instance.link_target }}
+    {{ instance.link_attributes_str }}
+    # link helper
+    {{ instance.get_link }} or {{ picture_link }}
+    # cropping settings
+    {{ instance.use_automatic_scaling }}
+    {{ instance.use_no_cropping }}
+    {{ instance.use_crop }}
+    {{ instance.use_upscale }}
+    {{ instance.thumbnail_options }}
+    # activate DJANGOCMS_PICTURE_NESTING to enable nested plugins:
+    {% for plugin in instance.child_plugin_instances %}
+        {% render_plugin plugin %}
+    {% endfor %}
+{% endcomment %}


### PR DESCRIPTION
## Overview

- If picture has caption or a link, place attributes on parent tags, not image.
- Use `c-offset-content--…` to align Pictures in a blog article.

## Related

- requires https://github.com/TACC/Core-Styles/pull/121
- required by https://github.com/TACC/tup-ui/pull/122

## Changes

- fix(templates): djangcms_picture, attr's on parent fc007ff
- chore(css): site.css, remove duplicate imports  6fe36a2
- feat(css): djangcms_blog, Picture alignment  592cdbc
- fix(core-styles): inutitive figure–caption layout b1b606d
- fix(css): propagate Picture plugin Bootstrap attrs 6318fe6
- fix(css): do not try to auto clear float alignment 6345d7e

## Testing / UI

1. See ALIGNMENT "Center" and "Left" on [Outlook for the Blue Economy](https://dev.tup.tacc.utexas.edu/news/latest-news/2023/01/26/outlook-for-the-blue-economy/).
1. See ALIGNMENT "Left" and "Right" on [James Webb Telescope Reveals Milky Way-like Galaxies in Young Universe](https://dev.tup.tacc.utexas.edu/news/latest-news/2023/01/05/james-webb-telescope-reveals-milky-way-galaxies-young-universe/).