### PR TITLE
Revert "task/tup551 Hide published text unless editing"

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -279,7 +279,6 @@ CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'
 
 TACC_BLOG_SHOW_CATEGORIES = True
 TACC_BLOG_SHOW_TAGS = True
-TACC_BLOG_SHOW_PUB_TEXT = True
 # To flag posts of certain category or tag, so template can take special action
 TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY = 'sample_value_e_g__mutlimedia__'
 TACC_BLOG_SHOW_ABSTRACT_TAG = 'sample_value_e_g__redirect__'
@@ -699,7 +698,6 @@ SETTINGS_EXPORT = [
     'GOOGLE_ANALYTICS_PRELOAD',
     'TACC_BLOG_SHOW_CATEGORIES',
     'TACC_BLOG_SHOW_TAGS',
-    'TACC_BLOG_SHOW_PUB_TEXT',
     'TACC_CORE_STYLES_VERSION',
     'TACC_BLOG_CUSTOM_MEDIA_POST_CATEGORY',
     'TACC_BLOG_SHOW_ABSTRACT_TAG',

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -21,9 +21,7 @@
       {# /TACC #}
       {# TACC (add <span> and &nbsp; so whitespace can be stripped): #}
       {# TACC ("Published" vs "To be published"): #}
-      {% if settings.TACC_BLOG_SHOW_PUB_TEXT %}
-        <span>{% if post.publish %}{% trans "Published" %}{% else %}{% trans "To be published" %}{% endif %}</span>&nbsp;
-      {% endif %}
+      <span>{% if post.publish %}{% trans "Published" %}{% else %}{% trans "To be published" %}{% endif %}</span>&nbsp;
       {# /TACC #}
       {# /TACC #}
       {# TACC (wrap with <time> tag because it should be so): #}


### PR DESCRIPTION
Reverts TACC/Core-CMS#763

_After chatting and thing since https://github.com/TACC/tup-ui/pull/395, this has proven to be an unnecessary setting. There is an easier solution: delete the "Published" text (that I had added long ago, as custom text)._