### PR TITLE
feat: TUP-568 redesign news article date

### DIFF
--- a/taccsite_cms/locale/en/LC_MESSAGES/django.po
+++ b/taccsite_cms/locale/en/LC_MESSAGES/django.po
@@ -104,11 +104,6 @@ msgstr "Provide a description, attribution, copyright or other information. WARN
 
 
 #: site-cms(djangocms-blog)
-#: templates/djangocms_blog/includes/blog_meta.html:6
-msgid "Published"
-msgstr "Published:"
-
-#: site-cms(djangocms-blog)
 #: templates/djangocms_blog/post_list.html:6
 msgid "News"
 msgstr ""

--- a/taccsite_cms/locale/en/LC_MESSAGES/django.po
+++ b/taccsite_cms/locale/en/LC_MESSAGES/django.po
@@ -104,6 +104,11 @@ msgstr "Provide a description, attribution, copyright or other information. WARN
 
 
 #: site-cms(djangocms-blog)
+#: templates/djangocms_blog/includes/blog_meta.html:6
+msgid "Published"
+msgstr "Published:"
+
+#: site-cms(djangocms-blog)
 #: templates/djangocms_blog/post_list.html:6
 msgid "News"
 msgstr ""

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -120,11 +120,7 @@ Styleguide Components.DjangoCMS.Blog.App
   display: flex;
   gap: 0.25em;
 }
-.app-blog .logos--social a {
-  height: fit-content; /* remove whitespace */
-}
 .app-blog .logos--social svg {
-  display: block; /* remove whitespace */
   height: var(--global-font-size--x-large);
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -41,18 +41,14 @@ Styleguide Components.DjangoCMS.Blog.App
 
 .app-blog header {
   display: grid;
-  grid-template-areas:
-    'cats'
-    'tags'
-    'attr'
-    'head'
-    'subh';
+  column-gap: 1em;
 }
 :--article-page h1,
 :--article-item h3    { grid-area: head }
 :--article-page h2,
 :--article-item h4    { grid-area: subh }
 .app-blog .attrs      { grid-area: attr }
+.app-blog .dates      { grid-area: date }
 .app-blog .categories { grid-area: cats }
 .app-blog .tags       { grid-area: tags }
 .app-blog .links      { grid-area: link }
@@ -61,7 +57,6 @@ Styleguide Components.DjangoCMS.Blog.App
   list-style: none;
 
   padding-left: 0; /* overwrite html-elements.css */
-  margin-bottom: 0.25em; /* overwrite html-elements.css */
 
   font-size: var(--global-font-size--medium);
 }
@@ -125,7 +120,11 @@ Styleguide Components.DjangoCMS.Blog.App
   display: flex;
   gap: 0.25em;
 }
+.app-blog .logos--social a {
+  height: fit-content; /* remove whitespace */
+}
 .app-blog .logos--social svg {
+  display: block; /* remove whitespace */
   height: var(--global-font-size--x-large);
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -101,6 +101,15 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 /* Header (Structure) */
 
 :--article-item header {
+  grid-template-areas:
+    'cats tags'
+    'date attr'
+    'head head'
+    'subh subh';
+  justify-content: space-between;
+}
+
+:--article-item header {
   margin-bottom: 5px;
 }
 
@@ -136,16 +145,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 /* Metadata */
 
-:--article-item .attrs {
-  display: flex;
-  flex-direction: row;
-}
-:--article-item .attrs {
-  justify-content: space-between;
-}
-:--article-item .date {
-  order: -1;
-}
+/* … */
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -33,11 +33,12 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 :--article-page header {
   grid-template-areas:
+    'cats date'
     'head head'
     'subh subh'
-    'cats link'
-    'tags tags'
-    'attr attr';
+    'attr link'
+    'tags tags';
+  grid-template-columns: minmax(0, max-content) 1fr;
 }
 :--article-page header h1,
 :--article-page header h2 {
@@ -51,20 +52,6 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 :--article-page header h2 {
   font-weight: normal;
   font-size: var(--global-font-size--large);
-}
-
-
-
-
-
-/* Metadata */
-
-:--article-page .attrs {
-  display: flex;
-  flex-direction: column;
-}
-:--article-page .date {
-  order: -1;
 }
 
 

--- a/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
+++ b/taccsite_cms/templates/djangocms_blog/includes/blog_meta.html
@@ -1,8 +1,10 @@
 {# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html #}
 {% load i18n easy_thumbnails_tags cms_tags %}
 
+{# TACC (isolate dates for CSS grid flexibility): #}
 {# TACC (add class so CSS can target this element): #}
 <ul class="post-detail attrs">
+{# /TACC #}
 {# /TACC #}
     {% if post.author %}
     {# TACC (add class so CSS can target this element): #}
@@ -13,6 +15,10 @@
         {# /TACC #}
         <a href="{% url 'djangocms_blog:posts-author' post.author.get_username %}">{% if post.author.get_full_name %}{{ post.author.get_full_name }}{% else %}{{ post.author }}{% endif %}</a>
     </li>
+{# TACC (isolate dates for CSS grid flexibility): #}
+</ul>
+<ul class="post-detail dates">
+{# /TACC #}
     {% endif %}
     {# TACC (add class so CSS can target this element): #}
     <li class="date date-published">


### PR DESCRIPTION
## Overview

Redesign the date for news articles.

## Related

- [TUP-568](https://tacc-main.atlassian.net/browse/TUP-568)

## Changes

- **changed** date style on article page
- **changed** byline and date layout
- **changed** byline and dates markup — moved dates to their own list

## Testing

1. Open News article and News list.
2. Verify that the date on both pages:
    - has the same style
3. Verify that the byline on **list** page:
    - (unchanged) is left-aligned underneath category
4. Verify that the byline on **article** page:
    - (new location) is left-aligned to the right of category

## UI

| list page | article page |
| - | - |
| ![list](https://github.com/TACC/Core-CMS/assets/62723358/7e39ac4b-8cea-4315-81f4-e2fbe9f89212) | ![page](https://github.com/TACC/Core-CMS/assets/62723358/7bb5a371-798a-4c00-ab5b-e3dc85313f42) |

| list page - grid | article page - grid |
| - | - |
| ![list - grid](https://github.com/TACC/Core-CMS/assets/62723358/3a24a470-bcab-42df-babd-7311e1b03d4f) | ![page - grid](https://github.com/TACC/Core-CMS/assets/62723358/d98b5dc7-2362-4e76-9a20-7b4ed32cdabe) |
