### PR TITLE
feat: core-styles v2.9.1 to v2.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^2.9.1",
+        "@tacc/core-styles": "^2.11.0",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.9.1.tgz",
-      "integrity": "sha512-sqXIWeF2k4Wf/qhJILZuy5HMUEI9lq9Aw2+pXwyVvIl6TvmZNGEMR+X2DZ1ZdSd+OTiARRxsVdSI+wgHFDBcCw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.11.0.tgz",
+      "integrity": "sha512-k7J2qpZSd8B9JD+1K7JzVvuOU8Q3guozI3oAaS9aLQYrJWzFVjhU1GTnjYHUcebPe0AAJTLlzvJy0x9+wW4J9A==",
       "dev": true,
       "bin": {
         "core-styles": "src/cli.js"
@@ -9500,9 +9500,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.9.1.tgz",
-      "integrity": "sha512-sqXIWeF2k4Wf/qhJILZuy5HMUEI9lq9Aw2+pXwyVvIl6TvmZNGEMR+X2DZ1ZdSd+OTiARRxsVdSI+wgHFDBcCw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.11.0.tgz",
+      "integrity": "sha512-k7J2qpZSd8B9JD+1K7JzVvuOU8Q3guozI3oAaS9aLQYrJWzFVjhU1GTnjYHUcebPe0AAJTLlzvJy0x9+wW4J9A==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^2.9.1",
+    "@tacc/core-styles": "^2.11.0",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",


### PR DESCRIPTION
## Overview / Changes

Bump from https://github.com/TACC/Core-Styles/releases/v2.9.1 to https://github.com/TACC/Core-Styles/releases/v2.11.0.

## Related

- supports https://github.com/TACC/tup-ui/pull/218

## Testing / UI

None.