### PR TITLE
feat(djangocms_blog): article 'has-blog-tag-...' class names

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -22,6 +22,25 @@
         a.tabIndex = -1;
       });
     </script>
+    <script>
+      /* HACK: To add class to article for each tag present */
+      {# FAQ: Using JavaScript let us avoid cloning includes/blog_item.html #}
+      const blogList = document.querySelector('.blog-list');
+      const articles = blogList.querySelectorAll('article');
+      [ ...articles ].forEach( article => {
+        const tags = article.querySelectorAll('.blog-tag');
+        [ ...tags ].forEach( tag => {
+          console.log({tag});
+          const classNames = tag.classList;
+          classNames.forEach( className => {
+            const isBlogTag = ( className.indexOf('blog-tag-') === 0 );
+            if ( isBlogTag ) {
+              article.classList.add(`has-${className}`);
+            }
+          });
+        });
+      });
+    </script>
 </div>
 {% endblock content_blog %}
 

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -24,7 +24,7 @@
         a.tabIndex = -1;
       });
     </script>
-    <script id="add-tag-classes-to-each-article">
+    <script id="blog-post-tag-classes-to-article">
       /* HACK: To add class to article for each tag present */
       {# FAQ: Using JavaScript let us avoid cloning includes/blog_item.html #}
       const blogList = document.querySelector('.blog-list');

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -22,7 +22,7 @@
         a.tabIndex = -1;
       });
     </script>
-    <script>
+    <script id="add-tag-classes-to-each-article">
       /* HACK: To add class to article for each tag present */
       {# FAQ: Using JavaScript let us avoid cloning includes/blog_item.html #}
       const blogList = document.querySelector('.blog-list');


### PR DESCRIPTION
## Overview

For every `li a.blog-tag-...` an article has (in its metadata), add `has-blog-tag-...` class on the `<article>`.

## Related

- part of #594

## Changes

- add script to `post_list.html`

## Testing

1. Load News list that has articles with tags.
2. Match each `article.post-item > header > ul.tags > li > a[class*="blog-tag-"]` class to `article.post-item` classes of the pattern `.has-blog-tag-…`* i.e.
    1. given a news article with tag `test`,
    2. then article has metadata tag link with class `blog-tag-test`,
    3. and article has class `has-blog-tag-test`*.

<sup>* The `has-` prefix is added to replicate CSS `:has()` selector, so that CSS can select via `article:has(.blog-tag-test)` (if browser supports `:has()`) and `article.has-blog-tag-test` (if browser does not support `:has()`).</sup>

## UI

![has-blog-tag-___](https://user-images.githubusercontent.com/62723358/216867740-6bee3cb7-3770-4d6c-8a23-a8ec46b51eec.png)