### PR TITLE
feat(templates): extract assets_delayed_custom js ❌

### DIFF
--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -1,4 +1,4 @@
-{# FAQ: Delayed assets are loaded piecemeal to maek this easier to clone #}
+{# FAQ: Delayed assets are loaded piecemeal to make this easier to clone #}
 {# FAQ: Cloned on newest repos using Core-CMS because they cannot extend #}
 {# SEE: TACC/tup-ui, TACC/Core-CMS-Resources #}
 {% include 'javascript/bootstrap.html' %}

--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -1,21 +1,5 @@
-{# SEE: ./assets_core.md #}
-{% load staticfiles %}
-
-{# FAQ: Bootstrap can use jQuery, Popper, then its own script #}
-{# SEE: https://getbootstrap.com/docs/4.0/getting-started/introduction/#starter-template #}
-<script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-<script type="module">
-  import updateEmailLinkHrefs from '{% static "site_cms/js/modules/updateEmailLinkHrefs.js" %}';
-
-  const scopeElement = document.getElementById('cms-content');
-  const fakeText = '__REMOVE_THIS__';
-
-  updateEmailLinkHrefs(scopeElement, fakeText, {
-    user: 'data-user',
-    domain: 'data-domain',
-    subject: 'data-subject',
-    body: 'data-body'
-  });
-</script>
+{# FAQ: Delayed assets are loaded piecemeal to maek this easier to clone #}
+{# FAQ: Cloned on newest repos using Core-CMS because they cannot extend #}
+{# SEE: TACC/tup-ui, TACC/Core-CMS-Resources #}
+{% include 'javascript/bootstrap.html' %}
+{% include 'javascript/update_email_links.html' %}

--- a/taccsite_cms/templates/javascript/bootstrap.html
+++ b/taccsite_cms/templates/javascript/bootstrap.html
@@ -1,0 +1,5 @@
+{# FAQ: Bootstrap can use jQuery, Popper, then its own script #}
+{# SEE: https://getbootstrap.com/docs/4.0/getting-started/introduction/#starter-template #}
+<script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>

--- a/taccsite_cms/templates/javascript/update_email_links.html
+++ b/taccsite_cms/templates/javascript/update_email_links.html
@@ -1,0 +1,15 @@
+{% load staticfiles %}
+
+<script type="module">
+  import updateEmailLinkHrefs from '{% static "site_cms/js/modules/updateEmailLinkHrefs.js" %}';
+
+  const scopeElement = document.getElementById('cms-content');
+  const fakeText = '__REMOVE_THIS__';
+
+  updateEmailLinkHrefs(scopeElement, fakeText, {
+    user: 'data-user',
+    domain: 'data-domain',
+    subject: 'data-subject',
+    body: 'data-body'
+  });
+</script>


### PR DESCRIPTION
## Overview

~~Extract `assets_delayed_custom` template into smaller templates, so when TACC/tup-ui (unfortunately) overwrites the file, it can easily recreate its original content.~~

**This changes `assets_core_delayed`, which is unnecessary.**

## Related

- required by ___

## Changes

- **changes** `assets_delayed_custom.html` to load markup from separate templates

## Testing

Noop.

0. Load page and inspect element.
1. Verify `assets_delayed_custom.html` original content is still loaded.

## UI

![core-cms pr 623](https://user-images.githubusercontent.com/62723358/230952182-6d7b27b7-b5da-4bba-a5f9-91ee0152b9ad.png)
