### PR TITLE
Task/auto responsive vdeo embed

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -601,6 +601,7 @@ CKEDITOR_SETTINGS = {
 
 # https://github.com/django-cms/djangocms-video
 DJANGOCMS_VIDEO_TEMPLATES = [
+    ('responsive-auto', _('Responsive - Automatic')),
     ('responsive-16by9', _('Responsive - 16 by 9')),
     ('responsive-4by3', _('Responsive - 4 by 3')),
     ('responsive-1by1', _('Responsive - 1 by 1')),

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django-cms-video.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django-cms-video.css
@@ -3,6 +3,6 @@
   /* To overwrite Bootstrap _embed */
   position: unset;
   top: unset;
-  bottom: 0;
-  left: 0;
+  bottom: unset;
+  left: unset;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django-cms-video.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django-cms-video.css
@@ -1,0 +1,8 @@
+.embed-responsive:not([class*="embed-responsive-"])
+:is(.embed-responsive-item, embed, iframe, object, video) {
+  /* To overwrite Bootstrap _embed */
+  position: unset;
+  top: unset;
+  bottom: 0;
+  left: 0;
+}

--- a/taccsite_cms/static/site_cms/css/src/site.cms.css
+++ b/taccsite_cms/static/site_cms/css/src/site.cms.css
@@ -11,5 +11,6 @@
 @import url("./_imports/components/django-cms-forms.css");
 @import url("./_imports/components/django.cms.post.css");
 @import url("./_imports/components/django.cms.picture.css");
+@import url("./_imports/components/django-cms-video.css");
 
 @import url("./_imports/trumps/s-drop-cap.css");

--- a/taccsite_cms/templates/djangocms_video/responsive-auto/video_player.html
+++ b/taccsite_cms/templates/djangocms_video/responsive-auto/video_player.html
@@ -1,0 +1,7 @@
+{% extends "djangocms_video/default/video_player.html" %}
+
+{% block content_video %}
+<div class="embed-responsive">
+  {{ block.super }}
+</div>
+{% endblock content_video %}


### PR DESCRIPTION
## Overview

Add choice for template that lets video plugin use automatic height for responsive media.

## Related

- builds upon #580

## Changes

- add new `djangocms_video` template
- add styles to undo hard ratio responsiveness for a non-specific responsive embed.

## Testing

1. Add a Video plugin instance.
2. Set the URL to https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1242255460.
3. Save the instance.
4. Verify the embed takes up available horizontal space in container.
5. Verify the height is nor more nor less than the height the embed needs.

## UI

![responsive-automatic](https://user-images.githubusercontent.com/62723358/216724519-736d95b3-7019-48fa-9511-4aad2ceb36a3.png)