### PR TITLE
feat: texascale, cms v3.12.0 beta

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -469,6 +469,7 @@ def get_subdirs_as_module_names(path):
     for entry in os.scandir(path):
         is_app = (
             entry.path.find('_readme') == -1 and # explains common project dirs
+            entry.path.find('-org') == -1 and    # deprecated Texascale templates
             entry.path.find('-cms') == -1 and    # deprecated project templates
             entry.path.find('docs') == -1        # documentation beyond README
         )

--- a/taccsite_cms/static/site_cms/css/src/_imports/settings/font.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/settings/font.css
@@ -1,6 +1,6 @@
 :root {
   /* FAQ: Used by TACC/Core-Styles `s-header` */
-  /* FAQ: Overwritten by TACC/Core-CMS-Resource:/texascale_org `props.font` */
+  /* FAQ: Overwritten by TACC/Core-CMS-Resource:/texascale_cms `props.font` */
   --global-font-family: var(--global-font-family--sans);
 
   /* To overwrite Boostrap */


### PR DESCRIPTION
## Overview

Updated Texascale for CMS v3.12, and renamed it to `texascale_cms`.

## Related

- requires https://github.com/TACC/Core-CMS-Resources/pull/190
- done so Texascale can have #711

## Changes

- **changed** `INSTALLED_APPS` to ignore `texascale-org` dir
- **changed** name of `texascale-org` to `texascale_cms`
