### PR TITLE
fix: poetry install url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip3 install --upgrade pip setuptools wheel
 
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 # copy project requirement files here to ensure they will be cached.
 WORKDIR $PYSETUP_PATH


### PR DESCRIPTION
## Overview / Changes

Fix Poetry install URL.

## Related

- [Update Dockerfile to use new Poetry install command.](https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/30/update-dockerfile-to-use-new-poetry) taccaci/frontera-tech-docs#30
- https://github.com/TACC-Cloud/geoapi/pull/115

## Testing

https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/964/console

## UI

Skipped.
