### PR TITLE
feat(djangocms_blog): drop scripts in favor of template overwrites

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -102,7 +102,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 }
 :--article-item h3          { grid-area: head }
 :--article-item h4          { grid-area: subh }
-:--article-item .attr       { grid-area: attr }
+:--article-item .attrs      { grid-area: attr }
 :--article-item .categories { grid-area: cats }
 :--article-item .tags {
   grid-area: tags;
@@ -162,7 +162,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 /* Header - Metadata (Structure) */
 
-:--article-item .attr,
+:--article-item .attrs,
 :--article-item .tags {
   display: flex;
   flex-wrap: nowrap;
@@ -203,13 +203,13 @@ Styleguide Components.DjangoCMS.Blog.App.Item
   line-height: unset; /* overwrite html-elements.css */
 }
 
-:--article-item .attr {
+:--article-item .attrs {
   margin-block: 2px 6px;
 
   font-size: var(--global-font-size--x-small);
   color: var(--global-color-primary--dark);
 }
-:--article-item .attr a { color: inherit }
+:--article-item .attrs a { color: inherit }
 
 :--article-item .categories {
   font-weight: var(--bold);
@@ -218,7 +218,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 }
 :--article-item .categories a { color: var(--global-color-primary--xx-dark) }
 
-/* NOTE: Mimicking .attr styles until we have a design */
+/* NOTE: Mimicking .attrs styles until we have a design */
 :--article-item .tags {
   font-size: var(--global-font-size--x-small);
   color: var(--global-color-primary--dark);

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -26,7 +26,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* Header (Structure) */
 
-:--article-page .attr {
+:--article-page .attrs {
   display: flex;
   justify-content: space-between;
 }
@@ -40,7 +40,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
   font-size: var(--global-font-size--large);
 }
 
-:--article-page header :is(h3, h2 + .attr) {
+:--article-page header :is(h3, h2 + .attrs) {
   padding-top: 17px;
   border-top: var(--global-border-width--normal) solid var(--global-color-primary--dark);
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.multimedia.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.multimedia.css
@@ -8,7 +8,7 @@ Reference:
 Styleguide Components.DjangoCMS.Blog.App.Page
 */
 
-@custom-selector :--multimedia-page .app-blog-category-multimedia;
+@custom-selector :--multimedia-page .app-blog.has-blog-category-multimedia;
 
 /* To move breadcrumbs atop article */
 :--multimedia-page article.post-detail .blog-visual {

--- a/taccsite_cms/templates/djangocms_blog/base.html
+++ b/taccsite_cms/templates/djangocms_blog/base.html
@@ -18,16 +18,8 @@
 <div class="app app-blog
   {% if not settings.TACC_BLOG_SHOW_CATEGORIES %}no-categories{% endif %}
   {% if not settings.TACC_BLOG_SHOW_TAGS %}no-tags{% endif %}
-  {% if post.categories.exists %}
-  app-blog-has-categories
-  {% for cat in post.categories.all %}
-  app-blog-category-{{ cat.slug }}
-  {% endfor %}{% endif %}
-  {% if post.tags.exists %}
-  app-blog-has-tags
-  {% for tag in post.tags.all %}
-  app-blog-tag-{{ tag.slug }}
-  {% endfor %}{% endif %}
+  {% if post %} {% include './includes/blog_cats.html' with prefix='has-' %} {% include './includes/blog_tags.html' with prefix='has-' %}
+  {% endif %}
 ">
     {% block content_blog %}{% endblock %}
 </div>

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_cats.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_cats.html
@@ -1,0 +1,1 @@
+{# To list classes for all categories #}{# @var prefix #}{% if post.categories.exists %}{% for category in post.categories.all %}{% if category.slug %} {{ prefix }}blog-category-{{ category.slug }}{% endif %}{% endfor %}{% endif %}

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_item.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_item.html
@@ -1,0 +1,37 @@
+{# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/includes/blog_item.html #}
+{% load djangocms_blog i18n easy_thumbnails_tags cms_tags %}
+
+<article id="post-{{ post.slug }}" class="post-item">
+    <header>
+        <h3><a href="{{ post.get_absolute_url }}">{{ post.title }}</a></h3>
+        {% if post.subtitle %}
+            <h4>{{ post.subtitle }}</h4>
+        {% endif %}
+        {% block blog_meta %}
+            {% include "djangocms_blog/includes/blog_meta.html" %}
+        {% endblock %}
+    </header>
+    {% if image and post.main_image %}
+    <div class="blog-visual">
+        {% thumbnail post.main_image post.thumbnail_options.size crop=post.thumbnail_options.crop upscale=post.thumbnail_options.upscale subject_location=post.main_image.subject_location as thumb %}
+        <img src="{{ thumb.url }}" alt="{{ post.main_image.default_alt_text }}" width="{{ thumb.width }}" height="{{ thumb.height }}" />
+    </div>
+    {% else %}
+        {% media_images post as previews %}
+        <div class="blog-visual">
+          {% for preview in previews %}<img src="{{ preview }}" />{% endfor %}
+        </div>
+    {% endif %}
+    <div class="blog-lead">
+        {% if not TRUNCWORDS_COUNT %}
+            {% render_model post "abstract" "" "" "safe" %}
+        {% else %}
+            {% render_model post "abstract" "" "" "truncatewords_html:TRUNCWORDS_COUNT|safe"  %}
+        {% endif %}
+    </div>
+    <footer class="read-more">
+        {# TACC (remove " »" from "read more" link): #}
+        <a href="{{ post.get_absolute_url }}">{% trans "read more" %}{# &raquo;#}</a>
+        {# /TACC #}
+    </footer>
+</article>

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_item.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_item.html
@@ -1,7 +1,9 @@
 {# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/includes/blog_item.html #}
 {% load djangocms_blog i18n easy_thumbnails_tags cms_tags %}
 
-<article id="post-{{ post.slug }}" class="post-item">
+{# TACC (include category & tag class names): #}
+<article id="post-{{ post.slug }}" class="post-item {% include './blog_cats.html' with prefix='has-' %} {% include './blog_tags.html' with prefix='has-' %}">
+{# /TACC #}
     <header>
         <h3><a href="{{ post.get_absolute_url }}">{{ post.title }}</a></h3>
         {% if post.subtitle %}

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -53,7 +53,10 @@
             {% if category.slug %}
                 {# TACC (fix bug nephila/djangocms-blog#711): #}
                 {# TACC (remove hard-coded comma so CSS handles separator): #}
-                <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ category.slug }}">{{ category.name }}</a></li>
+                {# TACC (rename `blog-categories-…` to `blog-category-…`): #}
+                <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-category-{{ category.slug }}">{{ category.name }}</a></li>
+                {# /TACC #}
+                {# /TACC #}
                 {# /TACC #}
             {% endif %}
         {% endfor %}
@@ -69,6 +72,8 @@
             {# TACC (fix bug nephila/djangocms-blog#711): #}
             {# TACC (remove hard-coded comma so CSS handles separator): #}
             <li class="tag_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-tagged' tag=tag.slug %}" class="blog-tag blog-tag-{{ tag.slug }}">{{ tag.name }}</a></li>
+            {# /TACC #}
+            {# /TACC #}
             {# /TACC #}
         {% endfor %}
     {% endif %}

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -2,7 +2,7 @@
 {% load i18n easy_thumbnails_tags cms_tags %}
 
 {# TACC (add class so CSS can target this element): #}
-<ul class="post-detail attr">
+<ul class="post-detail attrs">
 {# /TACC #}
     {% if post.author %}
     {# TACC (add class so CSS can target this element): #}

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -1,43 +1,77 @@
 {# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html #}
 {% load i18n easy_thumbnails_tags cms_tags %}
 
+{# TACC (add class so CSS can target this element): #}
 <ul class="post-detail attr">
+{# /TACC #}
     {% if post.author %}
+    {# TACC (add class so CSS can target this element): #}
     <li class="byline">
+    {# /TACC #}
+        {# TACC (add <span> and &nbsp; so whitespace can be stripped): #}
         <span>{% trans "by" %}</span>&nbsp;
+        {# /TACC #}
         <a href="{% url 'djangocms_blog:posts-author' post.author.get_username %}">{% if post.author.get_full_name %}{{ post.author.get_full_name }}{% else %}{{ post.author }}{% endif %}</a>
     </li>
     {% endif %}
+    {# TACC (add class so CSS can target this element): #}
     <li class="date date-published">
+    {# /TACC #}
+      {# TACC (add <span> and &nbsp; so whitespace can be stripped): #}
       <span>{% trans "Published" %}</span>&nbsp;
+      {# /TACC #}
+      {# TACC (wrap with <time> tag because it should be so): #}
       <time datetime="{{ post.date_published }}"
             title="{{ post.date_published }}">
+      {# /TACC #}
         {{ post.date_published|date:"DATE_FORMAT" }}
+      {# TACC (wrap with <time> tag because it should be so): #}
       </time>
+      {# /TACC #}
     </li>
     {% if post.date_featured %}
+    {# TACC (add class so CSS can target this element): #}
     <li class="date date-featured">
+    {# /TACC #}
+      {# TACC (add <span> and &nbsp; so whitespace can be stripped): #}
       <span>{% trans "Published" %}</span>&nbsp;
+      {# /TACC #}
       <time datetime="{{ post.date_featured }}"
             title="{{ post.date_featured }}">
-          {{ post.date_featured|date:"DATE_FORMAT" }}
+        {{ post.date_featured|date:"DATE_FORMAT" }}
       </time>
     </li>
     {% endif %}
 </ul>
+{# TACC (distinguish categories and tags via class): #}
+{# TACC (strip whitespace): #}
 <ul class="post-detail categories">{% spaceless %}
+{# /TACC #}
+{# /TACC #}
     {% if post.categories.exists %}
         {% for category in post.categories.all %}
             {% if category.slug %}
-                <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ category.slug }}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}</li>
+                {# TACC (fix bug nephila/djangocms-blog#711): #}
+                {# TACC (remove hard-coded comma so CSS handles separator): #}
+                <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ category.slug }}">{{ category.name }}</a></li>
+                {# /TACC #}
             {% endif %}
         {% endfor %}
     {% endif %}
+{# TACC (distinguish categories and tags via class): #}
+{# TACC (strip whitespace): #}
 {% endspaceless %}</ul>
 <ul class="post-detail tags">{% spaceless %}
+{# /TACC #}
+{# /TACC #}
     {% if post.tags.exists %}
         {% for tag in post.tags.all %}
+            {# TACC (fix bug nephila/djangocms-blog#711): #}
+            {# TACC (remove hard-coded comma so CSS handles separator): #}
             <li class="tag_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-tagged' tag=tag.slug %}" class="blog-tag blog-tag-{{ tag.slug }}">{{ tag.name }}</a></li>
+            {# /TACC #}
         {% endfor %}
     {% endif %}
+{# TACC (strip whitespace): #}
 {% endspaceless %}</ul>
+{# /TACC #}

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_tags.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_tags.html
@@ -1,0 +1,1 @@
+{# To list classes for all tags #}{# @var prefix #}{% if post.tags.exists %}{% for tag in post.tags.all %}{% if tag.slug %} {{ prefix }}blog-tag-{{ tag.slug }}{% endif %}{% endfor %}{% endif %}

--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -1,3 +1,4 @@
+{# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/post_detail.html #}
 {% extends "djangocms_blog/post_detail.html" %}
 {% load i18n easy_thumbnails_tags cms_tags blog_post_is_multimedia blog_post_is_show_abstract %}
 

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -15,14 +15,6 @@
       [ ...document.querySelectorAll('.pagination a') ].forEach( a => {
         a.innerText = a.innerText.replace('«', '<').replace('»', '>');
       });
-      /* HACK: To manipulate "read more" link */
-      {# FAQ: Using JavaScript let us avoid cloning includes/blog_item.html #}
-      [ ...document.querySelectorAll('.read-more a') ].forEach( a => {
-        /* To remove " »" from "read more »" */
-        a.innerText = a.innerText.replace(' »', '');
-        /* To disallow focus (because article header link is ample) */
-        a.tabIndex = -1;
-      });
     </script>
     <script id="blog-post-tag-classes-to-article" type="module">
       /* HACK: To add class to article for each tag present */

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -1,45 +1,17 @@
 {# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/post_list.html #}
-{% extends "djangocms_blog/post_list.html" %}
-{% load cms_tags i18n %}
+{% extends "djangocms_blog/base.html" %}
+{% load i18n easy_thumbnails_tags %}{% spaceless %}
+
+{% block canonical_url %}<link rel="canonical" href="{{ view.get_view_url }}"/>{% endblock canonical_url %}
+
+{# TACC (wrap list in container w/ breadcrumbs to mimic other page layouts): #}
+<div class="container">
+{% include "nav_cms_breadcrumbs.html" %}
+{# /TACC #}
 
 {% block content_blog %}
-<div class="container">
-    {% include "nav_cms_breadcrumbs.html" %}
-    {# FAQ: The extended template adds `spaceless` but it fails #}
-    {% spaceless %}
-      {{ block.super }}
-    {% endspaceless %}
-    <script id="blog-post-text-manipulation">
-      /* HACK: To replace « and » of "« Previous" and "Next »" with < and > */
-      {# FAQ: Using JavaScript let us avoid cloning includes/blog_item.html #}
-      [ ...document.querySelectorAll('.pagination a') ].forEach( a => {
-        a.innerText = a.innerText.replace('«', '<').replace('»', '>');
-      });
-    </script>
-    <script id="blog-post-tag-classes-to-article" type="module">
-      /* HACK: To add class to article for each tag present */
-      {# NOTE: Not used yet; can be used to style article based on tag or cat #}
-      {# FAQ: TUP CMS was going to use this in Phase 1, but now for Phase 2 #}
-      {# FAQ: Using JavaScript let us avoid cloning includes/blog_item.html #}
-      const blogList = document.querySelector('.blog-list');
-      const articles = blogList.querySelectorAll('article');
-      [ ...articles ].forEach( article => {
-        const tags = article.querySelectorAll('.blog-tag');
-        [ ...tags ].forEach( tag => {
-          const classNames = tag.classList;
-          classNames.forEach( className => {
-            const isBlogTag = ( className.indexOf('blog-tag-') === 0 );
-            if ( isBlogTag ) {
-              article.classList.add(`has-${className}`);
-            }
-          });
-        });
-      });
-    </script>
-</div>
-{% endblock content_blog %}
-
-{% block blog_title %}
+<section class="blog-list">
+    {% block blog_title %}
     <header>
         <h2>
         {% if author %}{% trans "Articles by" %} {{ author.get_full_name }}
@@ -49,4 +21,36 @@
         {% else %}{% trans "News" %}{% endif %}
         </h2>
     </header>
+    {% endblock %}
+    {% for post in post_list %}
+        {% include "djangocms_blog/includes/blog_item.html" with post=post image="true" TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
+    {% empty %}
+    <p class="blog-empty">{% trans "No article found." %}</p>
+    {% endfor %}
+    {% if author or archive_date or tagged_entries %}
+    <p class="blog-back"><a href="{% url 'djangocms_blog:posts-latest' %}">{% trans "Back" %}</a></p>
+    {% endif %}
+    {% if is_paginated %}
+    <nav class="{% firstof css_grid instance.css_grid %} pagination">
+        {% if page_obj.has_previous %}
+            {# TACC (swap '«' with '<'): #}
+            <a href="?{{ view.page_kwarg }}={{ page_obj.previous_page_number }}">&lt; {% trans "previous" %}</a>
+            {# /TACC #}
+        {% endif %}
+        <span class="current">
+            {% trans "Page" %} {{ page_obj.number }} {% trans "of" %} {{ paginator.num_pages }}
+        </span>
+        {% if page_obj.has_next %}
+            {# TACC (swap '»' with '>'): #}
+            <a href="?{{ view.page_kwarg }}={{ page_obj.next_page_number }}">{% trans "next" %} &gt;</a>
+            {# /TACC #}
+        {% endif %}
+    </nav>
+    {% endif %}
+</section>
 {% endblock %}
+{% endspaceless %}
+
+{# TACC (wrap list in container w/ breadcrumbs to mimic other page layouts): #}
+</div>
+{# /TACC #}


### PR DESCRIPTION
## Overview

Clone and edit more templates from https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/, and remove JavaScript DOM manipulation.

<details>

Rather than be so afraid of updates to templates, such that I would rather use JavaScript to change the markup, assume templates rarely change, and that their API—i.e. the context variables—do not change.

</details>

## Related

- supports https://github.com/TACC/tup-ui/pull/128 later commits

## Changes

See commits (which are change-specific and polished).

## Testing & UI

I tested the changes. I skipped the recording. I am sorry.