### PR TITLE
chore: retire env()-based themes (Core-CMS v3.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@tacc/core-cms",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tacc/core-cms",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "license": "MIT",
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^0.11.0",
+        "@tacc/core-styles": "github:TACC/Core-Styles#release/v0.12.0--retire-env-vars",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -510,10 +510,10 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.11.0.tgz",
-      "integrity": "sha512-TmAqeQPzJ39lGOj3AF9QNtt+Lo1Jfne35PSdSl0M+K52qCoFqurSqiV36thB/JJ7W6VcAR4LHP4J1pDwVuj7wg==",
+      "version": "0.12.0",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#e3634e5aab42c8888f24b04d81c4c34e027bf0d6",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -9634,10 +9634,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-0.11.0.tgz",
-      "integrity": "sha512-TmAqeQPzJ39lGOj3AF9QNtt+Lo1Jfne35PSdSl0M+K52qCoFqurSqiV36thB/JJ7W6VcAR4LHP4J1pDwVuj7wg==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#e3634e5aab42c8888f24b04d81c4c34e027bf0d6",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#release/v0.12.0--retire-env-vars",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^0.11.0",
+    "@tacc/core-styles": "github:TACC/Core-Styles#release/v0.12.0--retire-env-vars",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -184,18 +184,6 @@ HAYSTACK_CONNECTIONS = {
 }
 
 ########################
-# TACC: (DEPRECATED)
-########################
-
-"""
-Optional theming of CMS (certain themes may only affect some elements)
-Usage:
-- None (standard theme)
-- 'has-dark-logo'
-"""
-THEME = None
-
-########################
 # TACC: BRANDING
 ########################
 
@@ -648,7 +636,6 @@ except ImportError:
 
 SETTINGS_EXPORT = [
     'DEBUG',
-    'THEME',
     'BRANDING',
     'LOGO',
     'FAVICON',

--- a/taccsite_cms/static/site_cms/css/.postcssrc.yml
+++ b/taccsite_cms/static/site_cms/css/.postcssrc.yml
@@ -7,9 +7,6 @@ plugins:
     path:
       - 'taccsite_cms/static/site_cms/css/src' # Core-CMS CSS source files
       - 'node_modules/@tacc/core-styles/src/lib' # Core-Styles CSS source files
-  postcss-env-function:
-    importFrom:
-      - 'node_modules/@tacc/core-styles/src/lib/_themes/default.json'
   postcss-replace:
     pattern: ../../fonts/
     data:

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.css
@@ -10,6 +10,9 @@ Reference:
 
 Styleguide Components.DjangoCMS
 */
+.cms-ready {
+  --cms-toolbar-height: 46px;
+}
 
 /* Prevent excess scrollbar when logged into Django CMS */
 /* NOTE: This code does NOT work */
@@ -18,17 +21,17 @@ Styleguide Components.DjangoCMS
   /* FAQ: CMS dynamically adds `margin-top` to `head` to fit toolbar height *\/
   /* WARNING: If the dynamic(!) header margin changes, then so should this *\/
   /* RFC: Consider creating JavaScript snippet (via CMS?) to solve this *\/
-  height: calc(100vh - env(--cms-toolbar-height));
+  height: calc(100vh - var(--cms-toolbar-height));
 }
 */
 
 /* Prevent anchor links from scrolling behind Django CMS header */
 .cms-ready :target {
-  scroll-margin-top: env(--cms-toolbar-height);
+  scroll-margin-top: var(--cms-toolbar-height);
 }
 
 /* Prevent top-sticking content from scrolling behind Django CMS header */
 .cms-ready .sticky-top /* Bootstrap class */,
 .cms-ready .position-sticky.fixed-top /* Bootstrap class */ {
-  top: env(--cms-toolbar-height);
+  top: var(--cms-toolbar-height);
 }

--- a/taccsite_cms/static/site_cms/css/src/site.css
+++ b/taccsite_cms/static/site_cms/css/src/site.css
@@ -11,6 +11,9 @@
         ﹡ Files is first searched for locally, then remotely.
 */
 
+/* THEME */
+@import url("@tacc/core-styles/src/lib/_imports/theme.default.css");
+
 /* SETTINGS */
 @import url("_imports/settings/border.css");
 @import url("_imports/settings/max-width.css");

--- a/taccsite_cms/static/site_cms/css/src/site.header.css
+++ b/taccsite_cms/static/site_cms/css/src/site.header.css
@@ -10,7 +10,7 @@
 /* CAVEAT: These are already imported in `site.css`, but necessary here to
            override Portal (which also loads `site.header.css`), so font
            variables are unfortunately overwritten 1x in CMS, 2x in Portal */
-/* TODO: Find a way to be modular, but not redundant; perhaps `env()` vars */
+/* TODO: Find a way to be modular, but not redundant */
 /* Unique to CMS */
 @import url("./_imports/settings/font.css");
 


### PR DESCRIPTION
## Overview

1. Replace `env()`-based themes with simpler solutions.
2. <details><summary>Remove <code>postcss-env-function</code> deprecation warning.</summary>

    ```
    postcss-env-function is deprecated and will be removed.
    We are looking for insights and anecdotes on how these features are used so that we can design the best alternative.
    Please let us know if our proposal will work for you.
    Visit the discussion on github for more details.
    https://github.com/csstools/postcss-plugins/discussions/192
    ```

    </details>

## Related

- requires https://github.com/TACC/Core-CMS-Resources/pull/178
- requires https://github.com/TACC/Core-Styles/pull/164
- required by https://github.com/TACC/Core-CMS/pull/605
    <sup>(because it is easier to remove themes than to support them backwards-compatibly in Core-CMS v3.10)</sup>

## Changes

1. Migrate `--cms-toolbar-height` from Core-Styless back to Core-CMS.
4. Do **not** promote `env()`.
5. Do **not** use `postcss-env-function`.
6. Do **not** load JSON theme values.
7. Do **not** support `THEME`.
8. Resolve `taccsite_custom` aftermath.

## Testing

1. <details><summary>Deploy several sites of unique relevance to themes…</summary>

    - **Core** — because it is uses `default` theme, and is a "pure" site
    - **ProTX** — because it uses `has-dark-logo` theme
    - **ECEP** — because it is uses a **custom** theme
    - **Frontera** — because it is uses `default` theme, and is a modified site
    - **Texascale** — because it is uses `default` theme, and is a heavily modified site

    </details>
2. Verify each site loads and loads theme variables as custom properties:
    - `--header-...`
    - `--menu-...`
3. Verify each site has same-themed header as its production site.
4. (where feasible[^1]) Verify each site has same-styled pages as its production site.
5. Verify builds do **not** warn about deprecation of `postcss-env-function`.

[^1]: [ECEP] site never got production server content. [Frontera] site has slightly outdated content.

## UI

| [core] <br /><sub>vars from<br />Core <code>site.css</code></sub> | [protx] <br /><sub>vars from<br />snippet</sub> | [ecep] <br /><sub>vars from<br />ECEP <code>site.css</code></sub> | [frontera] <br /><sub>vars from<br />Core <code>site.css</code></sub> | [texascale] <br /><sub>vars from<br />Core <code>site.css</code></sub> |
| - | - | - | - | - |
| ![core](https://user-images.githubusercontent.com/62723358/236927778-6ae8627c-4e25-4881-b82e-f3c997585c76.png) | ![protx](https://user-images.githubusercontent.com/62723358/236932517-cad6c2c2-a9cc-4e8a-9a83-1e4eee76fb43.png) | ![ecep](https://user-images.githubusercontent.com/62723358/236934260-fef8e625-ae30-4f46-b2b0-237ad8f65f5c.png) | ![frontera](https://user-images.githubusercontent.com/62723358/236935075-a14132fd-0a4a-40fa-b2de-e93089934224.png) | ![texascale](https://user-images.githubusercontent.com/62723358/236935368-dd07f094-101f-4476-8b14-d2cc130ece44.png) |

[core]: https://dev.cep.tacc.utexas.edu/
[protx]: https://pprd.protx.tacc.utexas.edu/
[ecep]: https://pprd.ecep.tacc.utexas.edu/
[frontera]: https://dev.fronteraweb.tacc.utexas.edu/
[texascale]: https://pprd.texascale.tacc.utexas.edu/