### PR TITLE
fix(css): add missing theme vars

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/site.header.css
+++ b/taccsite_cms/static/site_cms/css/src/site.header.css
@@ -5,6 +5,9 @@
 /* Organize via ITCSS */
 /* SEE: https://confluence.tacc.utexas.edu/x/IAA9Cw */
 
+/* THEME */
+@import url("@tacc/core-styles/src/lib/_imports/theme.default.css");
+
 /* SETTINGS */
 /* CAVEAT: These are already imported in `site.css`, but necessary here to
            override Portal (which also loads `site.header.css`), so font

--- a/taccsite_cms/static/site_cms/css/src/theme.has-dark-logo.css
+++ b/taccsite_cms/static/site_cms/css/src/theme.has-dark-logo.css
@@ -2,4 +2,4 @@
 
 /* NOTE: This file exists so that Portal can load non-default theme styles */
 
-@import url("@tacc/core-styles/src/lib/_imports/theme.default.css");
+@import url("@tacc/core-styles/src/lib/_imports/theme.has-dark-logo.css");

--- a/taccsite_cms/static/site_cms/css/src/theme.has-dark-logo.css
+++ b/taccsite_cms/static/site_cms/css/src/theme.has-dark-logo.css
@@ -1,0 +1,5 @@
+/* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
+
+/* NOTE: This file exists so that Portal can load non-default theme styles */
+
+@import url("@tacc/core-styles/src/lib/_imports/theme.default.css");


### PR DESCRIPTION
## Overview

1. Add default theme variables to `site.header.css`.
2. Add "has dark logo" theme variables to new `theme.has-dark-logo.css`.

## Related

- fixes #632
    <sup>After which Portal would not render header colors, so legibility was broken.</sup>
- supports https://github.com/TACC/Core-Portal/pull/799

## Changes

- **added** theme vars to `site.header.css`
- **added** `has-dark-logo` theme stylesheet

## Testing

1. On a site running this branch, verify `/static/site_cms/css/build/theme.has-dark-logo.css` loads theme variables.
2. On Portal dashboard, verify header is black with white text.
3. Deploy both [#634] and to ProTX local or pre-prod site.
4. Add to [ProTX](https://pprd.protx.tacc.utexas.edu/) **Portal** `settings_local.py`:

    ```py
    PORTAL_CSS_FILENAMES = [
        '/static/site_cms/css/build/theme.has-dark-logo.css'
    ]
    ```

5. On [ProTX Portal dashboard](https://pprd.protx.tacc.utexas.edu/workbench/dashboard), verify header is white with black text.

[#634]: https://github.com/TACC/Core-CMS/pull/634
[#632]: https://github.com/TACC/Core-CMS/pull/632

## UI

<details><summary>CEP</summary>

[CEP](https://dev.cep.tacc.utexas.edu/)[^1]

| cms render | portal code |
| - | - |
| <img width="1200" alt="cep portal code" src="https://github.com/TACC/Core-CMS/assets/62723358/77081755-e070-481e-a66b-c5bc6c3a2de8"> | <img width="1200" alt="cep cms render" src="https://github.com/TACC/Core-CMS/assets/62723358/b550cfdb-4431-4493-a097-dc7029270102"> |

</details>
<details><summary>Frontera</summary>

[Frontera](https://dev.fronteraweb.tacc.utexas.edu/)[^1]

| cms render*† | portal code |
| - | - |
| <img width="1200" alt="frontera cms render" src="https://github.com/TACC/Core-CMS/assets/62723358/70d2e2bb-031e-4cf9-92d6-678c0231985d"> | <img width="1200" alt="frontera portal code" src="https://github.com/TACC/Core-CMS/assets/62723358/3b73cb16-e2b3-4878-adaa-23784806cdfd"> |

<sup>* On Frontera homepage, the right-most banner news article is offset from gray background. **Fixed** after screenshots via snippet like prod.</sup>\
<sup>† On Frontera homepage, the system monitor table has white background cells. **Fixed** in #635.</sup>

</details>
<details><summary>ProTX</summary>

[ProTX](https://pprd.protx.tacc.utexas.edu/)[^2]

| cms render | portal code | [theme css](https://pprd.protx.tacc.utexas.edu/static/site_cms/css/build/theme.has-dark-logo.css) |
| - | - | - |
| <img width="1200" alt="protx cms render" src="https://github.com/TACC/Core-CMS/assets/62723358/61c3f206-50f4-4aba-a089-b7d50aa14828"> | <img width="1200" alt="protx portal code" src="https://github.com/TACC/Core-CMS/assets/62723358/f1eeddb1-e082-42b3-b562-b6e3ece8a82f"> | <img width="1200" alt="protx theme css" src="https://github.com/TACC/Core-CMS/assets/62723358/9a011af8-c9bc-44f9-a39a-bb96f9b3b40e"> |

</details>
<details><summary>UTRC</summary>

[UTRC](https://pprd.utrc.tacc.utexas.edu/)[^3]

| cms render | portal code |
| - | - |
| <img width="1200" alt="utrc portal code" src="https://github.com/TACC/Core-CMS/assets/62723358/a8e2436d-cbfa-469d-a0a4-f6ae1593c832"> | <img width="1200" alt="utrc cms render" src="https://github.com/TACC/Core-CMS/assets/62723358/bc08b431-a7fb-40b6-af06-024e7d3566e5"> |

</details>

[^1]: Because the header of most projects (e.g. CEP, Frontera) uses default header theme, their Portal does not need extra styles, so their Portal does not need to be deployed to test this fix.
[^2]: Because the header of ProTX project uses a light header theme, its Portal needs extra styles, so I deployed "all" to test this fix.
[^3]: Because of [a default Python value for Core-Portal#799 new Portal setting](https://github.com/TACC/Core-Portal/pull/799/commits/1e8e40f), a regular Portal (e.g. UTRC) needs to be tested on a default header theme, so I deployed "all" to test this fix.