### PR TITLE
Sub-Task/TUP-573 Add accessibility role(button) to dropdown a-tags

### DIFF
--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -15,7 +15,9 @@
       class="nav-link dropdown-toggle"
       data-toggle="dropdown"
       aria-haspopup="true"
-      aria-expanded="false">
+      aria-expanded="false"
+      role="button"
+      >
       {{ child.get_menu_title|safe }}
       {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
       <span class="sr-only">Toggle Dropdown</span>


### PR DESCRIPTION
## Overview

Adds role='button' to a-tags in dropdown.

## Related

[TUP-573](https://jira.tacc.utexas.edu/browse/TUP-573)

## Changes

Adds role='button' to a-tags in dropdown.

## Testing

1. Follow https://github.com/TACC/Core-CMS/wiki/Locally-Develop-CMS-and-TUP-CMS to test changes in this on tup-ui
2. Check for a-tag roles on dropdowns (role='button')

## UI

<img width="1969" alt="Screenshot 2023-12-01 at 5 22 04 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/4079e2b1-16f6-4b6e-98e0-cd3216e6fa43">
<img width="556" alt="Screenshot 2023-12-01 at 4 01 48 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/b3ca31c4-d13f-427a-a493-29b38746e69c">


<!--
## Notes

…
-->
