### PR TITLE
Feat/tup 631 migrate blog page css from tup

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -109,6 +109,17 @@ Styleguide Components.DjangoCMS.Blog.App.Page
   clear: both;
 }
 
+/* To support gallery feature */
+/* SEE: ./lightgallery.css */
+.app-blog .lightgallery {
+  --min-width: 230px;
+}
+@supports selector(:has(*)) {
+  .app-blog .lightgallery a:has(figcaption) {
+    align-items: start;
+  }
+}
+
 
 
 /* Media & Content - Content */

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -164,7 +164,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
   :--article-page .blog-content .align-center,
   :--article-page .blog-content .align-right,
   :--article-page .blog-content .align-left {
-    max-width: unset;
+    max-width: 100%;
   }
   :--article-page .blog-content .align-right,
   :--article-page .blog-content .align-left {


### PR DESCRIPTION
## Overview

Migrate blog page CSS from tup-ui.

## Related

- [TUP-631](https://tacc-main.atlassian.net/browse/TUP-631)
- required by https://github.com/TACC/tup-ui/pull/385

## Changes

- **deleted** stylesheet
- **deleted** load of that stylesheet

## Testing & UI

See https://github.com/TACC/tup-ui/pull/385.
