### PR TITLE
fix: TUP-477, set X_FRAME_OPTIONS like django 2 (for TUP CMS)

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -38,6 +38,9 @@ ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']   # In development.
 # Default portal authorization verification endpoint.
 CEP_AUTH_VERIFICATION_ENDPOINT = 'localhost'  # 'https://0.0.0.0:8000'
 
+# https://docs.djangoproject.com/en/3.0/ref/clickjacking/#how-to-use-it
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+
 ########################
 # DATABASE SETTINGS
 ########################


### PR DESCRIPTION
Mimics #630, but for #626 instead of #625.