### PR TITLE
feat(settings): tup-437, SEARCH_QUERY_PARAM_NAME

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -233,7 +233,6 @@ FAVICON = {
     "img_file_src": "site_cms/img/favicons/favicon.ico"
 }
 
-
 ########################
 # TACC: SEARCH
 ########################

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -144,6 +144,8 @@ CMS_TEMPLATES = (
 
 CMS_PERMISSION = True
 
+
+
 ########################
 # TACC: GOOGLE ANALYTICS
 ########################
@@ -231,6 +233,13 @@ FAVICON = {
     "img_file_src": "site_cms/img/favicons/favicon.ico"
 }
 
+
+########################
+# TACC: SEARCH
+########################
+
+SEARCH_QUERY_PARAM_NAME = 'query_string'
+
 ########################
 # TACC: PORTAL
 ########################
@@ -255,6 +264,8 @@ TACC_BLOG_SHOW_TAGS = True
 # To flag posts of certain category or tag, so template can take special action
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'sample_value_e_g__mutlimedia__'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'sample_value_e_g__redirect__'
+
+
 
 ########################
 # CLIENT BUILD SETTINGS
@@ -627,5 +638,6 @@ SETTINGS_EXPORT = [
     'TACC_BLOG_SHOW_CATEGORIES',
     'TACC_BLOG_SHOW_TAGS',
     'TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY',
-    'TACC_BLOG_SHOW_ABSTRACT_TAG'
+    'TACC_BLOG_SHOW_ABSTRACT_TAG',
+    'SEARCH_QUERY_PARAM_NAME',
 ]

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -1,3 +1,5 @@
+{# @var settings #}
+
 {# WARNING: Some markup is duplicated in other repositories #}
 {# SEE: https://confluence.tacc.utexas.edu/x/LoCnCQ #}
 {# FAQ: Extra lines exist to ease CMS/Portal/Guide template comparison #}
@@ -23,7 +25,7 @@
       {% include "nav_cms.html" with className="navbar-nav" %}
 
       {# NOTE: As of 2022-10, search is only available with a Portal #}
-      {% if settings.INCLUDES_SEARCH_BAR %}{% include "nav_search.html" with className="form-inline  ml-auto" only %}{% endif %}
+      {% if settings.INCLUDES_SEARCH_BAR %}{% include "nav_search.html" with className="form-inline  ml-auto" settings=settings only %}{% endif %}
       {% if settings.INCLUDES_PORTAL_NAV %}{% include "nav_portal.html" with className="navbar-nav" settings=settings only %}{% endif %}
     {% else %}
       {# FAQ: If template were included with `only`, then it would NOT render `show_menu` #}

--- a/taccsite_cms/templates/nav_search.html
+++ b/taccsite_cms/templates/nav_search.html
@@ -1,4 +1,4 @@
-{# @var className #}
+{# @var className, settings #}
 
 {# Encapsulate search bar as custom element, so styles do not bleed out #}
 {# IDEA: Should CMS use React component or Portal's React use custom element #}
@@ -28,5 +28,5 @@
   import * as inputFieldValue from '/static/site_cms/js/modules/inputFieldValue.js';
 
   const shadowRoot = document.getElementById('s-search-bar').shadowRoot;
-  inputFieldValue.update(shadowRoot, 'query_string');
+  inputFieldValue.update(shadowRoot, '{{ settings.SEARCH_QUERY_PARAM_NAME }}');
 </script>

--- a/taccsite_cms/templates/nav_search.raw.html
+++ b/taccsite_cms/templates/nav_search.raw.html
@@ -1,3 +1,5 @@
+{# @var settings #}
+
 {% load staticfiles %}
 <!-- FAQ: This template loads independently at a unique url (see `urls.py`)
           so Portal and User Guide can render this markup into their markup. -->
@@ -16,7 +18,7 @@
   <input part="input"
     id="header-search"
     type="search"
-    name="query_string"
+    name="{{ settings.SEARCH_QUERY_PARAM_NAME }}"
     placeholder="Search"
     data-testid="input"
     autocomplete="off" minlength="3"


### PR DESCRIPTION
## Overview

Add and use new setting `SEARCH_QUERY_PARAM_NAME` to allow [TUP CMS](https://github.com/TACC/tup-ui/tree/main/apps/tup-cms)* to use a different query parameter.

<sup>* Or any CMS that opts for Google search.</sup>

## Related

- [TUP-437](https://jira.tacc.utexas.edu/browse/TUP-437)
- required by https://github.com/TACC/tup-ui/pull/159
- required by https://github.com/TACC/tup-ui/pull/161

## Changes

- added `SEARCH_QUERY_PARAM_NAME` setting — default value "query_string"
- changed templates to use `{{SEARCH_QUERY_PARAM_NAME}}` instead of `query_string`

## Testing & UI

See https://github.com/TACC/tup-ui/pull/159.

## Notes

### Ideas

1. Make the use of ElasticSearch conditional.