### PR TITLE
hotfix(example_cms): missing urls.py

### DIFF
--- a/taccsite_cms/settings_custom.example.py
+++ b/taccsite_cms/settings_custom.example.py
@@ -182,3 +182,10 @@ BLOG_ENABLE_COMMENTS = False
 # TACC settings
 TACC_BLOG_SHOW_CATEGORIES = True
 TACC_BLOG_SHOW_TAGS = True
+
+########################
+# CLIENT BUILD SETTINGS
+########################
+
+# TACC/Core-CMS-Resources#75: Load custom urls.py so we can add urlpatterns for taggit_autosuggest
+ROOT_URLCONF = 'taccsite_custom.example_cms.urls'


### PR DESCRIPTION
## Overview

[Creating new post via `example_cms` causes error because of missing `urls.py` tweak.](https://github.com/nephila/djangocms-blog/issues/81#issuecomment-1819497693)

## Related

- coupled to https://github.com/TACC/Core-CMS-Resources/pull/195

## Changes

- **added** import of `example_cms`'s new `urls.py` to example settings

## Testing & UI

Skipped. Familiar mistake. Easy fix.