### PR TITLE
Update dockerfile to speed up builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,5 @@
 FROM python:3.8-buster as python-base
-
 LABEL maintainer="TACC-ACI-WMA <wma_prtl@tacc.utexas.edu>"
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-ENV PYTHONUNBUFFERED 1
-
-# https://python-poetry.org/docs/configuration/#using-environment-variables
-ENV POETRY_VERSION=1.4.0 \
-    POETRY_HOME="/opt/poetry" \
-    POETRY_VIRTUALENVS_IN_PROJECT=true \
-    POETRY_NO_INTERACTION=1 \
-    PYSETUP_PATH="/opt/pysetup" \
-    VENV_PATH="/opt/pysetup/.venv"
-
-# prepend poetry and venv to path
-ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
-
-FROM python-base as builder-base
 
 RUN apt-get update && apt-get install -y \
     build-essential python3-dev \
@@ -27,46 +9,46 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip3 install --upgrade pip setuptools wheel
 
+ARG DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED 1
+ENV PATH="/root/.local/bin:$PATH"
+
+# https://python-poetry.org/docs/configuration/#using-environment-variables
+ENV POETRY_VERSION=1.4.0 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    POETRY_NO_INTERACTION=1
+
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
 RUN curl -sSL https://install.python-poetry.org | python3 -
-
+RUN mkdir /code
 # copy project requirement files here to ensure they will be cached.
-WORKDIR $PYSETUP_PATH
-COPY pyproject.toml poetry.lock ./
-
+COPY pyproject.toml poetry.lock /code/
+WORKDIR /code
 # install runtime deps - uses $POETRY_VIRTUALENVS_IN_PROJECT internally
 RUN poetry install --no-dev
 
 # `development` image is used for local development
 FROM python-base as development
-WORKDIR $PYSETUP_PATH
-
-# copy in our built poetry + venv
-COPY --from=builder-base $POETRY_HOME $POETRY_HOME
-COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
-
 # quicker install as runtime deps are already installed
+COPY . /code/
 RUN poetry install
+
+FROM node:18 as node_build
+COPY package.json package-lock.json /code/
+WORKDIR /code
+RUN npm ci
+
+COPY . /code/
+ARG PROJECT_NAME
+ARG BUILD_ID
+RUN npm run build --project=$PROJECT_NAME --build-id=$BUILD_ID
 
 # `production` image is used for deployed runtime environments
 FROM python-base as production
-
-# install node
-RUN curl -sL https://deb.nodesource.com/setup_17.x | bash -
-RUN apt-get install -y nodejs
-
-COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
-
 # Make CMS logs
 RUN mkdir -p /var/log/cms
 
 # load files
-RUN mkdir /code
-COPY . /code
+COPY --from=node_build /code/ /code
 WORKDIR /code
 
-# build assets
-RUN npm ci
-ARG PROJECT_NAME
-ARG BUILD_ID
-RUN npm run build --project=$PROJECT_NAME --build-id=$BUILD_ID

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
 FROM python:3.8-buster as python-base
 LABEL maintainer="TACC-ACI-WMA <wma_prtl@tacc.utexas.edu>"
-
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     build-essential python3-dev \
     libldap2-dev libsasl2-dev ldap-utils tox \
     lcov valgrind vim \
     && pip3 install uwsgi
 
-RUN pip3 install --upgrade pip setuptools wheel
-
-ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED 1
 ENV PATH="/root/.local/bin:$PATH"
 
@@ -18,6 +15,7 @@ ENV POETRY_VERSION=1.4.0 \
     POETRY_VIRTUALENVS_CREATE=false \
     POETRY_NO_INTERACTION=1
 
+RUN pip3 install --upgrade pip setuptools wheel
 # Install Poetry - respects $POETRY_VERSION & $POETRY_HOME
 RUN curl -sSL https://install.python-poetry.org | python3 -
 RUN mkdir /code
@@ -50,5 +48,3 @@ RUN mkdir -p /var/log/cms
 
 # load files
 COPY --from=node_build /code/ /code
-WORKDIR /code
-


### PR DESCRIPTION
## Overview
Update the Dockerfile to remove Node deprecation warnings in CI and streamline Python dependency installation

## Related
- [WI-63](https://jira.tacc.utexas.edu/browse/WI-63)

## Changes
- Use a separate Node build step to handle style building
- Update Poetry config to use the container's system Python
- expose the Poetry binary when Core-CMS is used as a base image.