### PR TITLE
feat/tup-633: Migrate lightgallery to core-cms

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/lightgallery.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/lightgallery.css
@@ -4,3 +4,8 @@
 .lightgallery {
   @extend .s-image-grid;
 }
+
+.lg-sub-html a {
+  /* FAQ: The `!important` overrides styles from plugin, in <anonymous> layer */
+  color: var(--global-color-link-on-dark--normal) !important;
+}


### PR DESCRIPTION
## Overview

Migrated lightgallery to core-cms.

## Related

- [TUP-633](https://jira.tacc.utexas.edu/browse/TUP-633)
- Migrate from [lightgallery](https://github.com/TACC/tup-ui/blob/main/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/components/lightgallery.css)

## Changes

Spoke with H. P. and TACC is moving away from purple to blue.

**Current site has:** 

CSS: color: `var(--global-color-link-on-dark--normal) !important;`

Var: `--global-color-link-on-dark--normal: var(global-color-accent--light);`

Color: `--global-color-accent--light: #a387ed;`

**Should be:** 

CSS: color: `var(--global-color-link-on-dark--normal) !important;`

Var: `--global-color-link-on-dark--normal: var(global-color-accent--light);`

Color: `--global-color-accent--light: #86aeff;`

## Testing

- Check CSS is coming from Core-CMS
- Check color is no longer #a387ed, but is #86aeff

## UI

| Before | After |
| --- | --- |
| <img width="2062" alt="Screenshot 2023-10-24 at 12 00 12 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/18915ad1-c7f4-4952-acde-a572c3f68c87"> | <img width="2061" alt="Screenshot 2023-10-24 at 11 55 06 AM" src="https://github.com/TACC/Core-CMS/assets/63771558/d9b4a606-8c93-44ad-a113-e2d5b8879fa8"> |



<!--
## Notes

…
-->
