### PR TITLE
feat(css): figure, caption, etc styles; whole site

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -8,8 +8,6 @@ Reference:
 Styleguide Components.DjangoCMS.Blog.App.Page
 */
 @import url("@tacc/core-styles/src/lib/_imports/objects/o-offset-content.css");
-@import url("@tacc/core-styles/src/lib/_imports/tools/x-figure.css");
-@import url("@tacc/core-styles/src/lib/_imports/tools/x-blockquote.css");
 
 @import url("./django.cms.blog.app.page.multimedia.css");
 
@@ -182,32 +180,4 @@ Styleguide Components.DjangoCMS.Blog.App.Page
   :--article-page .blog-content .align-left {
     max-width: 50%;
   }
-}
-
-
-
-
-
-/* Components & Elements */
-
-/* To style elements that are or have captions */
-:--article-page figure,
-:--article-page .embed-responsive {
-  @extend .x-figure;
-}
-:--article-page figcaption,
-:--article-page p.caption {
-  @extend .x-figure-caption;
-}
-
-:--article-page blockquote {
-  @extend .x-blockquote;
-}
-:--article-page blockquote footer {
-  @extend .x-blockquote-caption;
-}
-
-/* To remove extra whitespace beneath embeded content */
-:--article-page .embed-responsive > * {
-  display: block;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/figure-caption-blockquote.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/figure-caption-blockquote.css
@@ -1,0 +1,24 @@
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-figure.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-blockquote.css");
+
+/* To style elements that are or have captions */
+figure,
+.embed-responsive {
+  @extend .x-figure;
+}
+figcaption,
+p.caption {
+  @extend .x-figure-caption;
+}
+
+blockquote {
+  @extend .x-blockquote;
+}
+blockquote footer {
+  @extend .x-blockquote-caption;
+}
+
+/* To remove extra whitespace beneath embeded content */
+.embed-responsive > * {
+  display: block;
+}

--- a/taccsite_cms/static/site_cms/css/src/site.cms.css
+++ b/taccsite_cms/static/site_cms/css/src/site.cms.css
@@ -5,6 +5,8 @@
 
 @import url("./_imports/settings/font.css");
 
+@import url("./_imports/elements/figure-caption-blockquote.css");
+
 @import url("./_imports/components/c-button.css");
 @import url("./_imports/components/django.cms.css");
 @import url("./_imports/components/django.cms.blog.css");


### PR DESCRIPTION
## Overview

Apply figure, caption, and blockquote styles to the whole site, not just news.

## Related

- required by https://github.com/TACC/tup-ui

## Changes

- **changed** location and breadth of application of `x-figure(-…)` and `x-blockquote(-…)`

## Testing

1. Start up a CMS using this branch.
2. If local, `npm run build:css --project="core-cms" && docker exec -it sad_cms python manage.py collectstatic --no-input`.
3. Add figure and caption and blockquote and `p.caption` to a page (not a news article).
4. Verify the styles match those of a news article.

## UI

![core-cms pr 624](https://user-images.githubusercontent.com/62723358/230957495-cd5fe22b-ffd1-47a1-9fe1-04bef8085539.png)