### PR TITLE
hotfix: restore margin-bottom for narrow-screen blog images

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -169,7 +169,6 @@ Styleguide Components.DjangoCMS.Blog.App.Page
   :--article-page .blog-content .align-right,
   :--article-page .blog-content .align-left {
     float: unset;
-    margin-bottom: unset;
   }
   :--article-page .blog-content .align-right {
     margin-left: unset;


### PR DESCRIPTION
## Overview

The left- and right-aligned images were missing the margin-bottom that a center-aligned image had.

_@wesleyboar found no reason for this._

## Related

- requires TACC/Core-Styles/pull/278

## Changes

- **removed** unset of margin-bottom

## Testing

0. Have a CMS with Blog/News.
1. Load a blog article with left-aligned, center-aligned, and right-aligned image.

## UI

| left | center | right |
| - | - | - |
| ![left](https://github.com/TACC/Core-CMS/assets/62723358/23f24094-a3ec-4a2f-891e-804d67c06d06) | ![center](https://github.com/TACC/Core-CMS/assets/62723358/610a50ea-be4e-4b34-9807-95b350b5df43) | ![right](https://github.com/TACC/Core-CMS/assets/62723358/4a9cafa8-e27c-46fc-a888-93a62fdb569b) |