### PR TITLE
feat(djangocms_blog): simple article link & "to be published"

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -206,4 +206,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
   /* To stretch link to cover footer */
   /* TODO: Try to retire `x-article-link-stretch` */
   display: grid;
+
+  /* To hide link text */
+  font-size: 0;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -196,8 +196,14 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 /* Footer */
 
-/* If editing, hide "read more" */
-/* FAQ: User can: edit by double clicking abstract; visit by clicking title */
-html:--cms-edit-mode .read-more {
-  display: none;
+/* Use "read more" link to make image clickable */
+.read-more {
+  /* To take up */
+  grid-row-start: 1;
+  grid-column-start: 1;
+  grid-row-end: span 2;
+
+  /* To stretch link to cover footer */
+  /* TODO: Try to retire `x-article-link-stretch` */
+  display: grid;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -196,21 +196,6 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 /* Footer */
 
-/* If not editing, stretch "read more" atop the article */
-html:not(:--cms-edit-mode) .read-more a:hover {
-  --outline-offset: var(--blog-item-buffer);
-  @extend %x-article-link-hover;
-}
-html:not(:--cms-edit-mode) .read-more a:active {
-  @extend %x-article-link-active;
-}
-html:not(:--cms-edit-mode) .read-more { grid-area: 1 / 1 / -1 / -1 }
-html:not(:--cms-edit-mode) .read-more { position: relative; }
-html:not(:--cms-edit-mode) .read-more a {
-  @extend %x-article-link-stretch;
-  @extend %x-article-link-text;
-}
-
 /* If editing, hide "read more" */
 /* FAQ: User can: edit by double clicking abstract; visit by clicking title */
 html:--cms-edit-mode .read-more {

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -1,8 +1,6 @@
 {# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html #}
 {% load i18n easy_thumbnails_tags cms_tags %}
 
-<big>{{ post.publish }}</big>
-
 {# TACC (add class so CSS can target this element): #}
 <ul class="post-detail attrs">
 {# /TACC #}

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -1,6 +1,8 @@
 {# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html #}
 {% load i18n easy_thumbnails_tags cms_tags %}
 
+<big>{{ post.publish }}</big>
+
 {# TACC (add class so CSS can target this element): #}
 <ul class="post-detail attrs">
 {# /TACC #}
@@ -20,7 +22,9 @@
       {% if post.date_published %}
       {# /TACC #}
       {# TACC (add <span> and &nbsp; so whitespace can be stripped): #}
-      <span>{% trans "Published" %}</span>&nbsp;
+      {# TACC ("Published" vs "To be published"): #}
+      <span>{% if post.publish %}{% trans "Published" %}{% else %}{% trans "To be published" %}{% endif %}</span>&nbsp;
+      {# /TACC #}
       {# /TACC #}
       {# TACC (wrap with <time> tag because it should be so): #}
       <time datetime="{{ post.date_published }}"

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -16,7 +16,7 @@
     {% endif %}
     {# TACC (add class so CSS can target this element): #}
     <li class="date date-published">
-      {# TACC (show date if featured otherwise show "Unpublished"): #}
+      {# TACC (show date if published otherwise show "Unpublished"): #}
       {% if post.date_published %}
       {# /TACC #}
       {# TACC (add <span> and &nbsp; so whitespace can be stripped): #}
@@ -30,7 +30,7 @@
       {# TACC (wrap with <time> tag because it should be so): #}
       </time>
       {# /TACC #}
-      {# TACC (show date if featured otherwise show "Unpublished"): #}
+      {# TACC (show date if published otherwise show "Unpublished"): #}
       {% else %}
       <span>{% trans "Unpublished" %}</span>
       {% endif %}


### PR DESCRIPTION
## Overview

- Do not let use click whole article as link.
- Clarify whether article is actually published or to be published.

## Related

- [TUP-258](https://jira.tacc.utexas.edu/browse/TUP-258)

## Changes

- [**feat**: "To be published"](https://github.com/TACC/Core-CMS/commit/9953a425a2eb5d95de1bb02d993775ebb4087fb5)
- [**feat**: do not stretch link over list article](https://github.com/TACC/Core-CMS/commit/63acc0cabf559144bab7878458d530283af289d4)

## Testing / UI

https://user-images.githubusercontent.com/62723358/218555902-44e5d9ec-f350-483b-b167-7cba60417d65.mov