### PR TITLE
fix(djangocms_picture): child plugins as caption

### DIFF
--- a/taccsite_cms/templates/djangocms_picture/default/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/default/picture.html
@@ -65,10 +65,10 @@
         {# TACC (support children as caption content): #}
         {# <figcaption>{{ instance.caption_text }}</figcaption> #}
         <figcaption>
-            {{ instance.caption_text }}
-            {% for plugin in instance.child_plugin_instances %}
-                {% render_plugin plugin %}
-            {% endfor %}
+        {{ instance.caption_text }}
+        {% for plugin in instance.child_plugin_instances %}
+            {% render_plugin plugin %}
+        {% endfor %}
         </figcaption>
         {# /TACC #}
     </figure>

--- a/taccsite_cms/templates/djangocms_picture/default/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/default/picture.html
@@ -16,15 +16,13 @@
 {% endif %}
 
 {# start render figure/figcaption #}
-{% if instance.caption_text %}
+{# TACC (support children as caption content): #}
+{# {% if instance.caption_text %} #}
+{% if instance.caption_text or instance.child_plugin_instances %}
     {# TACC (assign attributes to parent): #}
     {# <figure> #}
     <figure {{ instance.attributes_str }}>
     {# /TACC #}
-{% endif %}
-{# TACC (support children as caption content): #}
-{% if instance.child_plugin_instances %}
-    <figure {{ instance.attributes_str }}>
 {% endif %}
 {# /TACC #}
 {# end render figure/figcaption #}
@@ -62,20 +60,19 @@
 {# /TACC #}
 
 {# start render figure/figcaption #}
-{% if instance.caption_text %}
-        <figcaption>{{ instance.caption_text }}</figcaption>
-    </figure>
-{% endif %}
-{# TACC (support children as caption content): #}
-{% if instance.child_plugin_instances %}
+{# {% if instance.caption_text %} #}
+{% if instance.caption_text or instance.child_plugin_instances %}
+        {# TACC (support children as caption content): #}
+        {# <figcaption>{{ instance.caption_text }}</figcaption> #}
         <figcaption>
-        {% for plugin in instance.child_plugin_instances %}
-            {% render_plugin plugin %}
-        {% endfor %}
+            {{ instance.caption_text }}
+            {% for plugin in instance.child_plugin_instances %}
+                {% render_plugin plugin %}
+            {% endfor %}
         </figcaption>
+        {# /TACC #}
     </figure>
 {% endif %}
-{# /TACC #}
 {# end render figure/figcaption #}
 
 {% if picture_link %}


### PR DESCRIPTION
## Overview

Render both types of captions together in a **shared** `<figure>` and `<figcaption>`.

## Related

- fixes #609 which mismanaged double captions

## Changes

- **changed** template logic

## Testing

1. Create a Picture / Image (Responsive) block.
2. Add a CAPTION TEXT (via "Advanced settings").
3. Save.
4. Verify Picture […] block caption text appears beneath image (via `<figcaption>` within `<figure>`).
5. Add a Text block nested as child of the Picture […] block.
6. Add text to Text block.
7. Save.
8. Verify both caption texts appear beneath image (via `<figcaption>` within `<figure>`).
9. Remove CAPTION TEXT from Picture […] block (via "Advanced settings").
10. Save.
11. Verify Text block caption text appears beneath image (via `<figcaption>` within `<figure>`).

## UI

| model field caption | both captions | child plugin caption |
| - | - | - |
| ![model field caption](https://user-images.githubusercontent.com/62723358/225374276-dbd1fc65-1491-4467-965d-570c166dccdf.png) | ![both captions](https://user-images.githubusercontent.com/62723358/225374279-99890ca8-04e0-4a77-a82b-0ed5954601e0.png) | ![child plugin caption](https://user-images.githubusercontent.com/62723358/225374265-fe47f31c-3712-4dac-8fc5-47124288cbe4.png) |