### PR TITLE
fix: portal nav not to touch cms menu if no search

### DIFF
--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -22,10 +22,10 @@
     {# GL-6: Remove need for different `className` values #}
     {% if settings.INCLUDES_PORTAL_NAV or settings.INCLUDES_SEARCH_BAR %}
       {# FAQ: If template were included with `only`, then it would NOT render `show_menu` #}
-      {% include "nav_cms.html" with className="navbar-nav" %}
+      {% include "nav_cms.html" with className="navbar-nav  mr-auto" %}
 
       {# NOTE: As of 2022-10, search is only available with a Portal #}
-      {% if settings.INCLUDES_SEARCH_BAR %}{% include "nav_search.html" with className="form-inline  ml-auto" settings=settings only %}{% endif %}
+      {% if settings.INCLUDES_SEARCH_BAR %}{% include "nav_search.html" with className="form-inline" settings=settings only %}{% endif %}
       {% if settings.INCLUDES_PORTAL_NAV %}{% include "nav_portal.html" with className="navbar-nav" settings=settings only %}{% endif %}
     {% else %}
       {# FAQ: If template were included with `only`, then it would NOT render `show_menu` #}


### PR DESCRIPTION
## Overview

If search bar is disabled, but portal nav is enabled, ensure portal nav is right-aligned.

- Given `INCLUDES_SEARCH_BAR = True` and `INCLUDES_PORTAL_NAV = False`
- Then `.s-cms-nav` **must not** be adjacent to `.s-portal-nav`

## Related

- required by https://github.com/TACC/tup-ui/pull/199

## Changes

- **changed** to use `mr-auto` on `.s-cms-nav` instead of `ml-auto` on `s-search-bar`

## Testing

1. Set `INCLUDES_SEARCH_BAR = True` and `INCLUDES_PORTAL_NAV = False`.
2. Load CMS website.
3. Verfiy header bottom bar horizontal layout is:
    `logo    cms nav                            portal nav`

## UI

### Localhost Core-CMS

✓ The cms nav has auto right margin.
![cms nav margin](https://user-images.githubusercontent.com/62723358/227610143-e9a0a61d-35cb-4631-8043-ae2f209fd173.png)

✓ The portal (not loaded[^1], so empty, but present) is at the far right.
![potal nav](https://user-images.githubusercontent.com/62723358/227610138-80112e09-972b-46f9-b2ba-cb1035626c58.png)

### Localhost https://github.com/TACC/tup-ui/pull/199

![dev tup no search bar](https://user-images.githubusercontent.com/62723358/227612679-3157ebf3-d67b-4918-915d-c6f2de40a4a0.png)

### (dev) TUP CMS https://github.com/TACC/tup-ui/pull/199

![tup ui no search bar](https://user-images.githubusercontent.com/62723358/227612682-f1aa8652-41e5-4cab-bd68-c1f1b0e9b7e1.png)

[^1]: Loading portal on CMS (which would render the portal nav content) is [cumbersome](https://github.com/TACC/Core-CMS/wiki/Locally-Develop-CMS---Portal---Docs). I skipped it.