### PR TITLE
feat(css): migrate tup-cms styles to core-cms (part 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -511,7 +511,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.6.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#0b5bb866beaffddc5ede6322748cbdc36510720e",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#b1e28838cab44f689f8dd47ea24a048e2e42d1d4",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9474,7 +9474,7 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#0b5bb866beaffddc5ede6322748cbdc36510720e",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#b1e28838cab44f689f8dd47ea24a048e2e42d1d4",
       "dev": true,
       "from": "@tacc/core-styles@github:TACC/Core-Styles#task/migrate-tup-cms-styles-to-core-styles",
       "requires": {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#task/migrate-tup-cms-styles-to-core-styles",
+        "@tacc/core-styles": "^2.6.2",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -317,9 +317,9 @@
       }
     },
     "node_modules/@csstools/selector-specificity": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz",
-      "integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
+      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -330,7 +330,6 @@
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.4",
         "postcss-selector-parser": "^6.0.10"
       }
     },
@@ -510,10 +509,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.6.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#b1e28838cab44f689f8dd47ea24a048e2e42d1d4",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.6.2.tgz",
+      "integrity": "sha512-0JjPjbcmSvYg7z2zRWIq3Yhj2I0L8fz+6L66AV8HVQUJ/7fDG1vC34mGR0q+l36kFT3KYCTA2+XOyOhxnc/C3w==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -793,9 +792,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "dev": true,
       "funding": [
         {
@@ -809,8 +808,8 @@
       ],
       "peer": true,
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -1307,9 +1306,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001460",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001460.tgz",
-      "integrity": "sha512-Bud7abqjvEjipUkpLs4D7gR0l8hBYBHoa+tGtKJHvT2AYzLp1z7EmVkUT4ERpVUfca8S2HGIVs883D8pUH1ZzQ==",
+      "version": "1.0.30001474",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz",
+      "integrity": "sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==",
       "dev": true,
       "funding": [
         {
@@ -1319,6 +1318,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "peer": true
@@ -1890,9 +1893,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
+      "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -1982,9 +1985,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.4.1.tgz",
-      "integrity": "sha512-0Q8NOMpXJ3iTDDbUv9grcmQAfdDx4qz+fN/+Md2FGbevT+6+bJNQ2LjB2YIUlLbpBTM32idU1Sb+tb/uGt6/XQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.5.3.tgz",
+      "integrity": "sha512-NQNRhrEnS6cW+RU/foLphb6xI/MDA70bI3Cy6VxJU8ilxgyTYz1X9zUzFGVTG5nGPylcKAGIt/UNc4deT56lQQ==",
       "dev": true,
       "peer": true,
       "funding": {
@@ -2144,13 +2147,6 @@
       "engines": {
         "node": ">=4.0.0"
       }
-    },
-    "node_modules/deep-get-set": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-get-set/-/deep-get-set-1.1.1.tgz",
-      "integrity": "sha512-dBrY4GeR55KfyF9Ipswif/Et4muInKpXkf3ro9hFT/8OdPMVsEGNSfuGzfBv/dJKKwKSqInoZGKV5f40bA7TJA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/defaults": {
       "version": "1.0.3",
@@ -2395,9 +2391,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.320",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.320.tgz",
-      "integrity": "sha512-h70iRscrNluMZPVICXYl5SSB+rBKo22XfuIS1ER0OQxQZpKTnFpuS6coj7wY9M/3trv7OR88rRMOlKmRvDty7Q==",
+      "version": "1.4.351",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.351.tgz",
+      "integrity": "sha512-W35n4jAsyj6OZGxeWe+gA6+2Md4jDO19fzfsRKEt3DBwIdlVTT8O9Uv8ojgUAoQeXASdgG9zMU+8n8Xg/W6dRQ==",
       "dev": true,
       "peer": true
     },
@@ -4756,10 +4752,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -5072,6 +5074,16 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-path": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10.12.0"
       }
     },
     "node_modules/object-visit": {
@@ -5491,9 +5503,9 @@
       }
     },
     "node_modules/postcss-cli/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -6609,14 +6621,14 @@
       }
     },
     "node_modules/postcss-replace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-replace/-/postcss-replace-2.0.0.tgz",
-      "integrity": "sha512-8d64/c/dJL2/zjnQvCD1/eH04xMreXFHdC9F0APl/M7Cg0KyLvN+f/HCb87jbyG1dyIbR4zD7sxl/W4JIp9ppQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-replace/-/postcss-replace-2.0.1.tgz",
+      "integrity": "sha512-T83GVovCkBQkFCTmuid0B2bWNu/O0Bh/HDMeEGFC62EwMvVBLZQFYM7iBbcGT48QDXSNSX6e/X1Q7/Syh5NFng==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "deep-get-set": "^1.1.1",
-        "kind-of": "^6.0.3"
+        "kind-of": "^6.0.3",
+        "object-path": "^0.11.8"
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
@@ -9318,9 +9330,9 @@
       "requires": {}
     },
     "@csstools/selector-specificity": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz",
-      "integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
+      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "dev": true,
       "peer": true,
       "requires": {}
@@ -9474,9 +9486,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#b1e28838cab44f689f8dd47ea24a048e2e42d1d4",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.6.2.tgz",
+      "integrity": "sha512-0JjPjbcmSvYg7z2zRWIq3Yhj2I0L8fz+6L66AV8HVQUJ/7fDG1vC34mGR0q+l36kFT3KYCTA2+XOyOhxnc/C3w==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#task/migrate-tup-cms-styles-to-core-styles",
       "requires": {}
     },
     "@trysound/sax": {
@@ -9672,14 +9685,14 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -10076,9 +10089,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001460",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001460.tgz",
-      "integrity": "sha512-Bud7abqjvEjipUkpLs4D7gR0l8hBYBHoa+tGtKJHvT2AYzLp1z7EmVkUT4ERpVUfca8S2HGIVs883D8pUH1ZzQ==",
+      "version": "1.0.30001474",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz",
+      "integrity": "sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==",
       "dev": true,
       "peer": true
     },
@@ -10523,9 +10536,9 @@
       }
     },
     "css-declaration-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
+      "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
       "dev": true,
       "peer": true,
       "requires": {}
@@ -10581,9 +10594,9 @@
       "peer": true
     },
     "cssdb": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.4.1.tgz",
-      "integrity": "sha512-0Q8NOMpXJ3iTDDbUv9grcmQAfdDx4qz+fN/+Md2FGbevT+6+bJNQ2LjB2YIUlLbpBTM32idU1Sb+tb/uGt6/XQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.5.3.tgz",
+      "integrity": "sha512-NQNRhrEnS6cW+RU/foLphb6xI/MDA70bI3Cy6VxJU8ilxgyTYz1X9zUzFGVTG5nGPylcKAGIt/UNc4deT56lQQ==",
       "dev": true,
       "peer": true
     },
@@ -10700,13 +10713,6 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
-    },
-    "deep-get-set": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-get-set/-/deep-get-set-1.1.1.tgz",
-      "integrity": "sha512-dBrY4GeR55KfyF9Ipswif/Et4muInKpXkf3ro9hFT/8OdPMVsEGNSfuGzfBv/dJKKwKSqInoZGKV5f40bA7TJA==",
-      "dev": true,
-      "peer": true
     },
     "defaults": {
       "version": "1.0.3",
@@ -10894,9 +10900,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.320",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.320.tgz",
-      "integrity": "sha512-h70iRscrNluMZPVICXYl5SSB+rBKo22XfuIS1ER0OQxQZpKTnFpuS6coj7wY9M/3trv7OR88rRMOlKmRvDty7Q==",
+      "version": "1.4.351",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.351.tgz",
+      "integrity": "sha512-W35n4jAsyj6OZGxeWe+gA6+2Md4jDO19fzfsRKEt3DBwIdlVTT8O9Uv8ojgUAoQeXASdgG9zMU+8n8Xg/W6dRQ==",
       "dev": true,
       "peer": true
     },
@@ -12711,9 +12717,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
       "peer": true
     },
@@ -12941,6 +12947,13 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
+    },
+    "object-path": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
+      "dev": true,
+      "peer": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -13241,9 +13254,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -13946,14 +13959,14 @@
       }
     },
     "postcss-replace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-replace/-/postcss-replace-2.0.0.tgz",
-      "integrity": "sha512-8d64/c/dJL2/zjnQvCD1/eH04xMreXFHdC9F0APl/M7Cg0KyLvN+f/HCb87jbyG1dyIbR4zD7sxl/W4JIp9ppQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-replace/-/postcss-replace-2.0.1.tgz",
+      "integrity": "sha512-T83GVovCkBQkFCTmuid0B2bWNu/O0Bh/HDMeEGFC62EwMvVBLZQFYM7iBbcGT48QDXSNSX6e/X1Q7/Syh5NFng==",
       "dev": true,
       "peer": true,
       "requires": {
-        "deep-get-set": "^1.1.1",
-        "kind-of": "^6.0.3"
+        "kind-of": "^6.0.3",
+        "object-path": "^0.11.8"
       }
     },
     "postcss-replace-overflow-wrap": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#task/migrate-tup-cms-styles-to-core-styles",
+    "@tacc/core-styles": "^2.6.2",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -192,11 +192,11 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* To style elements that are or have captions */
 :--article-page figure,
-:--article-page p.caption,
 :--article-page .embed-responsive {
   @extend .x-figure;
 }
-:--article-page figcaption {
+:--article-page figcaption,
+:--article-page p.caption {
   @extend .x-figure-caption;
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -196,8 +196,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 :--article-page .embed-responsive {
   @extend .x-figure;
 }
-:--article-page figcaption,
-:--article-page p.caption {
+:--article-page figcaption {
   @extend .x-figure-caption;
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -208,12 +208,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
   @extend .x-blockquote-caption;
 }
 
-/* To fix caption styles for `.embed-responsive` */
-:--article-page .embed-responsive + p.caption {
-  /* To hide `.embed-…` margin-bottom */
-  margin-top: calc( var(--buffer-middle) - var(--buffer-below) );
-}
+/* To remove extra whitespace beneath embeded content */
 :--article-page .embed-responsive > * {
-  /* To remove extra whitespace beneath embeded content */
   display: block;
 }


### PR DESCRIPTION
## Overview

Fix mistakes in #616 (migrating [TACC CMS](https://github.com/TACC/tup-ui/tree/main/apps/tup-cms) styles to Core-CMS).

## Related

- continues #616
- requires https://github.com/TACC/Core-Styles/pull/150
- required by https://github.com/TACC/tup-ui/pull/202
- similar to https://github.com/TACC/TACC-Docs/pull/8

## Changes

- **fixes** core-styles `x-figure` & `x-blockquote` mistakes via new install

## Testing

1. Verify caption and blockquote and figure match design.*

<sup>\* ⚠️ No reference. Going by memory. Sorry. It was a working meeting with designers that resulted in code snippets.</sup>

## UI

| p.caption | figure | blockquote |
| - | - | - |
| ![p caption](https://user-images.githubusercontent.com/62723358/229863702-c5636f5d-b637-4b73-9dcf-3f753767da60.png) | ![figure](https://user-images.githubusercontent.com/62723358/229863705-45cea98b-5409-4e2e-8924-0acd42656e14.png) | ![blockquote](https://user-images.githubusercontent.com/62723358/229863710-90773771-11b4-4c96-9033-5943a8595676.png) |

(same testing as in https://github.com/TACC/Core-Styles/pull/150)