### PR TITLE
fix(js): DES-2498 auto new window ignores redirect

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -33,8 +33,8 @@ const SHOULD_DEBUG = window.DEBUG;
       // FAQ: I am literally double-checking, because I don't trust JavaScript
       const isExternal = (link.origin !== document.location.origin);
       const isInternal = (link.host === document.location.host);
-      const shouldOpenInNewWindow = (
-          ! isInternal && (isExternal || hasExternalRedirect) && ! isMailto
+      const shouldOpenInNewWindow = hasExternalRedirect || (
+          ! isInternal && isExternal && ! isMailto
       );
 
       if ( shouldOpenInNewWindow ) {


### PR DESCRIPTION
## Overview

Make `pathsToExternalSite` take precedent when auto-adding `target="_blank"`.

## Related

- [DES-2498](https://jira.tacc.utexas.edu/browse/DES-2498)

## Changes

- changed boolean logic to give precedence to `hasExternalRedirect`

## Testing

1. Load raw updated code into a `<script>` in a snippet.
    <sup>I tested on [DesignSafe](https://www.designsafe-ci.org/) via snippet [#9](https://www.designsafe-ci.org/admin/djangocms_snippet/snippet/9/change/).</sup>
2. Add `window.DEBUG = true;` in a second `<script>` **before** the first.
3. Save snippet.
4. Refresh page.
5. Verify console logs debug info form the script.
6. Verify any `pathsToExernalSite` are given `target="_blank"`.

<details><summary>Sample Code</summary>

```html
<script type="module">
    window.DEBUG = true;
</script>
<script type="module">
/* PASTE UPDATED SCRIPT CODE HERE */

    findLinksAndSetTargets({
        pathsToExernalSite: ['/facilities/simcenter/', '/facilities/rapid-facility/']
    });
</script>
```

</details>

## UI

Skipped.