### PR TITLE
Feat/tup-632: django.cms.picture.css to core-cms

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -9,9 +9,6 @@ a.img-fluid {
   display: inline-block;
 }
 
-img.align-center {
-  display: block;
-}
 
 /* Try to auto-clear image floats */
 /* WARNING: The commented solution clears float BUT also negates float */

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -9,6 +9,9 @@ a.img-fluid {
   display: inline-block;
 }
 
+img.align-center {
+  display: block;
+}
 
 /* Try to auto-clear image floats */
 /* WARNING: The commented solution clears float BUT also negates float */

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -9,6 +9,9 @@ a.img-fluid {
   display: inline-block;
 }
 
+/* Support centering originating from Core-Styles */
+/* FAQ: We set display in client, so Core-Styles does not assume display */
+/* SEE: https://github.com/TACC/Core-Styles/blob/dd2bbb0/src/lib/_imports/components/align.css#L16-L19 */
 img.align-center {
   display: block;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -9,6 +9,10 @@ a.img-fluid {
   display: inline-block;
 }
 
+img.align-center {
+  display: block;
+}
+
 /* Try to auto-clear image floats */
 /* WARNING: The commented solution clears float BUT also negates float */
 /*
@@ -46,3 +50,4 @@ a.img-fluid {
 :is(figure, a).rounded {
   border-radius: unset !important; /* overwrite Bootstrap (uses !important) */
 }
+


### PR DESCRIPTION
## Overview

Migrated django.cms.picture.css to core-cms

## Related

- [TUP-632](https://jira.tacc.utexas.edu/browse/TUP-632)
- Migrate from [django.cms.picture.css](https://github.com/TACC/tup-ui/blob/main/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/django.cms.picture.css)

## Changes

- CSS includes centering images


## Testing

1. Zoom out and make sure image is centered. You can tick off the img.align-center class and see that the images will move to the left of the screen. Also, make sure it is importing from core-cms.css

## UI

| Before | 
| --- |
| <img width="2553" alt="Screenshot 2023-10-23 at 1 52 16 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/d240965a-0101-4690-89ff-c592896e0319"> | 

| Without | 
| --- |
| <img width="2557" alt="Screenshot 2023-10-23 at 1 52 42 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/b3e7a129-ec5e-4ef8-b4b2-be064d6f788e"> |

| After |
| --- |
| <img width="2557" alt="Screenshot 2023-10-23 at 1 51 33 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/3026e2ef-d3bc-40f2-b710-7edccfd1833d"> |




<!--
## Notes

…
-->
