### PR TITLE
fix: tup 662 nav dropdown id not unique

### DIFF
--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -17,13 +17,13 @@
       aria-haspopup="true"
       aria-expanded="false"
       role="button"
-      id="navbarDropdown"
+      id="navbarDropdown--{{child.get_menu_title|slugify}}"
       >
       {{ child.get_menu_title|safe }}
       {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
       <span class="sr-only">Toggle Dropdown</span>
     </a>
-    <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown">
+    <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown--{{child.get_menu_title|slugify}}">
       {# Bootstrap4 does not support submenus, so nor do we (and other users). See https://github.com/twbs/bootstrap/pull/6342. #}
       {% for grandchild in child.children %}
       {% limit_visibility_in_menu grandchild as can_view %}

--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -17,13 +17,13 @@
       aria-haspopup="true"
       aria-expanded="false"
       role="button"
-      id="navbarDropdown--{{child.get_menu_title|slugify}}"
+      id="navbarDropdown-{{child.id}}"
       >
       {{ child.get_menu_title|safe }}
       {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
       <span class="sr-only">Toggle Dropdown</span>
     </a>
-    <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown--{{child.get_menu_title|slugify}}">
+    <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown-{{child.id}}">
       {# Bootstrap4 does not support submenus, so nor do we (and other users). See https://github.com/twbs/bootstrap/pull/6342. #}
       {% for grandchild in child.children %}
       {% limit_visibility_in_menu grandchild as can_view %}

--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -16,14 +16,15 @@
       data-toggle="dropdown"
       aria-haspopup="true"
       aria-expanded="false"
+      aria-controls="nav-menu-{{child.id}}"
       role="button"
-      id="navbarDropdown-{{child.id}}"
+      id="nav-link-{{child.id}}"
       >
       {{ child.get_menu_title|safe }}
       {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}
       <span class="sr-only">Toggle Dropdown</span>
     </a>
-    <div class="dropdown-menu" role="menu" aria-labelledby="navbarDropdown-{{child.id}}">
+    <div class="dropdown-menu" role="menu" id="nav-menu-{{child.id}}" aria-labelledby="nav-link-{{child.id}}">
       {# Bootstrap4 does not support submenus, so nor do we (and other users). See https://github.com/twbs/bootstrap/pull/6342. #}
       {% for grandchild in child.children %}
       {% limit_visibility_in_menu grandchild as can_view %}


### PR DESCRIPTION
## Overview

Use unique IDs for nav dropdowns.

## Related

- [TUP-662](https://tacc-main.atlassian.net/browse/TUP-662)

## Changes

- **changed** link `id` and menu `aria-labelledby` values
- **added** menu `id`
- **added** link `aria-controls`

## Testing

> [!NOTE]
> You may test on https://dev.tup.tacc.utexas.edu/.

1. Have a CMS with nav dropdowns in CMS navigation menu.
2. Verify values of dropdown's link `id` and menu `aria-labelledby`:
    - are unique
    - match per dropdown
3. Verify values of dropdown's menu `id` and link `aria-controls`:
    - are unique
    - match per dropdown
4. Verify Accessibility details are accurate.

## Notes

I followed [MDN: Accessibility: "menu_role"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role), except I did not use `aria-label`, because **(A)** there are already `<span class="sr-only">` tags that serve the same purpose, and **(B)** I did not want to further increase scope of the ticket beyond "fixing ID".

## UI

<img width="1200" alt="TUP-662" src="https://github.com/TACC/Core-CMS/assets/62723358/19ec518d-b61c-400a-a1b6-d7dd122e5dc0">