### PR TITLE
hotfix: tup-638 "share this" can show w/out icons

### DIFF
--- a/taccsite_cms/templates/share_on_social.html
+++ b/taccsite_cms/templates/share_on_social.html
@@ -3,12 +3,12 @@
 {% with request.scheme|add:"://"|add:request.get_host|add:request.path as url %}
 {% with settings.TACC_SOCIAL_SHARE_PLATFORMS as platforms %}
 <nav class="logos--social {{className}}">
-  {% block text_before %}
-  <span class="logos__text-before">share this:</span>
-  {% endblock text_before %}
 {% if platforms|length == 0 %}
   <!-- No entries found in settings.TACC_SOCIAL_SHARE_PLATFORMS -->
 {% else %}
+  {% block text_before %}
+  <span class="logos__text-before">share this:</span>
+  {% endblock text_before %}
   {% if 'facebook' in platforms %}
   <a href="https://www.facebook.com/sharer/sharer.php?u={{ url }}" target="_blank" class="logos__facebook">
     <svg viewbox="0 0 25 25">


### PR DESCRIPTION
## Overview

Do **not** render "share this:" if `TACC_SOCIAL_SHARE_PLATFORMS` array is **empty**.

## Related

- [TUP-638](https://jira.tacc.utexas.edu/browse/TUP-638)

## Changes

…

## Testing

1. …

## UI

…
