### PR TITLE
fix: render/style responsive video/audio player (off of main)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_migrations/v3-10_v3-11/site.v3-11-plus.css
+++ b/taccsite_cms/static/site_cms/css/src/_migrations/v3-10_v3-11/site.v3-11-plus.css
@@ -1,0 +1,8 @@
+/* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
+
+/* WARNING: Only import new stylesheets that will not break old site designs */
+
+/* Organize via ITCSS */
+/* https://confluence.tacc.utexas.edu/x/IAA9Cw */
+
+@import url("../../_imports/components/django-cms-video.css");

--- a/taccsite_cms/templates/assets_site.html
+++ b/taccsite_cms/templates/assets_site.html
@@ -15,10 +15,10 @@ FAQ: IF a script or style is better cached with markup, THEN:
 
 <link id="css-bootstrap" rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 
-{# CAVEAT: Requires `npm run build` step before running the Django project. #}
 <link id="css-site" rel="stylesheet" href="{% static 'site_cms/css/build/site.css' %}">
 <link id="css-site-header" rel="stylesheet" href="{% static 'site_cms/css/build/site.header.css' %}">
-
+{# CAVEAT: Requires `npm run build` step before running the Django project. #}
+<link id="css-site-v3-11+" rel="stylesheet" href="{% static 'site_cms/css/build/site.v3-11-plus.css' %}">
 
 
 {# Impacts the clients "CEPv2" Portal & Frontera Docs #}


### PR DESCRIPTION
## Overview

Support responsive embed of a podcast (or any audio or video).

## Related

- Texascale 2023
- mimics #684

## Changes

- **added** `site.v3-11-plus.css`
    <sup>to load existing `…/django-cms-video.css`</sup>
- **added** link to `site.v3-11-plus.css`
    <sup>in `taccsite_cms/templates/assets_site.html`</sup>

## Testing

1. Create/Open a test page.
    <sup>If deployed to Texascale, you may use https://prod.texascale.tacc.utexas.edu/testing/wes-test/?edit.</sup>
2. Add a "Video player" plugin instance.
	| Field | Value |
	| - | - |
	| TEMPLATE: | Responsive Automatic |
	| LABEL: | Podcast |
	| EMBED LINK: | `https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1242255460` |
3. Save plugin instance.
4. Verify podcast:
	- renders
	- stretches to fit available horizontal space
	- is not cut off
	- is functional

## UI

Relying on #684.
