### PR TITLE
task/tup551 Hide published text unless editing

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -279,6 +279,7 @@ CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'
 
 TACC_BLOG_SHOW_CATEGORIES = True
 TACC_BLOG_SHOW_TAGS = True
+TACC_BLOG_SHOW_PUB_TEXT = True
 # To flag posts of certain category or tag, so template can take special action
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'sample_value_e_g__mutlimedia__'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'sample_value_e_g__redirect__'
@@ -698,6 +699,7 @@ SETTINGS_EXPORT = [
     'GOOGLE_ANALYTICS_PRELOAD',
     'TACC_BLOG_SHOW_CATEGORIES',
     'TACC_BLOG_SHOW_TAGS',
+    'TACC_BLOG_SHOW_PUB_TEXT',
     'TACC_CORE_STYLES_VERSION',
     'TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY',
     'TACC_BLOG_SHOW_ABSTRACT_TAG',

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -21,7 +21,9 @@
       {# /TACC #}
       {# TACC (add <span> and &nbsp; so whitespace can be stripped): #}
       {# TACC ("Published" vs "To be published"): #}
-      <span>{% if post.publish and settings.TACC_BLOG_SHOW_PUB_TEXT %}{% trans "Published" %}{% else %}{% trans "To be published" %}{% endif %}</span>&nbsp;
+      {% if settings.TACC_BLOG_SHOW_PUB_TEXT %}
+        <span>{% if post.publish %}{% trans "Published" %}{% else %}{% trans "To be published" %}{% endif %}</span>&nbsp;
+      {% endif %}
       {# /TACC #}
       {# /TACC #}
       {# TACC (wrap with <time> tag because it should be so): #}

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -21,7 +21,7 @@
       {# /TACC #}
       {# TACC (add <span> and &nbsp; so whitespace can be stripped): #}
       {# TACC ("Published" vs "To be published"): #}
-      <span>{% if post.publish %}{% trans "Published" %}{% else %}{% trans "To be published" %}{% endif %}</span>&nbsp;
+      <span>{% if post.publish and settings.TACC_BLOG_SHOW_PUB_TEXT %}{% trans "Published" %}{% else %}{% trans "To be published" %}{% endif %}</span>&nbsp;
       {# /TACC #}
       {# /TACC #}
       {# TACC (wrap with <time> tag because it should be so): #}


### PR DESCRIPTION
## Overview

Removes published verbiage when not editing.


## Related

- [TUP-551](https://tacc-main.atlassian.net/browse/TUP-551)
- https://github.com/TACC/tup-ui/pull/395


## Changes

Simple. When not editing, the published verbiage is hidden. When editing the published verbiage appears.

## Testing

1. On Core-CMS, adjust the `TACC_BLOG_SHOW_PUB_TEXT` value in the `settings.py` file
2. Test that it disappears when false, and appears when true

## UI

| editing (`TACC_BLOG_SHOW_PUB_TEXT = True`) |
| - |
| <img width="599" alt="Screenshot 2023-12-13 at 3 49 51 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/c4d2f030-ba23-4080-8043-48dff7045eb1"> |

| not editing (`TACC_BLOG_SHOW_PUB_TEXT = False`) |
| - |
| <img width="770" alt="Screenshot 2023-12-13 at 3 50 16 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/3bb8cd7d-4493-4f77-b62c-b18e1dd7c323"> |



<!--
## Notes

…
-->
