### PR TITLE
hotfix: set SESSION_COOKIE_SECURE = True

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -41,6 +41,9 @@ CEP_AUTH_VERIFICATION_ENDPOINT = 'localhost'  # 'https://0.0.0.0:8000'
 # https://docs.djangoproject.com/en/3.0/ref/clickjacking/#how-to-use-it
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
+# whether the session cookie should be secure (https:// only)
+SESSION_COOKIE_SECURE = True
+
 ########################
 # DATABASE SETTINGS
 ########################


### PR DESCRIPTION
## Overview

Sets `SESSION_COOKIE_SECURE = True` to resolve a flag set by an ISO security audit.

## Testing

1. In the chrome devtools, go to Application -> Cookies -> and ensure that the "Secure" column for the "sessionid" cookie is checked. See screenshot below

## UI
<img width="91" alt="Screenshot 2023-08-22 at 9 37 19 AM" src="https://github.com/TACC/Core-CMS/assets/20326896/4dafdcdc-963d-4d44-9434-7bbe830e3ff6">
