### PR TITLE
hotfix: set SESSION_COOKIE_SECURE = True (off of v3.9.5) 

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -38,6 +38,9 @@ ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']   # In development.
 # Default portal authorization verification endpoint.
 CEP_AUTH_VERIFICATION_ENDPOINT = 'localhost'  # 'https://0.0.0.0:8000'
 
+# whether the session cookie should be secure (https:// only)
+SESSION_COOKIE_SECURE = True
+
 ########################
 # DATABASE SETTINGS
 ########################


### PR DESCRIPTION
## Overview

Sets `SESSION_COOKIE_SECURE = True` to resolve a flag set by an ISO security audit.

## Related

- mimics #695

## Testing

1. In the chrome devtools, go to Application -> Cookies -> and ensure that the "Secure" column for the "sessionid" cookie is checked. See screenshot below

## UI
<img width="91" alt="Screenshot 2023-08-22 at 9 37 19 AM" src="https://github.com/TACC/Core-CMS/assets/20326896/4dafdcdc-963d-4d44-9434-7bbe830e3ff6">
