### PR TITLE
feat(core-styles): change accent color from purple to blue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#675e5d5",
+        "@tacc/core-styles": "github:TACC/Core-Styles#task/accent-color-from-purple-to-blue",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -511,7 +511,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.6.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#675e5d596cf7aaa88fcc16196fda3a97427dcab8",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9fd865963c119e59231f9893deb6be524b5ec5d2",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9474,9 +9474,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#675e5d596cf7aaa88fcc16196fda3a97427dcab8",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9fd865963c119e59231f9893deb6be524b5ec5d2",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#675e5d5",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/accent-color-from-purple-to-blue",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#675e5d5",
+    "@tacc/core-styles": "github:TACC/Core-Styles#task/accent-color-from-purple-to-blue",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",


### PR DESCRIPTION
## Overview / Changes

The `core-styles.base.css` now defaults to blue accent color (instead of purple).

## Related

- requires https://github.com/TACC/Core-Styles/pull/149
- accompanied by https://github.com/TACC/tup-ui/pull/203
- accompanied by https://github.com/TACC/TACC-Docs/pull/9

## Testing

0. Prepare to [Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes).
1. Add/Verify `settings_local.py` setting `TACC_CORE_STYLES_VERSION = 2`.[^1]
2. Open test server e.g. https://localhost:8000.
3. Visit a page with a link, or add a link to page (via Text or Link plugin) (via breadcrumbs on nested page).
4. Verify link color is sapphire blue _not_ purple.

## UI

| `TACC_CORE_STYLES_VERSION = 2`[^1] | `TACC_CORE_STYLES_VERSION = 0` |
| - | - |
| ![cms accent color change styles v2](https://user-images.githubusercontent.com/62723358/229168744-95323c2a-761f-4fbf-aba3-928b306ac7c6.png) | ![cms accent color change styles v0](https://user-images.githubusercontent.com/62723358/229168742-c6f23241-3bd9-4ce0-b66c-3425d7fcce4f.png) |

[^1]: `TACC_CORE_STYLES_VERSION` is an idea that may help #605.