### PR TITLE
fix(css): anchor around image not supporting margin

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -2,6 +2,13 @@
 /* SEE: https://github.com/django-cms/djangocms-picture/blob/2.3.0/djangocms_picture/models.py#L24-L34 */
 @import url("@tacc/core-styles/src/lib/_imports/components/align.css");
 
+/* Allow anchor tag to wrap like a block but still behave inline */
+/* FAQ: TACC/Core-CMS causes this tag-class combination, so it must manage it */
+/* FAQ: TACC/Core-CMS moves (side effect) Picture classes to <figure> or <a> */
+a.img-fluid {
+  display: inline-block;
+}
+
 /* Try to auto-clear image floats */
 /* WARNING: The commented solution clears float BUT also negates float */
 /*


### PR DESCRIPTION
## Overview

Make anchor that wraps image have excepted block behavior without losing inherit inline behavior.

## Related

- supports https://github.com/TACC/Core-Styles/pull/5

## Changes

- **added** rule to use `inline-block` layout for `a.img-fluid`

## Testing / UI

See result of the style applied to https://www.tacc.utexas.edu/research/scivis-gallery/ via [TACC/tup-ui `visualization-gallery-styles`](https://github.com/TACC/tup-ui/blob/23dbed3/apps/tup-cms/src/taccsite_cms/templates/snippets/visualization-gallery-styles.html). If style is removed (via editing live markup), markup has no effect.