### PR TITLE
fix: v3.12.0-alpha.10 crash (ignore docs, add redirects)

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -462,7 +462,7 @@ def get_subdirs_as_module_names(path):
     for entry in os.scandir(path):
         is_app = (
             entry.path.find('_readme') == -1 and
-            entry.path.find('demdata-') == -1
+            entry.path.find('docs') == -1
         )
         if entry.is_dir() and is_app:
             # FAQ: There are different root paths to tweak:

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -461,8 +461,9 @@ def get_subdirs_as_module_names(path):
     module_names = []
     for entry in os.scandir(path):
         is_app = (
-            entry.path.find('_readme') == -1 and
-            entry.path.find('docs') == -1
+            entry.path.find('_readme') == -1 and # explains common project dirs
+            entry.path.find('-cms') == -1 and    # deprecated project templates
+            entry.path.find('docs') == -1        # documentation beyond README
         )
         if entry.is_dir() and is_app:
             # FAQ: There are different root paths to tweak:


### PR DESCRIPTION
## Overview / Related

Fix server crash since https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.10.

## Related

- fixes #675
- requires https://github.com/TACC/Core-CMS-Resources/pull/186

## Changes

- **changed** taccsite_custom directory scan to ignore `docs/`
- **added** `frontera-cms` template redirects

## Testing

1. Build CMS image.
2. Deploy CMS image.
3. Access website.
4. Check whether site loads or crashes.

## UI

Just visit website ツ.

- [x] https://pprd.ecep.tacc.utexas.edu/
- [x] https://dev.fronteraweb.tacc.utexas.edu/
- [x] https://dev.a2cps.tacc.utexas.edu/

## Notes

The fixes alone seem **not** adequate for a CMS at v3.12 **and** on https://github.com/TACC/Core-CMS-Custom. Example: 
- https://github.com/TACC/Core-CMS-Custom/pull/175 — 2023-07-25