### PR TITLE
fix: TUP-477, set X_FRAME_OPTIONS like django 2

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -38,6 +38,9 @@ ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']   # In development.
 # Default portal authorization verification endpoint.
 CEP_AUTH_VERIFICATION_ENDPOINT = 'localhost'  # 'https://0.0.0.0:8000'
 
+# https://docs.djangoproject.com/en/3.0/ref/clickjacking/#how-to-use-it
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+
 ########################
 # DATABASE SETTINGS
 ########################


### PR DESCRIPTION
## Overview

Fix problem caused by [Django 3 protection against clickjacking](https://docs.djangoproject.com/en/3.0/ref/clickjacking/).

## Related

- [TUP-477]

[TUP-477]: https://jira.tacc.utexas.edu/browse/TUP-477

## Changes

- **added** `X_FRAME_OPTIONS = 'SAMEORIGIN'`

## Testing

Test [TUP-477].

## UI

Skipped.

## Notes

### Help Wanted

1. Is there an option that only sets `SAMEORIGIN` where we know we need it, and otherwise defaults to `DENY`?
2. Is that option more secure? And sensible?
