### PR TITLE
feat: allow disable elasticsearch via setting 🧪

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -160,7 +160,7 @@ GOOGLE_ANALYTICS_PRELOAD = True
 
 # TODO: Consider adding 'GOOGLE' as an option
 # SEE: https://github.com/TACC/tup-ui/blob/6eb9412/apps/tup-cms/src/taccsite_cms/settings_custom.py#L101
-SearchEngines = Enum('SearchEngines', ['ELASTIC'])
+SearchEngines = Enum('SearchEngines', ['ELASTIC', 'OTHER'])
 
 SEARCH_ENGINE = SearchEngines.ELASTIC
 SEARCH_QUERY_PARAM_NAME = 'query_string'

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -14,6 +14,8 @@ from glob import glob
 
 from django.utils.translation import gettext_lazy as _
 
+from taccsite_cms.utils.search import SearchEngines
+
 from taccsite_cms._settings.auth import *
 from taccsite_cms._settings.email import *
 from taccsite_cms._settings.form_plugin import *
@@ -158,19 +160,14 @@ GOOGLE_ANALYTICS_PRELOAD = True
 # TACC: SEARCH
 ########################
 
-# TODO: Consider adding 'GOOGLE' as an option
-# SEE: https://github.com/TACC/tup-ui/blob/6eb9412/apps/tup-cms/src/taccsite_cms/settings_custom.py#L101
-SearchEngines = Enum('SearchEngines', ['ELASTIC', 'OTHER'])
-
 SEARCH_ENGINE = SearchEngines.ELASTIC
 SEARCH_QUERY_PARAM_NAME = 'query_string'
+SEARCH_APPS = [
+    'haystack',
+    'aldryn_apphooks_config',
+]
 
-if SEARCH_ENGINE == SearchEngines.ELASTIC:
-    SEARCH_APPS = [
-        'haystack',
-        'aldryn_apphooks_config',
-    ]
-else:
+if SEARCH_ENGINE != SearchEngines.ELASTIC:
     SEARCH_APPS = []
 
 ########################
@@ -445,11 +442,6 @@ INSTALLED_APPS = [
     'aldryn_apphooks_config',  # search index & django CMS Blog
     'test_without_migrations', # run tests faster
 
-    # search
-    *[
-        app for app in SEARCH_APPS if app not in INSTALLED_APPS
-    ]
-
 ] + form_plugin_INSTALLED_APPS + [
 
     # core TACC CMS
@@ -470,6 +462,12 @@ INSTALLED_APPS = [
     'taccsite_cms.contrib.taccsite_system_specs',
     'taccsite_cms.contrib.taccsite_system_monitor',
     'taccsite_cms.contrib.taccsite_data_list'
+]
+
+# search apps
+tacc_app_index = INSTALLED_APPS.index('taccsite_cms')
+INSTALLED_APPS[tacc_app_index:tacc_app_index] = [
+    app for app in SEARCH_APPS if app not in INSTALLED_APPS
 ]
 
 # Convert list of paths to list of dotted module names

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -158,18 +158,20 @@ GOOGLE_ANALYTICS_PRELOAD = True
 # TACC: SEARCH
 ########################
 
-SearchEngines = Enum('SearchEngines', ['ELASTIC', 'GOOGLE'])
+# TODO: Consider adding 'GOOGLE' as an option
+# SEE: https://github.com/TACC/tup-ui/blob/6eb9412/apps/tup-cms/src/taccsite_cms/settings_custom.py#L101
+SearchEngines = Enum('SearchEngines', ['ELASTIC'])
 
 SEARCH_ENGINE = SearchEngines.ELASTIC
-if SEARCH_ENGINE == SearchEngines.GOOGLE:
-    SEARCH_QUERY_PARAM_NAME = 'q'
-    SEARCH_APPS = []
-else:
-    SEARCH_QUERY_PARAM_NAME = 'query_string'
+SEARCH_QUERY_PARAM_NAME = 'query_string'
+
+if SEARCH_ENGINE == SearchEngines.ELASTIC:
     SEARCH_APPS = [
         'haystack',
         'aldryn_apphooks_config',
     ]
+else:
+    SEARCH_APPS = []
 
 ########################
 # ELASTICSEARCH

--- a/taccsite_cms/signal_processor.py
+++ b/taccsite_cms/signal_processor.py
@@ -3,9 +3,11 @@ from django.db import models
 from django.core.management import call_command
 from cms import signals
 from cms.models.pagemodel import Page
-from django.conf import settings
 
-should_rebuild_index = settings.SEARCH_ENGINE == settings.SearchEngines.ELASTIC
+from taccsite_cms.settings import SEARCH_ENGINE
+from taccsite_cms.utils.search import SearchEngines
+
+should_rebuild_index = SEARCH_ENGINE == SearchEngines.ELASTIC
 
 class RealtimeSignalProcessor(BaseSignalProcessor):
     """

--- a/taccsite_cms/signal_processor.py
+++ b/taccsite_cms/signal_processor.py
@@ -3,7 +3,9 @@ from django.db import models
 from django.core.management import call_command
 from cms import signals
 from cms.models.pagemodel import Page
+from django.conf import settings
 
+should_rebuild_index = settings.SEARCH_ENGINE == settings.SearchEngines.ELASTIC
 
 class RealtimeSignalProcessor(BaseSignalProcessor):
     """
@@ -29,5 +31,6 @@ class RealtimeSignalProcessor(BaseSignalProcessor):
         models.signals.post_delete.disconnect(self.handle_save)
 
     def handle_save(self, **kwargs):
-        if type(kwargs.get('instance')) is Page:
-            call_command('rebuild_index', '--noinput')
+        if should_rebuild_index:
+            if type(kwargs.get('instance')) is Page:
+                call_command('rebuild_index', '--noinput')

--- a/taccsite_cms/utils/search.py
+++ b/taccsite_cms/utils/search.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+# TODO: Consider adding 'GOOGLE' as an option
+# SEE: https://github.com/TACC/tup-ui/blob/6eb9412/apps/tup-cms/src/taccsite_cms/settings_custom.py#L101
+SearchEngines = Enum('SearchEngines', ['ELASTIC'])


### PR DESCRIPTION
## Overview

Allow client to disable Elasticsearch via new `SEARCH_ENGINE` setting.

<details><summary><strong>Why?</strong></summary>

Content-heavy CMS instances, like [ECEP-CMS](https://ecepalliance.org/) and [new TUP-CMS](https://dev.tup.tacc.utexas.edu/), have problems that may be related to Elasticsearch.
- The ECEP site opens Text plugin editor (a WYSIWYG editor in a modal) very slowly.
- The new TUP CMS publishes pages more slowly than it did when it had little content.

Also, the [new TUP uses Google search](https://dev.tup.tacc.utexas.edu/search/?q=bob), not Elasticsearch.

</details>

## Related

- created for https://github.com/TACC/tup-ui/pull/207

## Changes

- Added support for `ELASTIC` search engine in `taccsite_cms/utils/search.py`
- Defined one option for search engine: `ELASTIC`
- Added if statement for configuring search settings based on selected search engine
- Changed `INSTALLED_APPS` to include search apps if not already present
- Added `SEARCH_ENGINE` to `SETTINGS_EXPORT`
- Changed `signal_processor.py` to only rebuild index if search engine is `ELASTIC`

## Testing & UI

1. Verify `SEARCH_ENGINE` unset supports user searching via Elasticsearch.

    ...

2. Verify `SEARCH_ENGINE` set to `OTHER` on TACC/Core-CMS... breaks search functionality.

    ...

3. Verify `SEARCH_ENGINE` set to `OTHER` on TACC/tup-ui supports search functionality via Google.
    - assuming `SEARCH_QUERY_PARAM_NAME` is still set to `q` there

    ...


## Notes

1. This solution assumes a search engine will be chosen.
2. This solution could provide a choice of Google ([TACC/tup-ui uses `q` search query param name](https://github.com/TACC/tup-ui/blob/6eb9412/apps/tup-cms/src/taccsite_cms/settings_custom.py#L102) for [a Google search](https://github.com/TACC/tup-ui/blob/23dbed3/apps/tup-cms/src/taccsite_cms/templates/snippets/search.html)), but does not add the relevant JavaScript to make Google search work. _Whether we support Google search for Core CMS is still uncertain._