### PR TITLE
hotfix: docs django syntax to html

### DIFF
--- a/docs/styles-and-scripts.md
+++ b/docs/styles-and-scripts.md
@@ -35,7 +35,7 @@
 
     - either **before** content
 
-      ```django
+      ```html
       {% block assets_custom %}
         {{ block.super }}
         <!-- ... -->
@@ -44,7 +44,7 @@
 
       <details><summary>for entire <strong>site</strong></summary>
 
-      ```django
+      ```html
         <link rel="stylesheet" href="{% static '__PROJECT__/css/build/site.css' %}">
         <script src="{% static '__PROJECT__/js/site.js' %}"></script>
       ```
@@ -53,7 +53,7 @@
 
       <details><summary>for one <strong>template</strong></summary>
 
-      ```django
+      ```html
         <link rel="stylesheet" href="{% static '__PROJECT__/css/build/template.___.css' %}">
         <script src="{% static '__PROJECT__/js/template.___.js' %}"></script>
       ```
@@ -69,7 +69,7 @@
 
     - or **after** content
 
-      ```django
+      ```html
       {% block assets_custom_delayed %}
         {{ block.super }}
         <!-- ... -->
@@ -78,7 +78,7 @@
 
       <details><summary>for entire <strong>site</strong></summary>
 
-      ```django
+      ```html
         <link rel="stylesheet" href="{% static '__PROJECT__/css/build/site.css' %}">
         <script src="{% static '__PROJECT__/js/site.js' %}"></script>
       ```
@@ -87,7 +87,7 @@
 
       <details><summary>for one <strong>template</strong></summary>
 
-      ```django
+      ```html
         <link rel="stylesheet" href="{% static '__PROJECT__/css/build/template.___.css' %}">
         <script src="{% static '__PROJECT__/js/template.___.js' %}"></script>
       ```
@@ -113,7 +113,7 @@
 
 ##### Styles
 
-```django
+```html
 {% block css %}
   {{ block.super }}
   <style>
@@ -127,7 +127,7 @@
 
 ##### Script
 
-```django
+```html
 {% block js %}
   {{ block.super }}
   <script type="module">


### PR DESCRIPTION
## Overview / Changes

Using `django` after backticks broke github-pages action (see https://github.com/TACC/Core-CMS/commit/bc92246), so use `html` for now.

## Related

- fixes #717

## Testing & UI

Skipped.