### PR TITLE
refactor: deprecated node version & install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,13 @@ RUN poetry install
 FROM python-base as production
 
 # install node
-RUN curl -sL https://deb.nodesource.com/setup_17.x | bash -
-RUN apt-get install -y nodejs
+# https://github.com/nodesource/distributions#installation-instructions
+RUN apt-get install -y ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN NODE_MAJOR=18 && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install nodejs -y
 
 COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
 


### PR DESCRIPTION
## Overview

1. Install Node the new way, to avoid artificial 20 second delay in build.
2. Update Node version to current LTS (our current version is EOL).

<details>

Build [Core_CMS_Build #1247](https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/1247/console) reported both a (version) "DEPRECATION WARNING" and a "SCRIPT DEPRECATION WARNING". The former has been occurring, but the latter is new.

</details>

## Related

None

## Changes

- **changed** `Dockerfile` commands to install Node

## Testing

1. `make build`
2. `make start`
4. Set up site (follow README).
5. Load site.
6. Every step should occur as it has.

## UI

Skipped.