### PR TITLE
fix: tup-639 move c-button font-weight bold to cms

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
@@ -1,3 +1,5 @@
+@import url("@tacc/core-styles/src/lib/_imports/components/c-button.selectors.css");
+
 .c-button--primary,
 .c-button--secondary,
 .c-button--tertiary,
@@ -6,4 +8,8 @@
 
   font-size: var(--global-font-size--small);
   text-transform: uppercase;
+}
+
+:--c-button {
+  font-weight: var(--bold);
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
@@ -12,5 +12,5 @@
 
 :--c-button {
   font-weight: var(--bold);
-  letter-spacing: 0.5em;
+  letter-spacing: 0.05em;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
@@ -1,9 +1,9 @@
 @import url("@tacc/core-styles/src/lib/_imports/components/c-button.selectors.css");
 
-.c-button--primary,
-.c-button--secondary,
-.c-button--tertiary,
-.c-button--is-active {
+:--c-button--primary,
+:--c-button--secondary,
+:--c-button--tertiary,
+:--c-button--is-active {
   padding: 10px 20px;
 
   font-size: var(--global-font-size--small);

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
@@ -12,4 +12,5 @@
 
 :--c-button {
   font-weight: var(--bold);
+  letter-spacing: 0.5em;
 }


### PR DESCRIPTION
## Overview

All `c-button` font-weight bold to CMS.

## Related

- [TUP-639](https://jira.tacc.utexas.edu/browse/TUP-639)
- inspired by https://github.com/TACC/Core-Styles/pull/251#discussion_r1380667528
- requires https://github.com/TACC/Core-Styles/pull/253
- required by https://github.com/TACC/tup-ui/pull/364

## Changes

- **changed** c-button font-weight to always be bold
- **changed** c-button styles to use custom selector

## Testing & UI

See https://github.com/TACC/tup-ui/pull/364.