### PR TITLE
hotfix: setting paths `example-cms` should be `example_cms`

### DIFF
--- a/taccsite_cms/settings_custom.example.py
+++ b/taccsite_cms/settings_custom.example.py
@@ -48,7 +48,7 @@ CMS_TEMPLATES = (
 
 NSF_BRANDING = [
     "nsf",
-    "example-cms/img/org_logos/nsf-white.png",
+    "example_cms/img/org_logos/nsf-white.png",
     "branding-nsf",
     "https://www.nsf.gov/",
     "_blank",
@@ -63,7 +63,7 @@ NSF_BRANDING = [
 
 TACC_BRANDING = [
     "tacc",
-    "example-cms/img/org_logos/tacc-white.png",
+    "example_cms/img/org_logos/tacc-white.png",
     "branding-tacc",
     "https://www.tacc.utexas.edu/",
     "_blank",
@@ -74,7 +74,7 @@ TACC_BRANDING = [
 
 UTEXAS_BRANDING = [
     "utexas",
-    "example-cms/img/org_logos/utaustin-white.png",
+    "example_cms/img/org_logos/utaustin-white.png",
     "branding-utaustin",
     "https://www.utexas.edu/",
     "_blank",
@@ -90,7 +90,7 @@ UTEXAS_BRANDING = [
 # Edit this config as needed for the project branding used in the navigation bar header.
 CUSTOM_BRANDING = [
     "portal",
-    "example-cms/img/org_logos/portal.png",
+    "example_cms/img/org_logos/portal.png",
     "branding-logo--short",
     "https://cep.tacc.utexas.edu",
     "_blank",
@@ -118,7 +118,7 @@ BRANDING = [ TACC_BRANDING, UTEXAS_BRANDING ]
 # Edit this config as needed for the project logo used in the navigation bar.
 LOGO =  [
     "example",
-    "example-cms/img/org_logos/portal.png",
+    "example_cms/img/org_logos/portal.png",
     "",
     "/",
     "_self",
@@ -131,7 +131,7 @@ LOGO =  [
 # If `INCLUDES_CORE_PORTAL = True` and you set `FAVICON`, then:
 # https://github.com/TACC/Core-CMS-Custom/blob/d4c93af/docs/port-project.md#has-a-core-portal
 FAVICON = {
-    "img_file_src": "example-cms/img/org_logos/favicon.ico"
+    "img_file_src": "example_cms/img/org_logos/favicon.ico"
 }
 
 ########################


### PR DESCRIPTION
## Overview

Setting paths `example-cms` should be `example_cms`.

<details><summary>Background</summary>

Migration Django 4 → Core-CMS 3.12 replaced Python names' "-" with "_".

The incorrect path makes Core-CMS-Resources example assets fail to load.

</details>

## Related

None.

## Changes

- **change** example customs settings asset paths from `example_cms` to `example_cms`

## Testing

1. Load app using `settings.custom.py` with **`example-cms`** asset paths (`v4.1.0` tag).
2. Open CMS website.
3. Verify logos do **not** load.
4. Load app using `settings.custom.py` with **`example_cms`** asset paths (this branch).
5. Refresh CMS website.
6. Verify logos **do** load.

## UI

| Before | After |
| - | - |
| ![before](https://github.com/TACC/Core-CMS/assets/62723358/e39e9724-3150-4cbe-87d1-81ef136f63a7) | ![after](https://github.com/TACC/Core-CMS/assets/62723358/090a0ad1-3921-4081-af1d-dcd34d2219b6) |