### PR TITLE
Revert "feat: do not let news editors add plain images (#691)"

### DIFF
--- a/taccsite_cms/management/commands/group_perms/news_writer_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/news_writer_advanced.py
@@ -40,6 +40,7 @@ def set_group_perms():
     group.permissions.add( Permission.objects.get(name='Can change video player') )
     group.permissions.add( Permission.objects.get(name='Can delete video player') )
     group.permissions.add( Permission.objects.get(name='Can view video player') )
+    group.permissions.add( Permission.objects.get(name='Can add image') )
     group.permissions.add( Permission.objects.get(name='Can change image') )
     group.permissions.add( Permission.objects.get(name='Can view image') )
     group.permissions.add( Permission.objects.get(name='Can add Tag') )

--- a/taccsite_cms/management/commands/group_perms/news_writer_basic.py
+++ b/taccsite_cms/management/commands/group_perms/news_writer_basic.py
@@ -30,5 +30,6 @@ def set_group_perms():
     group.permissions.add( Permission.objects.get(name='Can change video player') )
     group.permissions.add( Permission.objects.get(name='Can delete video player') )
     group.permissions.add( Permission.objects.get(name='Can view video player') )
+    group.permissions.add( Permission.objects.get(name='Can add image') )
     group.permissions.add( Permission.objects.get(name='Can change image') )
     group.permissions.add( Permission.objects.get(name='Can view image') )


### PR DESCRIPTION
This reverts commit 5d1c585.

## Overview

I thought I was preventing the addition of "Image" plugin (i.e. `djangocms-picture`), but I prevented addition of image files.