### PR TITLE
feat(js): DES-2496 auto new tab, regex + callbacks

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -5,17 +5,33 @@
 const SHOULD_DEBUG = window.DEBUG;
 
 /**
+ * Function to perform after setting link target
+ * @callback setTargetCallback
+ * @param {HTMLElement} link
+ */
+
+/**
  * Set external links (automatically discovered) to open in new tab
  * @param {object} [options] - Optional parameters
- * @param {array.<string>} [options.pathsToExernalSite=[]] - A list of relative URL paths that should be treated like external URLs
+ * @param {array.<string>} [options.pathsToExernalSite=[]] - (DEPRECATED) A list of relative URL paths that should be treated like external URLs
+ * @param {array.<string|RegExp>} [options.pathsToForceSetTarget=[]] - A list of relative URL paths (or patterns) that should trigger setting a target
+ * @param {string} [options.target="_blank"] - The value for the target attribute
  * @param {HTMLElement|Document} [options.scopeElement=document] - The element within which to search for links
+ * @param {setTargetCallback} [options.setTargetCallback] - A callback for after a target is set
  */
  export default function findLinksAndSetTargets(options) {
   const defaults = {
+    target: '_blank',
     pathsToExernalSite: [],
+    pathsToForceSetTarget: [],
     scopeElement: document
   }
- const {pathsToExernalSite, scopeElement} = {...defaults, ...options};
+  const {target, pathsToExernalSite, scopeElement, setTargetCallback} = {...defaults, ...options};
+  let {pathsToForceSetTarget} = {...defaults, ...options};
+
+  if ( pathsToExernalSite.length && ! pathsToForceSetTarget.length ) {
+    pathsToForceSetTarget = pathsToExernalSite;
+  }
 
   const links = scopeElement.getElementsByTagName('a');
   [ ...links ].forEach( function setTarget(link) {
@@ -27,39 +43,54 @@ const SHOULD_DEBUG = window.DEBUG;
       }
 
       const isMailto = (link.href.indexOf('mailto:') === 0);
-      const hasExternalRedirect = pathsToExernalSite.some(path => {
-          return _doPathsMatch(path, link.pathname);
+      const shouldForceSetTarget = pathsToForceSetTarget.some(path => {
+        let shouldForce;
+        if (path instanceof RegExp) {
+          shouldForce = path.test(link.pathname);
+        }
+        if (typeof path === 'string') {
+          shouldForce = _doPathsMatch(path, link.pathname);
+        }
+        if (SHOULD_DEBUG && shouldForce) {
+          console.debug(`Path "${link.pathname}" matches "${path}"`);
+        }
+        return shouldForce;
       });
       // FAQ: I am literally double-checking, because I don't trust JavaScript
       const isExternal = (link.origin !== document.location.origin);
       const isInternal = (link.host === document.location.host);
-      const shouldOpenInNewWindow = hasExternalRedirect || (
+      const shouldSetTarget = shouldForceSetTarget || (
           ! isInternal && isExternal && ! isMailto
       );
 
-      if ( shouldOpenInNewWindow ) {
-          if (link.target !== '_blank') {
-              link.target = '_blank';
+      if ( shouldSetTarget ) {
+          if (link.target !== target) {
+              link.target = target;
               if (SHOULD_DEBUG) {
                 console.debug(`Link ${link.href} now opens in new tab`);
               }
+          }
+          if (typeof setTargetCallback === 'function') {
+            setTargetCallback( link );
           }
       }
   });
 }
 
 /**
-* Does redirect path match link path (ignoring "/" link path)
-* @param {string} redirectPath - A path known to redirect to an external site
-* @param {string} testLinkPath - A path found on the page being updated
-*/
+ * Does redirect path match link path (ignoring "/" link path)
+ * @param {string} redirectPath - A path known to redirect to an external site
+ * @param {string} testLinkPath - A path found on the page being updated
+ */
 function _doPathsMatch(redirectPath, testLinkPath) {
-if (testLinkPath === '/') {
-  return false;
-}
+  if (testLinkPath === '/') {
+    return false;
+  }
 
-return redirectPath === testLinkPath
+  const isMatch = redirectPath === testLinkPath
     || redirectPath === testLinkPath.slice(1)
     || redirectPath === testLinkPath.slice(0, -1)
     || redirectPath === testLinkPath.slice(1).slice(0, -1);
+
+  return isMatch;
 }

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -15,7 +15,6 @@ const SHOULD_DEBUG = window.DEBUG;
  * @param {object} [options] - Optional parameters
  * @param {array.<string>} [options.pathsToExernalSite=[]] - (DEPRECATED) A list of relative URL paths that should be treated like external URLs
  * @param {array.<string|RegExp>} [options.pathsToForceSetTarget=[]] - A list of relative URL paths (or patterns) that should trigger setting a target
- * @param {string} [options.target="_blank"] - The value for the target attribute
  * @param {HTMLElement|Document} [options.scopeElement=document] - The element within which to search for links
  * @param {setTargetCallback} [options.setTargetCallback] - A callback for after a target is set
  */
@@ -64,8 +63,8 @@ const SHOULD_DEBUG = window.DEBUG;
       );
 
       if ( shouldSetTarget ) {
-          if (link.target !== target) {
-              link.target = target;
+          if (link.target !== '_blank') {
+              link.target = '_blank';
               if (SHOULD_DEBUG) {
                 console.debug(`Link ${link.href} now opens in new tab`);
               }


### PR DESCRIPTION
## Overview

Updates to JavaScript that opens link in a new tab:

- **add** pattern matching (Regex)
- **add** callback
- **deprecate** misspelled option for paths
- **add** better-named option for paths

## Related

- [DES-2496](https://jira.tacc.utexas.edu/browse/DES-2496)
- adds to recent #649

## Changes

- **deprecated** `pathsToExernalSite` option
- **added** `pathsToForceSetTarget` option
- **added** `setTargetCallback` option
- **change** script to prefer `pathsToForceSetTarget`
- **change** script variables to reflect "force set target" context
    <sup>This more clearly describes what user is doing, and suggests they can define the `target` value.</sup>
- **add** RegEx matching for paths

## Testing

### `pathsToForceSetTarget` & `setTargetCallback` & RegEx matching for paths

1. Load raw updated code into a `<script>` in a snippet.
    <sup>I tested via [DesignSafe](https://www.designsafe-ci.org/) via snippet [#10](https://www.designsafe-ci.org/admin/djangocms_snippet/snippet/10/change/).</sup>
2. Call the `findLinksAndSetTargets` with `pathsToForceSetTarget` and `setTargetCallback`.
    <sup>See "Sample Code".</sup>
3. Add `window.DEBUG = true;` in a second `<script>` **before** the first.
4. Save snippet.
5. Refresh page.
6. Verify console logs debug info from the script.
7. Verify any `pathsToForceSetTarget` are:
    - given `target="_blank"` (unless they already had it)
    - given `aria-describedby="msg-open-new-window"` (unless there is a `<span class="sr-only">…</span>`)

<details><summary>Sample Code</summary>

```html
<script type="module">
    window.DEBUG = true;
</script>
<script type="module">
    // import findLinksAndSetTargets from 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS@v3.10.2/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js';
/* PASTE UPDATED SCRIPT CODE HERE */

    findLinksAndSetTargets({
        pathsToForceSetTarget: [ /\.pdf/ ],
        setTargetCallback: function supportA11y( link ) {
            const hasA11yNote = link.querySelector('span.sr-only');
            const hasA11yDesc = link.hasAttribute('aria-describedby');

            if ( ! hasA11yNote && ! hasA11yDesc ) {
                link.setAttribute('aria-describedby', 'msg-open-new-window');
                if (SHOULD_DEBUG) {
                    console.debug(`Link ${link} now has "aria-describedby"`);
                }
            }
        },
    });
</script>
```

</details>

### Regression Testing e.g. `pathsToExernalSite` & #649

1. Load raw updated code into a `<script>` in a snippet.
    <sup>I tested via [DesignSafe](https://www.designsafe-ci.org/) via snippet [#9](https://www.designsafe-ci.org/admin/djangocms_snippet/snippet/9/change/).</sup>
2. Continue to call the `findLinksAndSetTargets` with `pathsToExernalSite`.
    <sup>See "Sample Code".</sup>
3. Retain `window.DEBUG = true;` in a second `<script>` **before** the first.
4. Save snippet.
5. Refresh page.
6. Verify console logs debug info from the script.
7. Verify any `pathsToExernalSite` are:
    - given `target="_blank"`

<details><summary>Sample Code</summary>

```html
<script type="module">
    window.DEBUG = true;
</script>
<script type="module">
/* PASTE UPDATED SCRIPT CODE HERE */

    findLinksAndSetTargets({
        pathsToExernalSite: [
            '/facilities/simcenter/',
            '/facilities/rapid-facility/',
            '/rw/simcenter-research-tools/',
            '/learning-center/simcenter-learning-tools/',
            '/community/mechs/',
            // TODO: Activate 2023-07 after launch of new DesignSafe docs
            // SEE: https://www.designsafe-ci.org/user-guide/
            // '/rw/use-cases/',
            // '/rw/user-guides/',
            // '/help/user-guides/',
        ]
    });
</script>
```

</details>

## UI

Page: https://www.designsafe-ci.org/community/user-forum/

| new `aria-describedby` (no `span.sr-only`) + new `target="_blank"` | no `aria-describedby` cuz `span.sr-only` + existing `target="_blank"` |
| - | - |
| <img width="1440" alt="new aria-describedby + new target=_blank" src="https://github.com/TACC/Core-CMS/assets/62723358/9d40a0d7-1a8f-4a3f-b35b-efdfff6f72af"> | <img width="1440" alt="no aria-describedby + existing target=_blank" src="https://github.com/TACC/Core-CMS/assets/62723358/be41e0f6-8c25-4161-bd52-9e12be9a1d26"> |

<details><summary>Log</summary>

```
Link http://designsafe-ci.org/ now opens in new tab
Link http://fiu.designsafe-ci.org/ now opens in new tab
Link http://lehigh.designsafe-ci.org/ now opens in new tab
Link http://mechs.designsafe-ci.org/ now opens in new tab
Link http://oregonstate.designsafe-ci.org/ now opens in new tab
Link http://rapid.designsafe-ci.org/ now opens in new tab
Link http://simcenter.designsafe-ci.org/ now opens in new tab
Link http://ucdavis.designsafe-ci.org/ now opens in new tab
Link http://ucsd.designsafe-ci.org/ now opens in new tab
Link http://ufl.designsafe-ci.org/ now opens in new tab
Link http://utexas.designsafe-ci.org/ now opens in new tab
Path "/rw/simcenter-research-tools/" matches "/rw/simcenter-research-tools/"
Link https://www.designsafe-ci.org/rw/simcenter-research-tools/ now opens in new tab
Path "/learning-center/simcenter-learning-tools/" matches "/learning-center/simcenter-learning-tools/"
Link https://www.designsafe-ci.org/learning-center/simcenter-learning-tools/ now opens in new tab
Path "/facilities/simcenter/" matches "/facilities/simcenter/"
Link https://www.designsafe-ci.org/facilities/simcenter/ now opens in new tab
Path "/facilities/rapid-facility/" matches "/facilities/rapid-facility/"
Link https://www.designsafe-ci.org/facilities/rapid-facility/ now opens in new tab
Path "/community/mechs/" matches "/community/mechs/"
Link https://www.designsafe-ci.org/community/mechs/ now opens in new tab
Link http://designsafe-ci.org/ now has "aria-describedby"
Link http://fiu.designsafe-ci.org/ now has "aria-describedby"
Link http://lehigh.designsafe-ci.org/ now has "aria-describedby"
Link http://mechs.designsafe-ci.org/ now has "aria-describedby"
Link http://oregonstate.designsafe-ci.org/ now has "aria-describedby"
Link http://rapid.designsafe-ci.org/ now has "aria-describedby"
Link http://simcenter.designsafe-ci.org/ now has "aria-describedby"
Link http://ucdavis.designsafe-ci.org/ now has "aria-describedby"
Link http://ucsd.designsafe-ci.org/ now has "aria-describedby"
Link http://ufl.designsafe-ci.org/ now has "aria-describedby"
Link http://utexas.designsafe-ci.org/ now has "aria-describedby"
Link https://www.nsf.gov/ now has "aria-describedby"
Link https://www.facebook.com/NaturalHazardsEngineeringResearchInfrastructure now has "aria-describedby"
Link https://twitter.com/NHERIDesignSafe now has "aria-describedby"
Link https://www.linkedin.com/company/nheri-designsafe/ now has "aria-describedby"