### PR TITLE
docs: cms admin uses ad hoc styles, so can tacc

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -55,7 +55,7 @@
   {% include 'assets_custom.html' %}
   {% endblock assets_custom %}
 
-  <!-- CMS Admin Styles. -->
+  <!-- Ad Hoc Styles. -->
   {% render_block "css" %}
 </head>
 
@@ -110,7 +110,7 @@
   {% include 'assets_custom_delayed.html' %}
   {% endblock assets_custom_delayed %}
 
-  <!-- CMS Admin Scripts. -->
+  <!-- Ad Hoc Scripts. -->
   {% render_block "js" %}
 </body>
 


### PR DESCRIPTION
## Overview

Rename "CMS Admin Styles/Scripts" to "Ad Hoc Styles/Scripts", so developers know they can also use `addtoblock`.

## Related

- used in https://github.com/TACC/tup-ui/pull/218/commits/b160855
    <sup>(to fix https://github.com/TACC/tup-ui/pull/218)></sup>

## Changes

- **changed** a comment in a template

## Testing

N/A

## UI

N/A

## Notes

What I once naively thought were "CMS Admin Styles/Scripts" are not limited to that. The `sekizai_tags` offers `addtoblock` tag (and `render_block` tag). So, TACC can add ad hoc styles like Django CMS Admin does.