### PR TITLE
feat(css): change CMS default accent color

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/color.css
@@ -2,6 +2,16 @@
 
 :root {
 
+  /* Accent */
+  --global-color-accent--x-light: #caddfe;
+  --global-color-accent--light: #86aeff;
+  --global-color-accent--normal: #003399;
+  --global-color-accent--dark: #002266;
+  --global-color-accent--x-dark: #001133;
+
+  --global-color-accent--alt: #dfeafe;
+  --global-color-accent--weak: #00226640;
+
   /* Link */
   --global-color-link-on-light--normal: var(--global-color-accent--normal);
   --global-color-link-on-dark--normal: var(--global-color-accent--xxx-light);


### PR DESCRIPTION
## Status

This is unnecessary if https://github.com/TACC/Core-CMS/pull/581 is merged.

> **Info**
> Update: Unnecessary, because #660 was merged.

## Overview

Change CMS default accent color from purple to blue.

## Related

- mimics #617
    <sup>in an easy way that works for `main` branch without touching TACC/Core-Styles</sup>

## Changes

- **added** global accent color variables with value specific to CMS

## Testing

1. On Core CMS instance (or a CMS with minimal difference), verify link colors are blue not purple.

## UI

…