### PR TITLE
feat: update core-styles from v2.11 to v2.22 - misc bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#9315ebbd",
+        "@tacc/core-styles": "^2.22.1",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.22.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9315ebbd28aa84e45432c253c4a10a0fe966ade9",
-      "license": "MIT",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.1.tgz",
+      "integrity": "sha512-uyrvc6Hh6udPo0YpNu16YPmpuwkeE44AI5RIEj5kOAQr52xeHpLogo2SbkgiEEXlsUzZpFUDkGERJcejTFOo4A==",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -8728,8 +8728,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9315ebbd28aa84e45432c253c4a10a0fe966ade9",
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#9315ebbd",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.1.tgz",
+      "integrity": "sha512-uyrvc6Hh6udPo0YpNu16YPmpuwkeE44AI5RIEj5kOAQr52xeHpLogo2SbkgiEEXlsUzZpFUDkGERJcejTFOo4A==",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^2.22.1",
+        "@tacc/core-styles": "github:TACC/Core-Styles#9ac94d3d",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -482,8 +482,8 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.1.tgz",
-      "integrity": "sha512-uyrvc6Hh6udPo0YpNu16YPmpuwkeE44AI5RIEj5kOAQr52xeHpLogo2SbkgiEEXlsUzZpFUDkGERJcejTFOo4A==",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9ac94d3d547e870b8a6eb675a3f73f787c5f19a4",
+      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -8728,9 +8728,8 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.1.tgz",
-      "integrity": "sha512-uyrvc6Hh6udPo0YpNu16YPmpuwkeE44AI5RIEj5kOAQr52xeHpLogo2SbkgiEEXlsUzZpFUDkGERJcejTFOo4A==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9ac94d3d547e870b8a6eb675a3f73f787c5f19a4",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#9ac94d3d",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#9ac94d3d",
+        "@tacc/core-styles": "^2.22.2",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.22.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#9ac94d3d547e870b8a6eb675a3f73f787c5f19a4",
-      "license": "MIT",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.2.tgz",
+      "integrity": "sha512-r2QTrZOcUZIjSIcOLktluGhPzGxvYNTEOKF7h6gYmQn8tgiFcesw4xzoIDCVynA5WpaPMZ2jkV3wM+M7SoBd9Q==",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -8728,8 +8728,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#9ac94d3d547e870b8a6eb675a3f73f787c5f19a4",
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#9ac94d3d",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.2.tgz",
+      "integrity": "sha512-r2QTrZOcUZIjSIcOLktluGhPzGxvYNTEOKF7h6gYmQn8tgiFcesw4xzoIDCVynA5WpaPMZ2jkV3wM+M7SoBd9Q==",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#9ac94d3d",
+    "@tacc/core-styles": "^2.22.2",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^2.22.1",
+    "@tacc/core-styles": "github:TACC/Core-Styles#9ac94d3d",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#9315ebbd",
+    "@tacc/core-styles": "^2.22.1",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
@@ -1,18 +1,20 @@
 @import url("@tacc/core-styles/src/lib/_imports/components/c-button.selectors.css");
 @import url("@tacc/core-styles/src/lib/_imports/tools/selectors.form.css");
 
-:--c-button--primary,
-:--c-button--secondary,
-:--c-button--tertiary,
-:--c-button--is-active,
-:--form__button {
-  padding: 10px 20px;
 
-  font-size: var(--global-font-size--small);
-  text-transform: uppercase;
+:--main-content {
+  & :--c-button,
+  & :--form__button {
+    padding: 10px 20px;
+
+    font-size: var(--global-font-size--small);
+
+    font-weight: var(--bold);
+    letter-spacing: 0.05em;
+  }
 }
 
-:--c-button {
-  font-weight: var(--bold);
-  letter-spacing: 0.05em;
+:--c-button,
+:--form__button {
+  text-transform: uppercase;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/c-button.css
@@ -1,9 +1,11 @@
 @import url("@tacc/core-styles/src/lib/_imports/components/c-button.selectors.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/selectors.form.css");
 
 :--c-button--primary,
 :--c-button--secondary,
 :--c-button--tertiary,
-:--c-button--is-active {
+:--c-button--is-active,
+:--form__button {
   padding: 10px 20px;
 
   font-size: var(--global-font-size--small);


### PR DESCRIPTION
## Overview

Fix miscellaneous bugs in #742.

## Related

- fixes #742
- coupled with https://github.com/TACC/tup-ui/pull/384

## Changes / Testing

- Django CMS form button is uppercase.
- TACC footer buttons match production (or look better).

## UI

| test | screenshot |
| - | - |
| form button | ![form button](https://github.com/TACC/Core-CMS/assets/62723358/cafb2071-a993-405e-911f-713b801b9e78) |
| footer buttons | ![before](https://github.com/TACC/tup-ui/assets/62723358/0f769433-7c71-4ff8-8b7c-82a3f93a9f22) / ![after](https://github.com/TACC/tup-ui/assets/62723358/4ee78494-3891-4127-8c4e-0df41a2cbd22)