### PR TITLE
docs: paper trail for v3-10_v3-11/ (off of main)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_migrations/v3-10_v3-11/README.md
+++ b/taccsite_cms/static/site_cms/css/src/_migrations/v3-10_v3-11/README.md
@@ -1,0 +1,12 @@
+# TACC CMS - Stylesheets - Migrations - v3.10 to v3.11
+
+This is a migration:
+
+- from v3.10 with **no** `TACC_CORE_STYLES_VERSION`
+- to v3.11 with `TACC_CORE_STYLES_VERSION = `**`2`**
+
+The files are imported from `site_cms/css/build/`.[^1]
+
+Thus, a search for `v3-10_v3-11` will return only this file.
+
+[^1]: That is the only location where CMS can access them. They appear there after `npm run build:css`.


### PR DESCRIPTION
## Overview

Add paper trail for users searching for `v3-10_v3-11` usage.

## Related

- mirrors #681

## Changes

- **added** `…/v3-10_v3-11/README.md`

## Testing & UI

See [readme file preview on this branch](https://github.com/TACC/Core-CMS/blob/docs/paper-trail-for-v3-10-migration/taccsite_cms/static/site_cms/css/src/_migrations/v3-10_v3-11/README.md).