### PR TITLE
feat: v3.12.0-alpha.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
-## [3.12.0] - 2023-07-18: Django 3, Redesign Blog, Fix Accent Hue, Gallery Plugin
-
-### Included
-
-- [3.12.0-alpha.9]: Remove Migrated Projects from Submodule
-- [3.12.0-alpha.8]: Re-Sync dev/tup-cms, main, taccsite_custom
-- [3.12.0-alpha.7]: Core-Styles v2.9.1 to v2.11.0
-- [3.12.0-alpha.6]: Display a.img-fluid as Inline Block
-- [3.12.0-alpha.5]: Remove demdata-cms, Merge v3.11.3
-- [3.12.0-alpha.4]: Gallery Updates, Style Fixes, taccsite_custom Update
-- [3.12.0-alpha.3]: Install Image Gallery Plugin
-- [3.12.0-alpha.2]: Fix v3.10 Accent Color From Purple Back to Blue
-- [3.12.0-alpha.1]: Django 3; Redesign Blog/News + Related Patterns
+## [3.12.0-alpha.10] - 2023-07-18: Conditional Blog/News Markup, Better README
 
 ### Fixed
 
@@ -774,8 +762,8 @@ formerly known as v2.5.2 published on Thu Jul 1 16:10:38 2021 -0500
 
 v2.0.0 Production release as of Mar 31, 2021.
 
-[unreleased]: https://github.com/TACC/Core-CMS/compare/v3.12.0...main
-[3.12.0]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0
+[unreleased]: https://github.com/TACC/Core-CMS/compare/v3.12.0-alpha.10...main
+[3.12.0-alpha.10]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.10
 [3.12.0-alpha.9]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.9
 [3.12.0-alpha.8]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.8
 [3.12.0-alpha.7]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,132 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+## [3.12.0] - 2023-07-18: Django 3, Redesign Blog, Fix Accent Hue, Gallery Plugin
+
+### Included
+
+- [3.12.0-alpha.9]: Remove Migrated Projects from Submodule
+- [3.12.0-alpha.8]: Re-Sync dev/tup-cms, main, taccsite_custom
+- [3.12.0-alpha.7]: Core-Styles v2.9.1 to v2.11.0
+- [3.12.0-alpha.6]: Display a.img-fluid as Inline Block
+- [3.12.0-alpha.5]: Remove demdata-cms, Merge v3.11.3
+- [3.12.0-alpha.4]: Gallery Updates, Style Fixes, taccsite_custom Update
+- [3.12.0-alpha.3]: Install Image Gallery Plugin
+- [3.12.0-alpha.2]: Fix v3.10 Accent Color From Purple Back to Blue
+- [3.12.0-alpha.1]: Django 3; Redesign Blog/News + Related Patterns
+
+### Fixed
+
+- fix(dev/tup-cms): blog/news markup (bugs found on ecep) #674
+
+### Changed
+
+- docs: simpler readme + add small docs (#665)
+
+## [3.12.0-alpha.9] - 2023-07-13: Remove Migrated Projects from Submodule
+
+## Removed
+
+- chore(taccsite_custom): remove migrated projects (afb6f21)
+
+## [3.12.0-alpha.8] - 2023-07-13: Re-Sync dev/tup-cms, main, taccsite_custom
+
+### Fixed
+
+- re-sync `dev/tup-cms` and `main` and their submodule pointers
+
+## [3.12.0-alpha.7] - 2023-07-12: Core-Styles v2.9.1 to v2.11.0
+
+### Added
+
+- feat: core-styles v2.9.1 to v2.11.0 (#671)
+
+## [3.12.0-alpha.6] - 2023-07-12: Display a.img-fluid as Inline Block
+
+### Fixed
+
+- fix(css): anchor around image not supporting margin (#670) (7b51038)
+
+### Removed
+
+- chore(taccsite_custom): delete acpd-cms dir (c615079)
+- chore(taccsite_custom): delete tup-cms dir (fa3c101)
+- chore(taccsite_custom): delete demdata (#666)
+
+## [3.12.0-alpha.5] - 2023-06-22: Remove demdata-cms, Merge v3.11.3
+
+### Added
+
+- feat: v3.11.3 (#664)
+
+### Changed
+
+- feat: add djangocms_tacc_image_gallery (#654)[^1]
+- feat(taccsite_custom): demdata-cms, css from tup (#606)
+
+---
+
+[^1]: Already available since https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.3 and https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.4 but now it comes officially from the trunk.
+
+## [3.12.0-alpha.4] - 2023-06-16: Gallery Updates, Style Fixes, taccsite_custom Update
+
+### Added
+
+- feat: s-image-grid → lightgallery (#663)
+
+### Changed
+
+- feat(taccsite_custom): explicit source css imports (7f25379)
+
+### Fixed
+
+- fix: update [image gallery] plugin to v0.1.3 (1358d36)
+- fix(core-styles): v2.9.1 (4894e4f)
+- fix(taccsite_custom): brainmap logo missing text (7cda385)
+
+## [3.12.0-alpha.3] - 2023-06-15: Install Image Gallery Plugin
+
+### Added
+
+- feat: add djangocms_tacc_image_gallery (un-styled) (#654)
+
+## [3.12.0-alpha.2] - 2023-06-15: Fix v3.10 Accent Color From Purple Back to Blue
+
+### Fixed
+
+- feat(css): accent color from purple to blue (#660)
+- fix(css): bump text editor css core-styles to v2.9 (#661)
+
+## [3.12.0-alpha.1] - 2023-06-14: Django 3; Redesign Blog/News + Related Patterns
+
+### Added
+
+- feat: styles v2.9.0 → s-image-grid → lightgallery (#655)
+- feat(css): figure, caption, etc styles; whole site (#624)
+- feat(css): migrate tup-cms styles to core-cms (part 2) (#620)
+- feat(css): migrate tup-cms styles to core-cms (part 1) (#616)
+- Task/tup 395 cmd news styles from tup cms (#612)
+- feat(core-styles): change accent color from purple to blue (#617)
+- feat: tup-398, improve blog css & layout toggle (#613)
+- feat(djangocms_blog): simple article link & "to be published" (#599)
+- feat(blog): tup-395, styles (#587)
+- feat: auto-responsive video embed (#590)
+- Task/tup 395 cmd news layout switch (#589)
+- feat(core-styles): base, cms, docs, portal re-org (#586)
+
+### Changed
+
+- Update to Django 3.2 (for TUP CMS) (#626)
+- chore: load static not staticfiles (#629)
+- chore(core-styles): tup-cms table updates (#603)
+
+### Fixed
+
+- Bugfix/news tags all black (#622)
+- fix: add+use core-styles.wysiwyg.css not copied code (#618)
+- fix: portal nav not to touch cms menu if no search (#615)
+- fix(templates): djangcms_picture, alignment issues (#588)
+
 ## [3.11.4] - 2023-07-11: Fix v3.11.3 Bad Submodule Pointer (taccsite_custom)
 
 ### Fixed
@@ -648,7 +774,17 @@ formerly known as v2.5.2 published on Thu Jul 1 16:10:38 2021 -0500
 
 v2.0.0 Production release as of Mar 31, 2021.
 
-[unreleased]: https://github.com/TACC/Core-CMS/compare/v3.11.4...main
+[unreleased]: https://github.com/TACC/Core-CMS/compare/v3.12.0...main
+[3.12.0]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0
+[3.12.0-alpha.9]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.9
+[3.12.0-alpha.8]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.8
+[3.12.0-alpha.7]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.7
+[3.12.0-alpha.6]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.6
+[3.12.0-alpha.5]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.5
+[3.12.0-alpha.4]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.4
+[3.12.0-alpha.3]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.3
+[3.12.0-alpha.2]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.2
+[3.12.0-alpha.1]: https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.1
 [3.11.4]: https://github.com/TACC/Core-CMS/releases/tag/v3.11.4
 [3.11.3]: https://github.com/TACC/Core-CMS/releases/tag/v3.11.3
 [3.11.2]: https://github.com/TACC/Core-CMS/releases/tag/v3.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.12.0-alpha.10] - 2023-07-18: ⚠️ Conditional Blog/News Markup, Better README
 
 > **Warning**
-> Any https://github.com/TACC/Core-CMS-Resources projects serving this return 500.
-> No known solution yet.
+> All projects that have attempted to serve this version return a 500 error.
+> Problem uncertain. Solution unknown.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
-## [3.12.0-alpha.10] - 2023-07-18: Conditional Blog/News Markup, Better README
+## [3.12.0-alpha.10] - 2023-07-18: ⚠️ Conditional Blog/News Markup, Better README
+
+> **Warning**
+> Any https://github.com/TACC/Core-CMS-Resources projects serving this return 500.
+> No known solution yet.
 
 ### Fixed
 
@@ -129,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix(taccsite_custom): wrong pointer in v3.11.3 (#668)
 
-## [3.11.3] - 2023-06-16: CSS Import Paths, Brainmap Logo, Core-Styles v2.9.1
+## [3.11.3] - 2023-06-16: ⚠️ CSS Import Paths, Brainmap Logo, Core-Styles v2.9.1
 
 > **Warning**
 > This accidentally breaks all https://github.com/TACC/Core-CMS-Resources projects.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKERHUB_REPO := taccwma/$(shell cat ./docker_repo.var)
-PROJECT_NAME := $(shell cat ./docker_repo.var)
+PROJECT_NAME := $(shell cat ./project_name.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 BUILD_ID := $(shell git describe --always)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,8 +56,4 @@ Only appointed team members may release versions.
 <!-- Link Aliases -->
 
 [development site]: https://dev.cep.tacc.utexas.edu
-
-> **Note**
-> The accessible behind the TACC Network
-
 [production site]: https://prod.cep.tacc.utexas.edu

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tacc/core-cms",
-  "version": "3.11.4",
+  "version": "3.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tacc/core-cms",
-      "version": "3.11.4",
+      "version": "3.12.0",
       "license": "MIT",
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tacc/core-cms",
-  "version": "3.12.0",
+  "version": "3.12.0-alpha.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tacc/core-cms",
-      "version": "3.12.0",
+      "version": "3.12.0-alpha.10",
       "license": "MIT",
       "devDependencies": {
         "@frctl/fractal": "^1.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacc/core-cms",
-  "version": "3.11.4",
+  "version": "3.12.0",
   "license": "MIT",
   "author": "TACC ACI WMA <wma-portals@gmail.com>",
   "description": "The TACC ACI-WMA Core CMS codebase used by TACC Portals.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacc/core-cms",
-  "version": "3.12.0",
+  "version": "3.12.0-alpha.10",
   "license": "MIT",
   "author": "TACC ACI WMA <wma-portals@gmail.com>",
   "description": "The TACC ACI-WMA Core CMS codebase used by TACC Portals.",


### PR DESCRIPTION
## Overview

<del>Prepare v3.12.0 release.</del>

<ins>Prepare v3.12.0-alpha.10 pre-release.</ins>

## Notes

> **Warning**
> All projects that have attempted to serve this version return a 500 error.
> Problem uncertain. Solution unknown.

<details>

I had hoped this would be v3.12.0, because I thought v3.12.0-alpha.**?** deployed well on https://pprd.ecep.tacc.utexas.edu, but this branch does not deploy well now, and I can't confirm what commit had.

The following websites are _still_ **down** because of trying to deploy this CMS image:
- https://pprd.ecep.tacc.utexas.edu\
    <sup>(deployed via https://github.com/TACC/Core-CMS-Custom and https://github.com/TACC/Core-CMS-Resources)</sup>
    Revert of the deploy **still** serves 500.
- https://dev.fronteraweb.tacc.utexas.edu\
    <sup>(deployed via https://github.com/TACC/Core-CMS-Resources)</sup>
    Revert of the deploy **still** serves 500.

The following websites _had been_ **down** because of trying to deploy this CMS image:
 - https://pprd.a2cps.tacc.utexas.edu was down
    <sup>(deployed via https://github.com/TACC/Core-CMS-Custom)</sup>
    Revert of the deploy **fixed** the 500.

</details>