### PR TITLE
fix: v2.0.0 can not build & deploy tapis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ENV PYTHONUNBUFFERED 1
 
+FROM python-base as production
+
 RUN apt-get update && apt-get install -y \
     build-essential python3-dev \
     libldap2-dev libsasl2-dev ldap-utils tox \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 DOCKERHUB_REPO := taccwma/$(shell cat ./docker_repo.var)
+PROJECT_NAME := $(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
+BUILD_ID := $(shell git describe --always)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
 DOCKER_IMAGE_LOCAL := $(DOCKERHUB_REPO):local
@@ -8,6 +10,10 @@ DOCKER_IMAGE_LOCAL := $(DOCKERHUB_REPO):local
 build:
 	docker build -t $(DOCKER_IMAGE) .
 	docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE_LATEST)
+
+.PHONY: build-full
+build-full:
+	docker build -t $(DOCKER_IMAGE) --target production --build-arg PROJECT_NAME=$(PROJECT_NAME) --build-arg BUILD_ID=$(BUILD_ID) -f ./Dockerfile .
 
 .PHONY: publish
 publish:


### PR DESCRIPTION
## Overview

Allow Jenkins to build and deploy a project on v2.0.0.

## Related

- [WI-6](https://jira.tacc.utexas.edu/browse/WI-6)
- requires https://github.com/TACC/Core-CMS-Resources/pull/184
- requires https://github.com/TACC/Core-CMS-Resources/pull/185

## Changes

- **added** `build-full` command to `Makefile`
- **added** `production` target/stag to `Dockerfile`
- **added** CMS v3 settings support to `settings.py`
- **changed** `taccsite_custom/`:
    - **added** tapis project placeholder css

## Testing

1. ✅ [Build `core-cms` on Jenkins.](https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/1180)
2. ✅ [Build `tapis-project-org` on Jenkins.](https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/1181)
3. ❌ [Deploy `tapis-project-org`](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/1181) on https://prod.tapisproject.tacc.utexas.edu/.

## UI

N/A
