### PR TITLE
feat(djangocms_picture): child plugins as caption

### DIFF
--- a/taccsite_cms/templates/djangocms_picture/default/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/default/picture.html
@@ -1,7 +1,9 @@
 {# https://github.com/django-cms/djangocms-picture/blob/3.0.0/djangocms_picture/templates/djangocms_picture/default/picture.html #}
 {# TACC (mimic v3.0.0 to v4.0.0 changes): #}
+{# TACC (support children as caption content): #}
 {# {% load thumbnail %} #}
-{% load thumbnail l10n %}
+{% load thumbnail l10n cms_tags %}
+{# /TACC #}
 {# /TACC #}
 
 {% if picture_link %}
@@ -20,6 +22,11 @@
     <figure {{ instance.attributes_str }}>
     {# /TACC #}
 {% endif %}
+{# TACC (support children as caption content): #}
+{% if instance.child_plugin_instances %}
+    <figure {{ instance.attributes_str }}>
+{% endif %}
+{# /TACC #}
 {# end render figure/figcaption #}
 
 
@@ -59,6 +66,16 @@
         <figcaption>{{ instance.caption_text }}</figcaption>
     </figure>
 {% endif %}
+{# TACC (support children as caption content): #}
+{% if instance.child_plugin_instances %}
+        <figcaption>
+        {% for plugin in instance.child_plugin_instances %}
+            {% render_plugin plugin %}
+        {% endfor %}
+        </figcaption>
+    </figure>
+{% endif %}
+{# /TACC #}
 {# end render figure/figcaption #}
 
 {% if picture_link %}


### PR DESCRIPTION
## Overview

Render child plugins as content in a `<figcaption>`.

## Related

- required by https://github.com/TACC/tup-ui/pull/182

## Changes

- **added** template logic to `djangocms_picture` default template

## Testing

1. Create a "Picture / Image (Responsive)" plugin instance.
2. Make it a link.
3. Within the "Picture / …", create a "Text" plugin instance.
4. Add text.
5. Verify the markup is:
    ```
    <a ...>
        <figure ...>
            <img ... />
            <figcaption ...>
                (The text you entered in Text plugin.)
            </figcaption>
        </figure>
    </a>
    ```

## UI

![picture children as figcaption](https://user-images.githubusercontent.com/62723358/225070070-bbc33513-f27a-4331-9f1d-aef6bacc0d9a.png)

<sup>Tested via https://github.com/TACC/tup-ui/pull/182.</sup>