### PR TITLE
feat/tup-634: Migrate pseudo-elements to core-cms

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/generics/pseudo-elements.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/generics/pseudo-elements.css
@@ -1,0 +1,11 @@
+/* To highlight targeted content */
+:target {
+    outline: var(--global-border-width--x-thick) solid transparent;
+    outline-offset: var(--global-border-width--xx-thick);
+    animation: focus 2s;
+}
+@keyframes focus {
+   from {
+        outline-color: var(--global-color-accent--tertiary);
+    }
+}

--- a/taccsite_cms/static/site_cms/css/src/core-cms.css
+++ b/taccsite_cms/static/site_cms/css/src/core-cms.css
@@ -15,4 +15,6 @@
 @import url("./_imports/components/django-cms-video.css");
 @import url("./_imports/components/lightgallery.css");
 
+@import url("./_imports/generics/pseudo-elements.css");
+
 @import url("./_imports/trumps/s-drop-cap.css");

--- a/taccsite_cms/static/site_cms/css/src/core-cms.css
+++ b/taccsite_cms/static/site_cms/css/src/core-cms.css
@@ -5,6 +5,8 @@
 
 @import url("./_imports/settings/font.css");
 
+@import url("./_imports/generics/pseudo-elements.css");
+
 @import url("./_imports/elements/figure-caption-blockquote.css");
 
 @import url("./_imports/components/c-button.css");
@@ -14,7 +16,5 @@
 @import url("./_imports/components/django.cms.picture.css");
 @import url("./_imports/components/django-cms-video.css");
 @import url("./_imports/components/lightgallery.css");
-
-@import url("./_imports/generics/pseudo-elements.css");
 
 @import url("./_imports/trumps/s-drop-cap.css");


### PR DESCRIPTION
## Overview

Migrate pseudo-elements to core-cms.

## Related

- [TUP-634](https://jira.tacc.utexas.edu/browse/TUP-634)
- Migrate from [pseudo-elements](https://github.com/TACC/tup-ui/blob/main/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-core-cms/generics/pseudo-elements.css)

## Changes

- Added folder for generics
- Added pseudo-element to generic folder

## Testing

Use the target pseudo-element on a div to see the interaction

<img width="444" alt="Screenshot 2023-10-24 at 5 14 00 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/f50bd181-9275-4668-bc3b-fb02e756cc28">

## UI
<img width="1649" alt="Screenshot 2023-10-24 at 5 27 27 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/db992a0b-c0c9-4ace-b662-e41173786da9">

<!--
## Notes

…
-->
