### PR TITLE
fix: poetry install url & version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED 1
 
 # https://python-poetry.org/docs/configuration/#using-environment-variables
-ENV POETRY_VERSION=1.1.0 \
+ENV POETRY_VERSION=1.2.0 \
     POETRY_HOME="/opt/poetry" \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     POETRY_NO_INTERACTION=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip3 install --upgrade pip setuptools wheel
 
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 # copy project requirement files here to ensure they will be cached.
 WORKDIR $PYSETUP_PATH


### PR DESCRIPTION
## Overview / Changes

Fix Poetry install URL and version.

## Related

- mimics [Update Dockerfile to use new Poetry install command.](https://bitbucket.org/taccaci/frontera-tech-docs/pull-requests/30/update-dockerfile-to-use-new-poetry) taccaci/frontera-tech-docs#30
- mimics https://github.com/TACC-Cloud/geoapi/pull/115
- (partially) mimics https://github.com/TACC/Core-CMS/pull/558/commits/5c4a165eef926c4d57550f5df672a0fb80788f88
- performs #601 correctly

## Testing

https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/965/console

## UI

Skipped.
