### PR TITLE
fix: (frontera) system_monitor colors

### DIFF
--- a/taccsite_cms/contrib/taccsite_system_monitor/static/taccsite_system_monitor/css/system_monitor.css
+++ b/taccsite_cms/contrib/taccsite_system_monitor/static/taccsite_system_monitor/css/system_monitor.css
@@ -47,6 +47,11 @@ Styleguide Trumps.Scopes.SystemMonitor
   margin-bottom: 0px;
 }
 .s-system-monitor .table-dark {
+  --global-color-background--app: transparent;
+
+  background-color: var(--global-color-primary--xx-dark);
+}
+.s-system-monitor .table-dark :is(th, td) {
   color: var(--global-color-primary--normal);
   background-color: var(--global-color-primary--xx-dark);
 }


### PR DESCRIPTION
## Overview

Fix incorrect colors on System Monitor table (only used on Frontera).

## Related

- fixes https://github.com/TACC/Core-CMS/pull/568/files#diff-4257a06b5695f2afd536fd7fb983e6cfbbced1462f96ec4d10c68e49f215a7feR31

## Changes

- **changed** system monitor to unset global background color
    <sup>The `<th>`s were white cuz default `--global-color-background--app` is white, and it is used to color `<th>` backgrounds.</sup>
- **changed** system monitor table color to be cell color (more specific)
    <sup>The `<td>` and `<th>` colors were trumped by Core Styles table CSS.</sup>

## Testing

Use the new styles instead of the old styles. I believe this can reliably be tested live.

https://github.com/TACC/Core-CMS/assets/62723358/f758daed-e5cf-454f-a1db-512714f42fa3

## UI

| before | after |
| - | - |
| <img width="1200" alt="before" src="https://github.com/TACC/Core-CMS/assets/62723358/e260bfd4-4b39-401f-8540-1738508cd6d0"> | <img width="1200" alt="after" src="https://github.com/TACC/Core-CMS/assets/62723358/1ea1fd26-22f7-4ac7-86d9-609442b38c3b"> |