### PR TITLE
feat: cmd-57 hide articles from latest news

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -40,7 +40,7 @@
     {% endblock %}
     {% for post in post_list %}
         {# TACC (when listing, exclude posts that are not of certain categories): #}
-        {% blog_post_is_in_category post 'exclude' as should_exclude_post %}
+        {% blog_post_is_in_category post category 'exclude' as should_exclude_post %}
         {% if not should_exclude_post %}
             {% include "djangocms_blog/includes/blog_item.html" with post=post image="true" TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
         {% endif %}

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -1,6 +1,6 @@
 {# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/post_list.html #}
 {% extends "djangocms_blog/base.html" %}
-{% load i18n easy_thumbnails_tags %}{% spaceless %}
+{% load i18n easy_thumbnails_tags blog_post_is_in_category %}{% spaceless %}
 
 {% block canonical_url %}<link rel="canonical" href="{{ view.get_view_url }}"/>{% endblock canonical_url %}
 
@@ -39,7 +39,12 @@
     </header>
     {% endblock %}
     {% for post in post_list %}
-        {% include "djangocms_blog/includes/blog_item.html" with post=post image="true" TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
+        {# TACC (when listing, exclude posts that are not of certain categories): #}
+        {% blog_post_is_in_category post 'exclude' as should_exclude_post %}
+        {% if not should_exclude_post %}
+            {% include "djangocms_blog/includes/blog_item.html" with post=post image="true" TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
+        {% endif %}
+        {# /TACC #}
     {% empty %}
     <p class="blog-empty">{% trans "No article found." %}</p>
     {% endfor %}

--- a/taccsite_cms/templatetags/blog_post_is_in_category.py
+++ b/taccsite_cms/templatetags/blog_post_is_in_category.py
@@ -3,7 +3,7 @@ from django import template
 register = template.Library()
 
 @register.simple_tag
-def blog_post_is_in_category(post=None, category_slug=''):
+def blog_post_is_in_category(post=None, current_category=None, category_slug=''):
     """
     Custom Template Tag `blog_post_is_in_category`
 
@@ -24,9 +24,10 @@ def blog_post_is_in_category(post=None, category_slug=''):
         ../templates/djangocms_blog/post_list.html
     """
     is_in_category = False
-    if post.categories.exists:
-        for category in post.categories.all():
-            if category.slug == category_slug:
-                is_in_category = True
+    if not current_category.slug == category_slug:
+        if post.categories.exists:
+            for category in post.categories.all():
+                if category.slug == category_slug:
+                    is_in_category = True
 
     return is_in_category

--- a/taccsite_cms/templatetags/blog_post_is_in_category.py
+++ b/taccsite_cms/templatetags/blog_post_is_in_category.py
@@ -1,0 +1,32 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag
+def blog_post_is_in_category(post=None, category_slug=''):
+    """
+    Custom Template Tag `blog_post_is_in_category`
+
+    Use: Return (boolean) whether given blog post is in a given category.
+
+    Load custom tag into template:
+        {% load blog_post_is_in_category %}
+
+    Template inline usage:
+        {# (renders `True` or `False`) #}
+        {% blog_post_is_in_category post 'include-me' %}
+
+        {# (renders "A" or "B") #}
+        {% blog_post_is_in_category post 'include-me' as should_include_post %}
+        {% if should_include_post %} A {% else %} B {% endif %}
+
+    Example:
+        ../templates/djangocms_blog/post_list.html
+    """
+    is_in_category = False
+    if post.categories.exists:
+        for category in post.categories.all():
+            if category.slug == category_slug:
+                is_in_category = True
+
+    return is_in_category


### PR DESCRIPTION
## Overview

Allow hiding articles of a certain single category from the news feed.

## Status

- [x] exclude article from main news feed
- [x] do not exclude article from category news feed
- [x] make this extensible or customizable
    - ~~add setting that is list of article categories to exclude~~
    - create block, let custom cms add logic → #752

## Related

- [CMD-57](https://jira.tacc.utexas.edu/browse/CMD-57)
- replaced by #752

## Changes

- **added** templatetag `blog_post_is_in_category`
- **changed** template to use templatetag `blog_post_is_in_category` for an "Exclude" Category

## Testing

1. Have a CMS with Blog/News installed.
2. Create two new articles.
3. Make one article be in a category "Exclude" (with slug as `exclude`).
4. Make one article be in a category "Normal Category" (with slug as `normal-category`).
5. Open News page.
6. ✓ Verify the "Exclude" article is **not** present.
7. ✓ Verify the other article **is** present.
8. ✓ Verify "Normal Category" category news feed **still** shows all its articles.
9. ✓ Verify "Exclude" category news feed **still** shows all its articles.

## UI

| All | Normal | Exclude |
| - | - | - |
| ![all news](https://github.com/TACC/Core-CMS/assets/62723358/73f847a2-ab4a-4ea6-b935-86aea5d004df) | ![news list for the normal category](https://github.com/TACC/Core-CMS/assets/62723358/bb4eef6e-49e9-40ec-8e09-8686054e1e01) | ![news list for the exclude category](https://github.com/TACC/Core-CMS/assets/62723358/3b1303df-515a-464b-ac5c-07cb4d6710b0) |