### PR TITLE
fix: do not serve ui demo unless it exists

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -298,7 +298,7 @@ STATICFILES_DIRS = (
 
 # If the UI Pattern Library exists, serve it at .../ui
 staticfiles_dir_ui = os.path.join(BASE_DIR, 'taccsite_ui', 'dist')
-if os.path.exists(ui_dist_path):
+if os.path.exists(staticfiles_dir_ui):
     STATICFILES_DIRS.append(('ui', ui_dist_path))
 
 # User Uploaded Files Location.

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -294,9 +294,12 @@ STATICFILES_DIRS = (
     # os.path.join(BASE_DIR, 'taccsite_cms', 'en', 'static'),
 ) + tuple(glob(
     os.path.join(BASE_DIR, 'taccsite_custom', '*', 'static')
-)) + (
-    ('ui', os.path.join(BASE_DIR, 'taccsite_ui', 'dist')),
-)
+))
+
+# If the UI Pattern Library exists, serve it at .../ui
+staticfiles_dir_ui = os.path.join(BASE_DIR, 'taccsite_ui', 'dist')
+if os.path.exists(ui_dist_path):
+    STATICFILES_DIRS.append(('ui', ui_dist_path))
 
 # User Uploaded Files Location.
 MEDIA_URL = '/media/'


### PR DESCRIPTION
## Overview

Do not serve UI Pattern Library unless its directory exists.

<sup>Because https://github.com/TACC/Core-CMS-Custom apps typically do not sync UI demo.[^1]</sup>

## Status

Core-CMS Build: https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/1212
Core-CMS-Custom Build: …
Deploy: …

## Related

- fixes https://github.com/TACC/Core-CMS-Custom/pull/175
- fixes https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.11 for https://github.com/TACC/Core-CMS-Custom

## Changes

- **changes** `settings.py` to not serve `/static/ui` unless `taccsite_ui` exists

## Testing & UI

https://github.com/TACC/Core-CMS-Custom/pull/175

[^1]: https://github.com/TACC/Core-CMS-Custom will probably not serve UI demo until that demo can auto-import their custom stylesheet.