### PR TITLE
feat: social media quick share links

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -274,6 +274,12 @@ TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'sample_value_e_g__mutlimedia__'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'sample_value_e_g__redirect__'
 
 ########################
+# TACC: SOCIAL MEDIA
+########################
+
+TACC_SOCIAL_SHARE_PLATFORMS = ['facebook', 'linkedin']
+
+########################
 # TACC: CORE STYLES
 ########################
 
@@ -682,5 +688,6 @@ SETTINGS_EXPORT = [
     'TACC_CORE_STYLES_VERSION',
     'TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY',
     'TACC_BLOG_SHOW_ABSTRACT_TAG',
+    'TACC_SOCIAL_SHARE_PLATFORMS',
     'SEARCH_QUERY_PARAM_NAME',
 ]

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -277,7 +277,9 @@ TACC_BLOG_SHOW_ABSTRACT_TAG = 'sample_value_e_g__redirect__'
 # TACC: SOCIAL MEDIA
 ########################
 
-TACC_SOCIAL_SHARE_PLATFORMS = ['facebook', 'linkedin']
+# TODO: Enable ONLY after TUP-590
+TACC_SOCIAL_SHARE_PLATFORMS = []
+# TACC_SOCIAL_SHARE_PLATFORMS = ['facebook', 'linkedin']
 
 ########################
 # TACC: CORE STYLES

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -145,13 +145,12 @@ Styleguide Components.DjangoCMS.Blog.App
 /* Social Media */
 
 .app-blog .logos--social {
-    display: grid;
-    gap: var(--gap, 0);
-    grid-auto-flow: column;
-    justify-content: center;
+  justify-content: end;
+  display: flex;
+  gap: 0.25em;
 }
 .app-blog .logos--social svg {
-    height: 2.5rem;
+  height: var(--global-font-size--x-large);
 }
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -78,6 +78,7 @@ Styleguide Components.DjangoCMS.Blog.App
 .app-blog .attrs      { grid-area: attr }
 .app-blog .categories { grid-area: cats }
 .app-blog .tags       { grid-area: tags }
+.app-blog .links      { grid-area: link }
 
 .app-blog ul.post-detail {
   list-style: none;
@@ -139,6 +140,19 @@ Styleguide Components.DjangoCMS.Blog.App
   background-color: var(--global-color-primary--light);
 }
 
+
+
+/* Social Media */
+
+.app-blog .logos--social {
+    display: grid;
+    gap: var(--gap, 0);
+    grid-auto-flow: column;
+    justify-content: center;
+}
+.app-blog .logos--social svg {
+    height: 2.5rem;
+}
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -36,7 +36,8 @@ Styleguide Components.DjangoCMS.Blog.App.Page
     'subh'
     'cats'
     'tags'
-    'attr';
+    'attr'
+    'link';
 }
 :--article-page header h1,
 :--article-page header h2 {

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -32,12 +32,11 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 :--article-page header {
   grid-template-areas:
-    'head'
-    'subh'
-    'cats'
-    'tags'
-    'attr'
-    'link';
+    'head head'
+    'subh subh'
+    'cats link'
+    'tags tags'
+    'attr attr';
 }
 :--article-page header h1,
 :--article-page header h2 {

--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -38,6 +38,11 @@
         {% block blog_meta %}
             {% include "djangocms_blog/includes/blog_meta.html" %}
         {% endblock %}
+        {# TACC (add social media sharing links): #}
+        {% block blog_share %}
+          {% include "share_on_social.html" %}
+        {% endblock %}
+        {# /TACC #}
     </header>
     {# TACC (support custom media even with thumbnail): #}
     {# {% if not post.main_image_id %} #}

--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -40,7 +40,7 @@
         {% endblock %}
         {# TACC (add social media sharing links): #}
         {% block blog_share %}
-          {% include "share_on_social.html" %}
+          {% include "share_on_social.html" with className="links" %}
         {% endblock %}
         {# /TACC #}
     </header>

--- a/taccsite_cms/templates/share_on_social.html
+++ b/taccsite_cms/templates/share_on_social.html
@@ -1,0 +1,14 @@
+{# @var className #}
+
+<nav class="logos--social {{className}}">
+  <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.path }}" target="_blank" class="logos__facebook">
+    <svg viewbox="0 0 25 25">
+      <use href="/static/site_cms/img/org_logos/facebook.svg#facebook-icon"></use>
+    </svg>
+  </a>
+  <a href="https://www.linkedin.com/cws/share?url={{ request.path }}" target="_blank" class="logos__linkedin">
+    <svg viewbox="0 0 25 25">
+      <use href="/static/site_cms/img/org_logos/linkedin.svg#linkedin-icon"></use>
+    </svg>
+  </a>
+<nav>

--- a/taccsite_cms/templates/share_on_social.html
+++ b/taccsite_cms/templates/share_on_social.html
@@ -1,14 +1,16 @@
 {# @var className #}
 
+{% with request.scheme|add:"://"|add:request.get_host|add:request.path as url %}
 <nav class="logos--social {{className}}">
-  <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.path }}" target="_blank" class="logos__facebook">
+  <a href="https://www.facebook.com/sharer/sharer.php?u={{ url }}" target="_blank" class="logos__facebook">
     <svg viewbox="0 0 25 25">
       <use href="/static/site_cms/img/org_logos/facebook.svg#facebook-icon"></use>
     </svg>
   </a>
-  <a href="https://www.linkedin.com/cws/share?url={{ request.path }}" target="_blank" class="logos__linkedin">
+  <a href="https://www.linkedin.com/cws/share?url={{ url }}" target="_blank" class="logos__linkedin">
     <svg viewbox="0 0 25 25">
       <use href="/static/site_cms/img/org_logos/linkedin.svg#linkedin-icon"></use>
     </svg>
   </a>
-<nav>
+</nav>
+{% endwith %}

--- a/taccsite_cms/templates/share_on_social.html
+++ b/taccsite_cms/templates/share_on_social.html
@@ -1,16 +1,26 @@
 {# @var className #}
 
 {% with request.scheme|add:"://"|add:request.get_host|add:request.path as url %}
+{% with settings.TACC_SOCIAL_SHARE_PLATFORMS as platforms %}
 <nav class="logos--social {{className}}">
+{% if platforms|length == 0 %}
+  <!-- No entries found in settings.TACC_SOCIAL_SHARE_PLATFORMS -->
+{% else %}
+  {% if 'facebook' in platforms %}
   <a href="https://www.facebook.com/sharer/sharer.php?u={{ url }}" target="_blank" class="logos__facebook">
     <svg viewbox="0 0 25 25">
       <use href="/static/site_cms/img/org_logos/facebook.svg#facebook-icon"></use>
     </svg>
   </a>
+  {% endif %}
+  {% if 'linkedin' in platforms %}
   <a href="https://www.linkedin.com/cws/share?url={{ url }}" target="_blank" class="logos__linkedin">
     <svg viewbox="0 0 25 25">
       <use href="/static/site_cms/img/org_logos/linkedin.svg#linkedin-icon"></use>
     </svg>
   </a>
+  {% endif %}
+{% endif %}
 </nav>
+{% endwith %}
 {% endwith %}


### PR DESCRIPTION
## Overview

Add quick links to share a News article on social media.

## Related

- [TUP-87](https://jira.tacc.utexas.edu/browse/TUP-87)
- expected by #713

## Changes

- **added** share links to news article
- **added** re-usable template for share links
- **added** setting `TACC_SOCIAL_SHARE_PLATFORMS` to list platforms

## Testing

### Setup

1. [Install blog.](https://github.com/TACC/Core-CMS/wiki/How-to-Install-DjangoCMS-Blog-i.e.-News)
2. [Create an article.](https://confluence.tacc.utexas.edu/pages/viewpage.action?pageId=182911007#UserGuideBlog/NewsInstructions-FromanEmptyCMS)
3. Open the article your created.

### Default Setting

4. Verify social media share links show as icons.
5. Live-edit the markup: In each share link URL, replace `http://localhost:8000` with `https://www.tacc.utexas.edu`.
6. Click each, and verify it lets user share via the appropriate platform.

### Custom Setting

7. Add/Edit `taccsite_cms/settings_local.py` file.
8. Add `TACC_SOCIAL_SHARE_PLATFORMS = []` (or `… = None`).
9. Refresh page.
10. Verify social media share links are not present.
    <sub>There is a comment in the markup where they would appear.</sub>

## UI

### Default Setting

| v1 by dev 2023-09-11 at 11.20 AM | tested _in situ_ on https://www.tacc.utexas.edu |
| - | - |
| ![share links with layout v1](https://github.com/TACC/Core-CMS/assets/62723358/8cefb5d0-2c51-4366-a712-9b23ca8cc270) | ![tacc news real with social media icons - top of page](https://github.com/TACC/Core-CMS/assets/62723358/78f81c7d-f877-4f34-9bdb-1cdb3c1f3c13) |

The new UI is icons under sub-heading, to the far-right of categories, above author.

<details><summary>

### Custom Setting

</summary>

![Screenshot 2023-09-11 at 4 16 22 PM](https://github.com/TACC/Core-CMS/assets/62723358/3121377e-67dc-48c3-b22c-01673b444e1d)

</details>

## Notes

1. [design review (private)](https://tacc-team.slack.com/archives/GS7512LU9/p1694449464309499)
2. [design approved (private)](https://tacc-team.slack.com/archives/GS7512LU9/p1694450383762399)
3. [design will revisit (private)](https://tacc-team.slack.com/archives/GS7512LU9/p1694453316949899?thread_ts=1694450383.762399&cid=GS7512LU9) during [TUP-584](https://jira.tacc.utexas.edu/browse/TUP-584)