### PR TITLE
fix: social media icons excess whitespace

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -126,7 +126,11 @@ Styleguide Components.DjangoCMS.Blog.App
   display: flex;
   gap: 0.25em;
 }
+.app-blog .logos--social a {
+  height: fit-content; /* remove whitespace */
+}
 .app-blog .logos--social svg {
+  display: block; /* remove whitespace */
   height: var(--global-font-size--x-large);
 }
 


### PR DESCRIPTION
## Overview

Remove excess whitespace under social media icons.

## Related

- replaces #768

## Changes

- **added** CSS to remove whitespace

## Testing

1. Verify size of social media icon links is the size of the social media icons.

## UI

| `<a>` | `<svg>` |
| - | - |
| ![a](https://github.com/TACC/Core-CMS/assets/62723358/dce0cbea-5a50-48ac-8d68-1563cdb989c6) | ![svg](https://github.com/TACC/Core-CMS/assets/62723358/688059e0-a3f9-4586-a43f-85db84bcaae7) | 