### PR TITLE
feat: styles v2.9.0 → s-image-grid → lightgallery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^2.8.0",
+        "@tacc/core-styles": "^2.9.0",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.8.0.tgz",
-      "integrity": "sha512-UN+zxCDljjloOhRTujLpQK4RhGaCY9KmOBC3ws7/hypoH6mr/vpRTFqynz127GhtQfUJOaSISlhFBk79gEAeWg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.9.0.tgz",
+      "integrity": "sha512-lExRZWuOfTFevjwBGvbrQQpIVPiMyRiL5m98ahCDyeRUzilVRw6kKDiYV8546jJ2xrpHA6vMPW2vgxLn0cFLxQ==",
       "dev": true,
       "bin": {
         "core-styles": "src/cli.js"
@@ -9500,9 +9500,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.8.0.tgz",
-      "integrity": "sha512-UN+zxCDljjloOhRTujLpQK4RhGaCY9KmOBC3ws7/hypoH6mr/vpRTFqynz127GhtQfUJOaSISlhFBk79gEAeWg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.9.0.tgz",
+      "integrity": "sha512-lExRZWuOfTFevjwBGvbrQQpIVPiMyRiL5m98ahCDyeRUzilVRw6kKDiYV8546jJ2xrpHA6vMPW2vgxLn0cFLxQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^2.8.0",
+    "@tacc/core-styles": "^2.9.0",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -275,7 +275,7 @@ TACC_BLOG_SHOW_ABSTRACT_TAG = 'sample_value_e_g__redirect__'
 
 # Only use integer numbers (not "v1", not "0.11.0"),
 # so templates can load based on simple comparisons
-TACC_CORE_STYLES_VERSION = 0
+TACC_CORE_STYLES_VERSION = 2
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/lightgallery.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/lightgallery.css
@@ -1,0 +1,6 @@
+/* To style lightGallery (https://www.lightgalleryjs.com/) */
+@import url("@tacc/core-styles/src/lib/_imports/trumps/s-image-grid.css");
+
+.lightgallery {
+  @extend .s-image-grid;
+}

--- a/taccsite_cms/static/site_cms/css/src/core-cms.css
+++ b/taccsite_cms/static/site_cms/css/src/core-cms.css
@@ -13,5 +13,6 @@
 @import url("./_imports/components/django-cms-icon.css");
 @import url("./_imports/components/django.cms.picture.css");
 @import url("./_imports/components/django-cms-video.css");
+@import url("./_imports/components/lightgallery.css");
 
 @import url("./_imports/trumps/s-drop-cap.css");


### PR DESCRIPTION
## Overview

Style an image grid.

## Related

- styles #654
- requires https://github.com/TACC/Core-Styles/pull/169

## Changes

- **changes** `package.json` to load core-styles to v2.9.0
- **adds** and loads `…/components/lightgallery.css`

## Testing

1. Using CMS, create a gallery with container different size images wrapped in links.
2. Set container class to `lightgallery`.
3. Verify styles **now** match https://github.com/TACC/Core-Styles/pull/169.
4. Set container class to `s-image-grid`.
5. Verify styles **still** match https://github.com/TACC/Core-Styles/pull/169.

## UI

| `lightgallery` | `s-image-grid` | no class |
| - | - | - |
| ![s-image-grid](https://github.com/TACC/Core-CMS/assets/62723358/84636391-68f4-4ff2-b700-a8442e212632) | ![lightgallery](https://github.com/TACC/Core-CMS/assets/62723358/d52d68be-1675-44e5-bad4-e30cadcead88) | ![none](https://github.com/TACC/Core-CMS/assets/62723358/4846611b-67a2-4827-9afa-89bbf3786aaa) |