### PR TITLE
fix: serve ui demo if it exists

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -299,7 +299,7 @@ STATICFILES_DIRS = (
 # If the UI Pattern Library exists, serve it at .../ui
 staticfiles_dir_ui = os.path.join(BASE_DIR, 'taccsite_ui', 'dist')
 if os.path.exists(staticfiles_dir_ui):
-    STATICFILES_DIRS.append(('ui', staticfiles_dir_ui))
+    STATICFILES_DIRS += (('ui', staticfiles_dir_ui),)
 
 # User Uploaded Files Location.
 MEDIA_URL = '/media/'

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -299,7 +299,7 @@ STATICFILES_DIRS = (
 # If the UI Pattern Library exists, serve it at .../ui
 staticfiles_dir_ui = os.path.join(BASE_DIR, 'taccsite_ui', 'dist')
 if os.path.exists(staticfiles_dir_ui):
-    STATICFILES_DIRS.append(('ui', ui_dist_path))
+    STATICFILES_DIRS.append(('ui', staticfiles_dir_ui))
 
 # User Uploaded Files Location.
 MEDIA_URL = '/media/'


### PR DESCRIPTION
## Overview

Serve the UI patternd emo if it exists.

## Related

- fixes bug caused by #688

## Changes

- **fixed** outdated variable name
- **fixed** bad assignment operator
- **fixed** missing comma

## Testing

1. Load.
2. Collect static.
3. Visit http://0.0.0.0:8000/static/ui/index.html.

## UI

<img width="820" alt="fixed ui demo" src="https://github.com/TACC/Core-CMS/assets/62723358/9a53a473-a40d-4429-bd2f-0bdd1995ae2d">