### PR TITLE
fix(templates): bump home_portal <hN> levels

### DIFF
--- a/taccsite_cms/templates/home_portal.html
+++ b/taccsite_cms/templates/home_portal.html
@@ -13,7 +13,7 @@
 {% block content %}
   {% placeholder "content" or %}
   <div class="container  s-document">
-    <h2>Core Experience Portal</h2>
+    <h1>Core Experience Portal</h1>
 
     <p><strong>The Texas Advanced Computing Center (TACC) provides powerful and intuitive web interfaces that remove technological hurdles.</strong></p>
 
@@ -21,7 +21,7 @@
 
     <p>The portal&#39;s main features include:</p>
 
-    <h3>Data Management</h3>
+    <h2>Data Management</h2>
 
     <ul>
       <li>Upload from your device or cloud storage.</li>
@@ -30,7 +30,7 @@
       <li>Share with collaborators and reviewers.</li>
     </ul>
 
-    <h3>Computation</h3>
+    <h2>Computation</h2>
 
     <ul>
       <li>Queue HPC Jobs.</li>


### PR DESCRIPTION
## Overview / Changes

Increase the `<h2>` and `<h3>` on `home_portal.html` to `<h1>` and `<h2>`.

## Related

- follow-up to #549

## Testing

1. Compare heading levels before this branch and after.

## UI

| before, _automatic_ | expectation, _manual_ | after, _automatic_ |
| - | - | - |
| ![cep auto home before hN bump](https://github.com/TACC/Core-CMS/assets/62723358/7ef435c6-a438-4648-8283-7029a0c68b54) | ![cep manual home expectation](https://github.com/TACC/Core-CMS/assets/62723358/7dbd5533-53f4-447f-9fe5-9b036560f05a) | ![cep auto home after hN bump](https://github.com/TACC/Core-CMS/assets/62723358/139a3f1d-66d4-4b5a-9770-c5e183d0e103) |
