### PR TITLE
Task/tup-671 News Article Drop-Cap

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -72,9 +72,9 @@
     {% endif %}
     {# /TACC #}
     {% if post.app_config.use_placeholder %}
-        <div class="blog-content">{% render_placeholder post.content %}</div>
+        <div class="blog-content s-drop-cap">{% render_placeholder post.content %}</div>
     {% else %}
-        <div class="blog-content">{% render_model post "post_text" "post_text" "" "safe" %}</div>
+        <div class="blog-content s-drop-cap">{% render_model post "post_text" "post_text" "" "safe" %}</div>
     {% endif %}
     {% if view.liveblog_enabled %}
         {% include "liveblog/includes/post_detail.html" %}

--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -72,9 +72,9 @@
     {% endif %}
     {# /TACC #}
     {% if post.app_config.use_placeholder %}
-        <div class="blog-content s-drop-cap">{% render_placeholder post.content %}</div>
+        <div class="blog-content">{% render_placeholder post.content %}</div>
     {% else %}
-        <div class="blog-content s-drop-cap">{% render_model post "post_text" "post_text" "" "safe" %}</div>
+        <div class="blog-content">{% render_model post "post_text" "post_text" "" "safe" %}</div>
     {% endif %}
     {% if view.liveblog_enabled %}
         {% include "liveblog/includes/post_detail.html" %}


### PR DESCRIPTION
## Overview

Adds drop-cap to news articles

## Related

- https://tacc-main.atlassian.net/browse/TUP-671

## Changes

- Added `s-drop-cap` to the blog-content div class

## Testing

1. Create a new article in your local environment
2. You may have to deactivate a couple of styles to see this take effect
a. Remove empty paragraph in `blog-content` div
![Screenshot 2023-12-20 at 5 38 45 PM](https://github.com/TACC/Core-CMS/assets/63771558/972a560c-ec8d-4d5b-ae77-65bb05382e90)
b. Remove the `blog-visual` div
![Screenshot 2023-12-20 at 5 39 59 PM](https://github.com/TACC/Core-CMS/assets/63771558/b126b6be-51e0-46c8-8218-10dff9525776)

## UI

| Drop-Cap in News Article |
| - |
| ![Screenshot 2023-12-20 at 5 26 46 PM](https://github.com/TACC/Core-CMS/assets/63771558/f67b66bc-4430-4a25-b4a2-8497160023c2) |

## Notes
Accidentally messed up the commits. But the final commit just adds in the `s-drop-cap` class to the `blog-content` div
