### PR TITLE
feat: s-image-grid → lightgallery

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/lightgallery.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/lightgallery.css
@@ -1,0 +1,6 @@
+/* To style lightGallery (https://www.lightgalleryjs.com/) */
+@import url("@tacc/core-styles/src/lib/_imports/trumps/s-image-grid.css");
+
+.lightgallery {
+  @extend .s-image-grid;
+}

--- a/taccsite_cms/static/site_cms/css/src/core-cms.css
+++ b/taccsite_cms/static/site_cms/css/src/core-cms.css
@@ -10,5 +10,6 @@
 @import url("./_imports/components/django-cms-forms.css");
 @import url("./_imports/components/django.cms.picture.css");
 @import url("./_imports/components/django-cms-video.css");
+@import url("./_imports/components/lightgallery.css");
 
 @import url("./_imports/trumps/s-drop-cap.css");


### PR DESCRIPTION
## Overview

Style an image grid.

## Related

- styles #654
- mimics #655
- requires https://github.com/TACC/Core-Styles/pull/169

## Changes

- **adds** and loads `…/components/lightgallery.css`

## Testing

1. Using CMS, create a gallery with container different size images wrapped in links.
2. Set container class to `lightgallery`.
3. Verify styles **now** match https://github.com/TACC/Core-Styles/pull/169.
4. Set container class to `s-image-grid`.
5. Verify styles **still** match https://github.com/TACC/Core-Styles/pull/169.

## UI

| `lightgallery` | `s-image-grid` | no class |
| - | - | - |
| ![s-image-grid](https://github.com/TACC/Core-CMS/assets/62723358/84636391-68f4-4ff2-b700-a8442e212632) | ![lightgallery](https://github.com/TACC/Core-CMS/assets/62723358/d52d68be-1675-44e5-bad4-e30cadcead88) | ![none](https://github.com/TACC/Core-CMS/assets/62723358/4846611b-67a2-4827-9afa-89bbf3786aaa) |