### PR TITLE
chore: tup-677 css/django/vite interoperability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "taccsite_custom"]
 	path = taccsite_custom
 	url = git@github.com:TACC/Core-CMS-Resources.git
-	branch = task/37-per-site-assets
+	branch = chore/tup-677-css-django-vite-interoperability

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Set up a new local CMS instance.
     python manage.py createsuperuser
     # To use default "Username" and skip "Email address", press Enter at both prompts.
     # At "Password" prompts, you may use an easy-to-remember password.
-    python manage.py collectstatic --no-input
+    python manage.py collectstatic --no-input --ignore assets/*/font*.css
 
     ```
 
@@ -138,7 +138,7 @@ make start
 | Node dependencies | `npm ci` |
 | CSS stylesheets | `npm run build:css` |
 | UI Demo | `npm run build:ui-demo` |
-| Assets e.g.<br><small>images, stylesheets, JavaScript</small> | `docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"` |
+| Assets e.g.<br><small>images, stylesheets, JavaScript</small> | `docker exec -it core_cms sh -c "python manage.py collectstatic --no-input --ignore assets/*/font*.css"` |
 | Python models | `docker exec -it core_cms sh -c "python manage.py migrate"` |
 
 ## Develop Project

--- a/docs/develop-custom-project.md
+++ b/docs/develop-custom-project.md
@@ -44,7 +44,7 @@ To compile CSS static files:
 
 ```sh
 npm run build:css --project="custom_project_dir"
-docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"
+docker exec -it core_cms sh -c "python manage.py collectstatic --no-input --ignore assets/*/font*.css"
 
 ```
 

--- a/docs/develop-project.md
+++ b/docs/develop-project.md
@@ -45,7 +45,7 @@ This allows use of future-proof CSS via [Core Styles].
 3. [Collect Static Files](#collect-static-files):
 
     ```sh
-    docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"
+    docker exec -it core_cms sh -c "python manage.py collectstatic --no-input --ignore assets/*/font*.css"
     ```
 
 ## Collect Static Files
@@ -53,7 +53,7 @@ This allows use of future-proof CSS via [Core Styles].
 Whenever files in a `static/` directory are changed, the CMS must be manually told to serve them:
 
 ```sh
-docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"
+docker exec -it core_cms sh -c "python manage.py collectstatic --no-input --ignore assets/*/font*.css"
 ```
 
 > **Note**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^2.22.3",
+        "@tacc/core-styles": "github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.3.tgz",
-      "integrity": "sha512-niE9F32p/eoywM+cdeHAaN+kIp0GbatBH+4KyRvBFxifKFxfAhnZljFZtGo6NxGHI6PRICjMoNZn+kMBWmDr/g==",
+      "version": "2.22.4",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#4e85f6cf8f605d691634a9f1be90fc2ba5a469ac",
+      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -8728,9 +8728,8 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.3.tgz",
-      "integrity": "sha512-niE9F32p/eoywM+cdeHAaN+kIp0GbatBH+4KyRvBFxifKFxfAhnZljFZtGo6NxGHI6PRICjMoNZn+kMBWmDr/g==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#4e85f6cf8f605d691634a9f1be90fc2ba5a469ac",
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -482,7 +482,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.22.4",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#4e85f6cf8f605d691634a9f1be90fc2ba5a469ac",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#fd68d7ad65e2cfb4352e5fe193e766b51de18524",
       "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
@@ -8728,7 +8728,7 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#4e85f6cf8f605d691634a9f1be90fc2ba5a469ac",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#fd68d7ad65e2cfb4352e5fe193e766b51de18524",
       "from": "@tacc/core-styles@github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^2.22.3",
+    "@tacc/core-styles": "github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/django/contrib/staticfiles_custom/apps.py
+++ b/taccsite_cms/django/contrib/staticfiles_custom/apps.py
@@ -12,5 +12,5 @@ class TaccStaticFilesConfig(StaticFilesConfig):
         'CVS', '.*', '*~',
         # Added by TACC
         # WARNING: Ignores these from non-TACC static's also
-        'src', 'README.md'
+        'README.md', "*src/*.css"
     ]

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -323,6 +323,15 @@ ui_demo_dir = os.path.join(BASE_DIR, 'taccsite_ui', 'dist')
 if os.path.exists(ui_demo_dir):
     STATICFILES_DIRS += (('ui', ui_demo_dir),)
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}
+
 # User Uploaded Files Location.
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(DATA_DIR, 'media')

--- a/taccsite_cms/static/djangocms_text_ckeditor/ckeditor/contents.css
+++ b/taccsite_cms/static/djangocms_text_ckeditor/ckeditor/contents.css
@@ -1,3 +1,3 @@
-@import url("/static/djangocms_text_ckeditor/ckeditor/contents.original.css");
+@import url("./contents.original.css");
 
-@import url("/static/site_cms/css/build/core-styles.wysiwyg.css");
+@import url("../../site_cms/css/build/core-styles.wysiwyg.css");


### PR DESCRIPTION
## Overview

Edit CSS so that Django and Vite do not use it unexpectedly.

> [!WARNING]
> This change causes errors collecting them as static files, so all `collectstatic` commands have had `--ignore` param added to avoid the error. This is intended to be a **temporary** workaround.

## Related

- [TUP-677](https://tacc-main.atlassian.net/browse/TUP-677)

<details><summary>Pull Requests</summary>

- https://github.com/TACC/tup-ui/pull/400 requires:
    - https://github.com/TACC/Core-Styles/pull/285
    - https://github.com/TACC/Core-CMS/pull/778 requires:
        - https://github.com/TACC/Core-CMS-Resources/pull/197
        - https://github.com/TACC/Core-Styles/pull/285

</details>

## Changes

### CSS
- **refactored** comments that suggest to `@import` code
- **refactored** absolute `/static` paths to be relative
- **changed** core-styles version

### Static Files / Cache
- **added** `STORAGES` setting to "fix a cache problem"
- **changed** static file config to ignore only `*src/*.css"` not all of `src`
- **documented** additional parameter for `collectstatic` command

## Testing

0. **Uncertain.** See https://github.com/TACC/tup-ui/pull/398.
1. Verify in a WYSIWYG editor that an instance of "Styles" → "Block Styles" → "Island" is styled.

## UI

<img width="960" alt="c-island" src="https://github.com/TACC/Core-CMS/assets/62723358/18fcfd13-3be2-4e7e-9972-dd481a1deb81">

## Notes

### How to FIx The Issue w/ Font

> In some of these font files `url(fonts/...)` needs to be `url(../fonts/..)` e.g. https://github.com/TACC/Core-Styles/blob/v2.22.4/dist/settings/font.css.
> — (paraphrased) @jarosenb

> The paths to fonts have — in the past — been manipulated via https://github.com/TACC/Core-Styles/blob/v2.22.4/src/.postcssrc.base.yml#L37-L43.
> — (paraphrased) @wesleyboar 
