### PR TITLE
fix(dev/tup-cms): blog/news markup (bugs found on ecep)

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -15,9 +15,25 @@
 {# /TACC #}
 <article id="post-{{ post.slug }}" class="post-item post-detail">
     <header>
+        {# TACC (use greater heading level): #}
+        {# TACC (do not use large header until core-styles.cms.css): #}
+        {% if settings.TACC_CORE_STYLES_VERSION >= 1 %}
         <h1>{% render_model post "title" %}</h1>
+        {% else %}
+        <h2>{% render_model post "title" %}</h2>
+        {% endif %}
+        {# /TACC #}
+        {# /TACC #}
         {% if post.subtitle %}
-        <h2>{% render_model post "subtitle" %}</h2>
+            {# TACC (use greater heading level): #}
+            {# TACC (do not use large header until core-styles.cms.css): #}
+            {% if settings.TACC_CORE_STYLES_VERSION >= 1 %}
+            <h2>{% render_model post "subtitle" %}</h2>
+            {% else %}
+            <h3>{% render_model post "subtitle" %}</h3>
+            {% endif %}
+            {# /TACC #}
+            {# /TACC #}
         {% endif %}
         {% block blog_meta %}
             {% include "djangocms_blog/includes/blog_meta.html" %}

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -13,6 +13,7 @@
 <section class="blog-list">
     {% block blog_title %}
     <header>
+        {# TACC (use greater heading level): #}
         {# TACC (do not use large header until core-styles.cms.css): #}
         {% if settings.TACC_CORE_STYLES_VERSION >= 1 %}
         <h1>
@@ -20,17 +21,20 @@
         <h2>
         {% endif %}
         {# /TACC #}
+        {# /TACC #}
         {% if author %}{% trans "Articles by" %} {{ author.get_full_name }}
         {% elif archive_date %}{% trans "Archive" %} &ndash; {% if month %}{{ archive_date|date:'F' }} {% endif %}{{ year }}
         {% elif tagged_entries %}{% trans "Tag" %} &ndash; {{ tagged_entries|capfirst }}
         {% elif category %}{% trans "Category" %} &ndash; {{ category }}
         {% else %}{% trans "News" %}{% endif %}
+        {# TACC (use greater heading level): #}
         {# TACC (do not use large header until core-styles.cms.css): #}
         {% if settings.TACC_CORE_STYLES_VERSION >= 1 %}
         </h1>
         {% else %}
         </h2>
         {% endif %}
+        {# /TACC #}
         {# /TACC #}
     </header>
     {% endblock %}

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -13,13 +13,25 @@
 <section class="blog-list">
     {% block blog_title %}
     <header>
+        {# TACC (do not use large header until core-styles.cms.css): #}
+        {% if settings.TACC_CORE_STYLES_VERSION >= 1 %}
         <h1>
+        {% else %}
+        <h2>
+        {% endif %}
+        {# /TACC #}
         {% if author %}{% trans "Articles by" %} {{ author.get_full_name }}
         {% elif archive_date %}{% trans "Archive" %} &ndash; {% if month %}{{ archive_date|date:'F' }} {% endif %}{{ year }}
         {% elif tagged_entries %}{% trans "Tag" %} &ndash; {{ tagged_entries|capfirst }}
         {% elif category %}{% trans "Category" %} &ndash; {{ category }}
         {% else %}{% trans "News" %}{% endif %}
+        {# TACC (do not use large header until core-styles.cms.css): #}
+        {% if settings.TACC_CORE_STYLES_VERSION >= 1 %}
         </h1>
+        {% else %}
+        </h2>
+        {% endif %}
+        {# /TACC #}
     </header>
     {% endblock %}
     {% for post in post_list %}


### PR DESCRIPTION
## Overview

Fix UI bugs in Blog/News.

## Related

- fixes #581
    - specifically [v3.12.0-alpha.1: Django 3; Redesign Blog/News + Related Patterns](https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.1)

## Changes

- **changes** blog templates to only use different `<hN>` if core styles v2+ is loaded

## Testing

0. Have a site that has `TACC_CORE_STYLES_VERSION` not set (or set below 2).
1. Verify [a news article](https://pprd.ecep.tacc.utexas.edu/news/2023/05/18/highlights-2023-ecep-summit-oakland-california/) title uses `<h2>` on ECEP site.
2. Verify [the news listing](https://pprd.ecep.tacc.utexas.edu/news/) "News" title uses `<h2>` on ECEP site.

## UI

https://pprd.ecep.tacc.utexas.edu/news/2023/05/18/highlights-2023-ecep-summit-oakland-california/
vs.
https://ecepalliance.org/news/2023/05/18/highlights-2023-ecep-summit-oakland-california/

https://pprd.ecep.tacc.utexas.edu/news/
vs.
https://ecepalliance.org/news/