### PR TITLE
chore: load static not staticfiles

### DIFF
--- a/taccsite_cms/templates/assets_core.html
+++ b/taccsite_cms/templates/assets_core.html
@@ -1,5 +1,5 @@
 {# SEE: ./assets_core.md #}
-{% load staticfiles %}
+{% load static %}
 
 <style>
   {# https://confluence.tacc.utexas.edu/x/b53tDg #}

--- a/taccsite_cms/templates/assets_core_cms.html
+++ b/taccsite_cms/templates/assets_core_cms.html
@@ -1,5 +1,5 @@
 {# SEE: ./assets_core.md #}
-{% load staticfiles %}
+{% load static %}
 
 <style>
   @import url("{% static 'site_cms/css/build/core-styles.cms.css' %}") layer(base);

--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -1,5 +1,5 @@
 {# SEE: ./assets_core.md #}
-{% load staticfiles %}
+{% load static %}
 
 {# FAQ: Bootstrap can use jQuery, Popper, then its own script #}
 {# SEE: https://getbootstrap.com/docs/4.0/getting-started/introduction/#starter-template #}

--- a/taccsite_cms/templates/assets_custom.html
+++ b/taccsite_cms/templates/assets_custom.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 {# Load assets as external files, to cache independently of markup. #}
 {% comment %}

--- a/taccsite_cms/templates/assets_font.html
+++ b/taccsite_cms/templates/assets_font.html
@@ -1,6 +1,6 @@
 {# Load web fonts early #}
 {# SEE: https://confluence.tacc.utexas.edu/x/B4COCw #}
-{% load staticfiles %}
+{% load static %}
 
 
 

--- a/taccsite_cms/templates/assets_site.html
+++ b/taccsite_cms/templates/assets_site.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 {# Load assets as external files, to cache independently of markup. #}
 {% comment %}

--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -1,4 +1,4 @@
-{% load cms_tags staticfiles sekizai_tags cache i18n meta %}
+{% load cms_tags static sekizai_tags cache i18n meta %}
 {% get_current_language as lang_code %}
 <!doctype html>
 <html

--- a/taccsite_cms/templates/debug_js.html
+++ b/taccsite_cms/templates/debug_js.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 {# Let all other scripts know that we are in debug mode #}
 {# CAVEAT: To be effectual, this file must load before other scripts (no `async`, no `defer`) #}

--- a/taccsite_cms/templates/guide.html
+++ b/taccsite_cms/templates/guide.html
@@ -1,5 +1,5 @@
 {% extends "fullwidth.html" %}
-{% load cms_tags staticfiles %}
+{% load cms_tags static %}
 
 {% block assets_custom %}
 	{{ block.super }}

--- a/taccsite_cms/templates/guides/getting_started.tam.html
+++ b/taccsite_cms/templates/guides/getting_started.tam.html
@@ -1,5 +1,5 @@
 {% extends "guide.html" %}
-{% load cms_tags staticfiles tacc_uri_shortcuts %}
+{% load cms_tags static tacc_uri_shortcuts %}
 
 {% block guide %}
   {% site_uri as site_uri %}

--- a/taccsite_cms/templates/guides/getting_started.v2.html
+++ b/taccsite_cms/templates/guides/getting_started.v2.html
@@ -1,5 +1,5 @@
 {% extends "guide.html" %}
-{% load cms_tags staticfiles tacc_uri_shortcuts %}
+{% load cms_tags static tacc_uri_shortcuts %}
 
 {% block guide %}
   {% site_uri as site_uri %}

--- a/taccsite_cms/templates/header_branding.html
+++ b/taccsite_cms/templates/header_branding.html
@@ -1,5 +1,5 @@
 {# @var brands, className #}
-{% load staticfiles custom_portal_settings %}
+{% load static custom_portal_settings %}
 
 {% with settings.BRANDING as brands %}
 <div id="header-branding" class="branding-header {{className}}">

--- a/taccsite_cms/templates/header_logo.html
+++ b/taccsite_cms/templates/header_logo.html
@@ -1,5 +1,5 @@
 {# @var logo, className #}
-{% load staticfiles custom_portal_settings %}
+{% load static custom_portal_settings %}
 
 {% with settings.LOGO as logo %}
   {% with filename=logo|index:1 selectors=logo|index:2 targeturl=logo|index:3 targettype=logo|index:4 accessibility=logo|index:5 corstype=logo|index:6 visibility=logo|index:7 %}

--- a/taccsite_cms/templates/home_portal.html
+++ b/taccsite_cms/templates/home_portal.html
@@ -1,5 +1,5 @@
 {% extends "fullwidth.html" %}
-{% load cms_tags staticfiles %}
+{% load cms_tags static %}
 
 {% block assets_custom %}
 	{{ block.super }}

--- a/taccsite_cms/templates/nav_search.raw.html
+++ b/taccsite_cms/templates/nav_search.raw.html
@@ -1,6 +1,6 @@
 {# @var settings #}
 
-{% load staticfiles %}
+{% load static %}
 <!-- FAQ: This template loads independently at a unique url (see `urls.py`)
           so Portal and User Guide can render this markup into their markup. -->
 

--- a/taccsite_cms/templates/snippets/typography-guide.html
+++ b/taccsite_cms/templates/snippets/typography-guide.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <link rel="stylesheet" href="{% static 'site_cms/css/build/template.guide.css' %}">
 

--- a/taccsite_cms/templates/style_guide.html
+++ b/taccsite_cms/templates/style_guide.html
@@ -1,5 +1,5 @@
 {% extends "standard.html" %}
-{% load cms_tags staticfiles %}
+{% load cms_tags static %}
 
 {% block assets_custom %}
   {{ block.super }}


### PR DESCRIPTION
## Overview

Load `static` not `staticfiles` template tag so #626 does **not** have error.

## Related

- mimics #625
- required by #626

## Changes

- **changed** all templates loading `staticfiles` to load just `static`

## Testing

1. Build TUP CMS off https://github.com/TACC/tup-ui/pull/225.
2. Load CMS in browser.
3. Verify no TemplateSyntaxError.

## UI

| Before | After |
| - | - |
| ![templatesyntaxerror](https://user-images.githubusercontent.com/62723358/235548128-8f538d81-8747-474b-908a-fbe73b41a2f9.png) | … |