### PR TITLE
Task/tup 395 cmd news styles  from tup cms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#236542c",
+        "@tacc/core-styles": "github:TACC/Core-Styles#e34ea4d",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -511,7 +511,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.5.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#236542cd5f1a0a99556718ab76163a099f1ac49f",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#e34ea4def2d7127ff1a51b343567349aee3d03b5",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9474,9 +9474,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#236542cd5f1a0a99556718ab76163a099f1ac49f",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#e34ea4def2d7127ff1a51b343567349aee3d03b5",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#236542c",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#e34ea4d",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^2.5.0",
+        "@tacc/core-styles": "github:TACC/Core-Styles#236542c",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -511,9 +511,9 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.5.0.tgz",
-      "integrity": "sha512-CpoC7SlzWTMZ+MWJOihdChpMnv/7ukFjUPPW511CoC+C2D7GEz+d5SVzlSnPnnX6sSanR50T3hfsoJsd4ovXlw==",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#236542cd5f1a0a99556718ab76163a099f1ac49f",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -9474,10 +9474,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.5.0.tgz",
-      "integrity": "sha512-CpoC7SlzWTMZ+MWJOihdChpMnv/7ukFjUPPW511CoC+C2D7GEz+d5SVzlSnPnnX6sSanR50T3hfsoJsd4ovXlw==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#236542cd5f1a0a99556718ab76163a099f1ac49f",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#236542c",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^2.5.0",
+    "@tacc/core-styles": "github:TACC/Core-Styles#236542c",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#236542c",
+    "@tacc/core-styles": "github:TACC/Core-Styles#e34ea4d",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -123,7 +123,8 @@ Styleguide Components.DjangoCMS.Blog.App
   order: -1
 }
 
-.app-blog .categories a {
+/* FAQ: Uses `:where()` to reduce specificity so colors are easily overridden */
+:where(.app-blog .categories a) {
   @extend :--c-tag;
 
   display: inline-block;

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -10,6 +10,7 @@ Reference:
 Styleguide Components.DjangoCMS.Blog.App
 */
 @import url("@tacc/core-styles/src/lib/_imports/components/bootstrap.pagination.css");
+@import url("@tacc/core-styles/src/lib/_imports/components/c-tag.css");
 
 @import url("./django.cms.blog.app.page.css");
 @import url("./django.cms.blog.app.item.css");
@@ -121,6 +122,18 @@ Styleguide Components.DjangoCMS.Blog.App
 .app-blog .date {
   order: -1
 }
+
+.app-blog .categories a {
+  @extend :--c-tag;
+
+  display: inline-block;
+
+  color: var(--global-color-primary--xx-light);
+  background-color: var(--global-color-primary--xx-dark);
+
+  font-size: var(--global-font-size--x-small);
+}
+
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -94,7 +94,7 @@ Styleguide Components.DjangoCMS.Blog.App
   list-style: none;
 
   padding-left: 0; /* overwrite html-elements.css */
-  margin-bottom: 0; /* overwrite Bootstrap `reboot.css` */
+  margin-bottom: 0.25em; /* overwrite html-elements.css */
 
   font-size: var(--global-font-size--medium);
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -121,8 +121,6 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 }
 
 :--article-item .attrs {
-  margin-block: 2px 6px;
-
   font-size: var(--global-font-size--x-small);
   color: var(--global-color-primary--dark);
 }
@@ -188,6 +186,12 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 }
 :--article-item .blog-lead p:last-child {
   margin-bottom: 0 /* overwrite Boostrap */
+}
+
+/* To undo inline content styles */
+/* FAQ: In case author pasted such markup from another source */
+.blog-list article .blog-lead [style] {
+    all: revert !important; /* force undo all inline styles */
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -126,13 +126,6 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 }
 :--article-item .attrs a { color: inherit }
 
-:--article-item .categories {
-  font-weight: var(--bold);
-  font-size: var(--global-font-size--x-small);
-  text-transform: uppercase;
-}
-:--article-item .categories a { color: var(--global-color-primary--xx-dark) }
-
 /* NOTE: Mimicking .attrs styles until we have a design */
 :--article-item .tags {
   font-size: var(--global-font-size--x-small);

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -63,6 +63,15 @@ Styleguide Components.DjangoCMS.Blog.App.Page
   margin-block: var(--blog-page-main-image-buffer);
 }
 
+/* To undo inline content styles */
+/* FAQ: In case author pasted such markup from another source */
+:--article-page .blog-content [style]:not(
+    [data-style="admin"], /* HACK: So CMS admin can override this */
+    [id^="flickrembed_"] * /* HACK: So Flickr slideshow works */
+) {
+    all: revert !important; /* force undo all inline styles */
+}
+
 
 
 /* Media & Content - Media */


### PR DESCRIPTION
## Overview

Integrate Blog/News styles from https://github.com/TACC/tup-ui.

## Related

- adds to #587
- requires https://github.com/TACC/Core-Styles/pull/144
- required by _upcoming_tup_ui_pr_

## Changes

- **added** core-styles `c-tag`
- **added** category styles (that extend core-styles `c-tag`)
- **changed** to use consistent margin under metadatas
- **removed** copy-paste styles from blog abstract/lead
- **removed** copy-paste styles from blog article content

## Testing & UI

See _upcoming_tup_ui_pr_.
