### PR TITLE
fix(tup-cms): make search field required input

### DIFF
--- a/taccsite_cms/templates/nav_search.raw.html
+++ b/taccsite_cms/templates/nav_search.raw.html
@@ -21,7 +21,7 @@
     name="{{ settings.SEARCH_QUERY_PARAM_NAME }}"
     placeholder="Search"
     data-testid="input"
-    autocomplete="off" minlength="3"
+    autocomplete="off" minlength="3" required
     value="" />
   <input type="hidden" name="page" value="1" />
 


### PR DESCRIPTION
## Overview

Do not let user submit empty search query.

## Related

- [TUP-???](https://jira.tacc.utexas.edu/browse/TUP-____)
- appropriately performs rushed https://github.com/TACC/tup-ui/pull/235

## Changes

- **added** search template from core-cms
- **added** `required` attribute to `<input>` in  search template.

## Testing

1. Submit empty search query through CMS header search bar.
2. Verify search does not proceed.

## UI

<img width="390" alt="tup-cms search input required" src="https://github.com/TACC/tup-ui/assets/62723358/92559caf-0711-42ec-a776-eed6a582cbca">

## Notes

❗️ After this is merged, https://github.com/TACC/tup-ui/pull/235 should be reverted, in favor of a newer CMS image.