### PR TITLE
Bugfix/news tags all black

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -111,8 +111,7 @@ Styleguide Components.DjangoCMS.Blog.App
 }
 
 /* To style categories as "tags" (the UI pattern) */
-/* FAQ: Uses `:where()` to reduce specificity so colors are easily overridden */
-:where(.app-blog .categories a) {
+.app-blog .categories a {
   @extend :--c-tag;
 
   display: inline-block;
@@ -124,8 +123,7 @@ Styleguide Components.DjangoCMS.Blog.App
 }
 
 /* To style tags as "pills" (the UI pattern) */
-/* FAQ: Uses `:where()` to reduce specificity so colors are easily overridden */
-:where(.app-blog .tags a) {
+.app-blog .tags a {
   /* TODO: When available in Core-Styles, uncomment this */
   /* @extend :--c-pill; */
 

--- a/taccsite_cms/templates/djangocms_blog/base.html
+++ b/taccsite_cms/templates/djangocms_blog/base.html
@@ -14,7 +14,9 @@
 {% endblock meta %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'site_cms/css/build/app.blog.css' %}">
+<style>
+  @import url("/static/site_cms/css/build/app.blog.css") layer(project);
+</style>
 <div class="app app-blog
   {% if not settings.TACC_BLOG_SHOW_CATEGORIES %}no-categories{% endif %}
   {% if not settings.TACC_BLOG_SHOW_TAGS %}no-tags{% endif %}


### PR DESCRIPTION
## Overview / Changes

Load blog CSS in appropriate layer. Remove unnecessary (and not working) css trick. (Layers will do it instead.)

## Related

- required by https://github.com/TACC/tup-ui/pull/210

## Testing & UI

Blog loads in project layer.

...

Blog category "tags" have unique background colors.

...