### PR TITLE
bugfix: security for example-cms docker compose

### DIFF
--- a/docker-compose.example-cms.yml
+++ b/docker-compose.example-cms.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - .:/code
     ports:
-      - 8000:8000
+      - 127.0.0.1:8000:8000
     command: ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
     container_name: core_cms
     hostname: core_cms
@@ -42,7 +42,7 @@ services:
       - core_cms_es_data:/usr/share/elasticsearch/data
     container_name: core_cms_elasticsearch
     ports:
-      - 9201:9200
+      - 127.0.0.1:9201:9200
     networks:
       - core_cms_net
 


### PR DESCRIPTION
## Overview

Port a security fix to the example docker compose files.

## Related

- mimics #579

## Changes

- **add** host IP for port set in docker compose

## Testing & UI

Skipped. Should be a noop change. Please correct me if I am mistaken.