### PR TITLE
sub-task/tup-579 Added navbarDropdown id to a tag

### DIFF
--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -17,6 +17,7 @@
       aria-haspopup="true"
       aria-expanded="false"
       role="button"
+      id="navbarDropdown"
       >
       {{ child.get_menu_title|safe }}
       {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}


### PR DESCRIPTION
## Overview

Added `id="navbarDropdown` to `a` tag. Unsure if any styles should be associated with id tag. Couldn't find any previous uses of this, other than `aria-labelledby="navbarDropdown"` in the dropdown-menu underneath it.

## Related

- [TUP-579](https://jira.tacc.utexas.edu/browse/TUP-579)

## Changes

Added `id="navbarDropdown` to `a` tag. 

## Testing

1. Create image with this change
2. Test on TUP-UI for id attribute

## UI
| id applied |
| - |
| <img width="2560" alt="Screenshot 2023-12-04 at 1 00 35 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/00f72306-8c9c-4c49-99da-4d330d5975e5"> |


<!--
## Notes

…
-->
