### PR TITLE
feat(settings): TACC_BLOG_SHOW_ABSTRACT_TAG

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -252,8 +252,9 @@ CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'
 
 TACC_BLOG_SHOW_CATEGORIES = True
 TACC_BLOG_SHOW_TAGS = True
-# To make "Multimedia" (e.g. `multimedia`) category post require custom media
-TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'sample-value-…-_mutlimedia_-makes-sense'
+# To flag posts of certain category or tag, so template can take special action
+TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'sample_value_e_g__mutlimedia__'
+TACC_BLOG_SHOW_ABSTRACT_TAG = 'sample_value_e_g__redirect__'
 
 ########################
 # CLIENT BUILD SETTINGS
@@ -625,5 +626,6 @@ SETTINGS_EXPORT = [
     'GOOGLE_ANALYTICS_PRELOAD',
     'TACC_BLOG_SHOW_CATEGORIES',
     'TACC_BLOG_SHOW_TAGS',
-    'TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY'
+    'TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY',
+    'TACC_BLOG_SHOW_ABSTRACT_TAG'
 ]

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -266,14 +266,16 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 /* Content */
 
-.blog-lead {
+:--article-item .blog-lead {
   @extend %x-truncate--many-lines;
   --lines: 3;
 
   line-height: 1.5;
   color: var(--global-color-primary--dark);
 }
-.blog-lead p:last-child { margin-bottom: 0 /* overwrite Boostrap */ }
+:--article-item .blog-lead p:last-child {
+  margin-bottom: 0 /* overwrite Boostrap */
+}
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -99,12 +99,14 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* Media & Content - Content */
 
+:--article-page .blog-lead,
 :--article-page .blog-content {
   font-size: var(--global-font-size--normal);
   line-height: 2;
 }
 /* Add space between all list items */
 /* FAQ: Use case is list items with as much text as a paragraph */
+:--article-page .blog-lead li + li,
 :--article-page .blog-content li + li {
   margin-top: 0.5em;
 }

--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -1,5 +1,5 @@
 {% extends "djangocms_blog/post_detail.html" %}
-{% load i18n easy_thumbnails_tags cms_tags blog_post_is_multimedia %}
+{% load i18n easy_thumbnails_tags cms_tags blog_post_is_multimedia blog_post_is_show_abstract %}
 
 {% block content_blog %}{% spaceless %}
 {# TACC (wrap and add breadcrumbs): #}
@@ -8,8 +8,9 @@
 {% include "nav_cms_breadcrumbs.html" %}
 
 {# /TACC #}
-{# TACC (define whether this is a multimedia post): #}
+{# TACC (define whether this is a special post): #}
 {% blog_post_is_multimedia post settings.TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY as is_multimedia_post %}
+{% blog_post_is_show_abstract post settings.TACC_BLOG_SHOW_ABSTRACT_TAG as is_show_abstract_post %}
 {# /TACC #}
 <article id="post-{{ post.slug }}" class="post-item post-detail">
     <header>
@@ -34,6 +35,19 @@
     {% endif %}
     {# TACC (do not let source end spaceless-ness prematurely): #}
     {# {% endspaceless %} #}
+    {# /TACC #}
+    {# TACC (print abstract for some posts e.g. an external article): #}
+    {% if is_show_abstract_post %}
+        {# TACC (copied from source app's includes/blog_item.html): #}
+        <div class="blog-lead">
+            {% if not TRUNCWORDS_COUNT %}
+                {% render_model post "abstract" "" "" "safe" %}
+            {% else %}
+                {% render_model post "abstract" "" "" "truncatewords_html:TRUNCWORDS_COUNT|safe"  %}
+            {% endif %}
+        </div>
+        {# /TACC #}
+    {% endif %}
     {# /TACC #}
     {% if post.app_config.use_placeholder %}
         <div class="blog-content">{% render_placeholder post.content %}</div>

--- a/taccsite_cms/templatetags/blog_post_is_show_abstract.py
+++ b/taccsite_cms/templatetags/blog_post_is_show_abstract.py
@@ -1,0 +1,32 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag
+def blog_post_is_show_abstract(post=None, tag_slug=''):
+    """
+    Custom Template Tag `blog_post_is_show_abstract`
+
+    Use: Return (boolean) whether given blog post is a "show_abstract" post.
+
+    Load custom tag into template:
+        {% load blog_post_is_show_abstract %}
+
+    Template inline usage:
+        {# (renders `True` or `False`) #}
+        {% blog_post_is_show_abstract post 'show_abstract' %}
+
+        {# (renders "A" or "B") #}
+        {% blog_post_is_show_abstract post 'show_abstract' as is_show_abstract %}
+        {% if is_show_abstract %} A {% else %} B {% endif %}
+
+    Example:
+        ../templates/djangocms_blog/post_detail.html
+    """
+    is_show_abstract = False
+    if post.tags.exists:
+        for tag in post.tags.all():
+            if tag.slug == tag_slug:
+                is_show_abstract = True
+
+    return is_show_abstract


### PR DESCRIPTION
## Overview

If tag matches setting value, article page will show the abstract.

<details><summary>Use Cases</summary>

**Actual**: So that if a user navigates to a page that they were not intended to access, the abstract can be shown to show them to where they should have been redirected. (That redirection relied on abstract having a link to an external article, but relies on JavaScript which can fail. Also, user could have pieced together the URL or received it in full via RSS.)

**Imagined:** Scientific article whose abstract should be listed before the content so all content is available together.

</details>

## Related

- borrows ideas from https://github.com/TACC/Core-CMS/pull/572

## Changes

- add setting `TACC_BLOG_SHOW_ABSTRACT_TAG`
- change article list `.blog-lead` styles to **only** be for list
- change article page `.blog-content` styles to **also** style `.blog-lead`
- change template to show abstract if template_tag and setting verify that
- add template_tag to set boolean after comparing given tag to article tags

## Testing

0. Add `TACC_BLOG_SHOW_ABSTRACT_TAG` setting with value `show_abstract`.
1. Create article with:
    - abstract (some text, any text)
    - tag `show_abstract`
2. Load article page.
3. Verify article shows abstract.
4. Add article content.
5. Verify article content loads beneath abstract.
6. Verify article abstract and article content text styles match.

## UI

| abstract | content | list | page |
| - | - | - | - |
| ![abstract](https://user-images.githubusercontent.com/62723358/216733336-969c1e0d-81a8-4a6b-9312-6cc429c59545.png) | ![content](https://user-images.githubusercontent.com/62723358/216733337-9cdb0c76-ed22-4dfb-8caa-84c74808d92a.png) | ![list](https://user-images.githubusercontent.com/62723358/216733339-129b09d3-8aa8-4984-9818-f44fd9cbaabf.png) | ![page](https://user-images.githubusercontent.com/62723358/216733340-1c279f8a-8857-4ca5-8740-14a9b329d8f1.png) |