### PR TITLE
Revert "chore: tup-677 css/django/vite interoperability (#778)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "taccsite_custom"]
 	path = taccsite_custom
 	url = git@github.com:TACC/Core-CMS-Resources.git
-	branch = chore/tup-677-css-django-vite-interoperability
+	branch = task/37-per-site-assets

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Set up a new local CMS instance.
     python manage.py createsuperuser
     # To use default "Username" and skip "Email address", press Enter at both prompts.
     # At "Password" prompts, you may use an easy-to-remember password.
-    python manage.py collectstatic --no-input --ignore assets/*/font*.css
+    python manage.py collectstatic --no-input
 
     ```
 
@@ -138,7 +138,7 @@ make start
 | Node dependencies | `npm ci` |
 | CSS stylesheets | `npm run build:css` |
 | UI Demo | `npm run build:ui-demo` |
-| Assets e.g.<br><small>images, stylesheets, JavaScript</small> | `docker exec -it core_cms sh -c "python manage.py collectstatic --no-input --ignore assets/*/font*.css"` |
+| Assets e.g.<br><small>images, stylesheets, JavaScript</small> | `docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"` |
 | Python models | `docker exec -it core_cms sh -c "python manage.py migrate"` |
 
 ## Develop Project

--- a/docs/develop-custom-project.md
+++ b/docs/develop-custom-project.md
@@ -44,7 +44,7 @@ To compile CSS static files:
 
 ```sh
 npm run build:css --project="custom_project_dir"
-docker exec -it core_cms sh -c "python manage.py collectstatic --no-input --ignore assets/*/font*.css"
+docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"
 
 ```
 

--- a/docs/develop-project.md
+++ b/docs/develop-project.md
@@ -45,7 +45,7 @@ This allows use of future-proof CSS via [Core Styles].
 3. [Collect Static Files](#collect-static-files):
 
     ```sh
-    docker exec -it core_cms sh -c "python manage.py collectstatic --no-input --ignore assets/*/font*.css"
+    docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"
     ```
 
 ## Collect Static Files
@@ -53,7 +53,7 @@ This allows use of future-proof CSS via [Core Styles].
 Whenever files in a `static/` directory are changed, the CMS must be manually told to serve them:
 
 ```sh
-docker exec -it core_cms sh -c "python manage.py collectstatic --no-input --ignore assets/*/font*.css"
+docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"
 ```
 
 > **Note**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
+        "@tacc/core-styles": "^2.22.3",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.22.4",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#fd68d7ad65e2cfb4352e5fe193e766b51de18524",
-      "license": "MIT",
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.3.tgz",
+      "integrity": "sha512-niE9F32p/eoywM+cdeHAaN+kIp0GbatBH+4KyRvBFxifKFxfAhnZljFZtGo6NxGHI6PRICjMoNZn+kMBWmDr/g==",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -8728,8 +8728,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#fd68d7ad65e2cfb4352e5fe193e766b51de18524",
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.22.3.tgz",
+      "integrity": "sha512-niE9F32p/eoywM+cdeHAaN+kIp0GbatBH+4KyRvBFxifKFxfAhnZljFZtGo6NxGHI6PRICjMoNZn+kMBWmDr/g==",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#chore/tup-677-css-django-vite-interoperability",
+    "@tacc/core-styles": "^2.22.3",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",

--- a/taccsite_cms/django/contrib/staticfiles_custom/apps.py
+++ b/taccsite_cms/django/contrib/staticfiles_custom/apps.py
@@ -12,5 +12,5 @@ class TaccStaticFilesConfig(StaticFilesConfig):
         'CVS', '.*', '*~',
         # Added by TACC
         # WARNING: Ignores these from non-TACC static's also
-        'README.md', "*src/*.css"
+        'src', 'README.md'
     ]

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -323,15 +323,6 @@ ui_demo_dir = os.path.join(BASE_DIR, 'taccsite_ui', 'dist')
 if os.path.exists(ui_demo_dir):
     STATICFILES_DIRS += (('ui', ui_demo_dir),)
 
-STORAGES = {
-    "default": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
-    },
-    "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
-    },
-}
-
 # User Uploaded Files Location.
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(DATA_DIR, 'media')

--- a/taccsite_cms/static/djangocms_text_ckeditor/ckeditor/contents.css
+++ b/taccsite_cms/static/djangocms_text_ckeditor/ckeditor/contents.css
@@ -1,3 +1,3 @@
-@import url("./contents.original.css");
+@import url("/static/djangocms_text_ckeditor/ckeditor/contents.original.css");
 
-@import url("../../site_cms/css/build/core-styles.wysiwyg.css");
+@import url("/static/site_cms/css/build/core-styles.wysiwyg.css");


### PR DESCRIPTION
This reverts commit 8610b2c558e504887d24d63c8e9e89daa15766b8.

## Overview

The Core-CMS and Core-CMS-Resources `tup-677 css/django/vite interoperability` branches are not ready to be merged. The Core-CMS-Resources changes break deploy of Frontera (and probably all CMS's).