### PR TITLE
fix: CMS c-button--as-link has button padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^2.23.0",
+        "@tacc/core-styles": "github:tacc/core-styles#fix/cms-button-as-a-link-has-button-padding",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -482,8 +482,8 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.23.0.tgz",
-      "integrity": "sha512-RDPDHn9Bd+EPqgxaaF0k4kV+Mgk0plC3ngyfQeaUpEleOfi6wSiBIZOvzZqqWhLQtEKdf6QZ4tFT0EUsLF1Akg==",
+      "resolved": "git+ssh://git@github.com/tacc/core-styles.git#c6310ac2b93da9707ca4878b75b27616dfdef2fa",
+      "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -1218,9 +1218,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001571",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001571.tgz",
-      "integrity": "sha512-tYq/6MoXhdezDLFZuCO/TKboTzuQ/xR5cFdgXPfDtM7/kchBO3b4VWghE/OAi/DV7tTdhmLjZiZBZi1fA/GheQ==",
+      "version": "1.0.30001576",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1839,9 +1839,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.9.1.tgz",
-      "integrity": "sha512-fqy6ZnNfpb8qAvTT0qijWyTsUmYThsDX2F2ctMG4ceI7mI4DtsMILSiMBiuuDnVIYTyWvCctdp9Nb08p/6m2SQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.10.0.tgz",
+      "integrity": "sha512-yGZ5tmA57gWh/uvdQBHs45wwFY0IBh3ypABk5sEubPBPSzXzkNgsWReqx7gdx6uhC+QoFBe+V8JwBB9/hQ6cIA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2217,9 +2217,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.616",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.616.tgz",
-      "integrity": "sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg==",
+      "version": "1.4.628",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.628.tgz",
+      "integrity": "sha512-2k7t5PHvLsufpP6Zwk0nof62yLOsCf032wZx7/q0mv8gwlXjhcxI3lz6f0jBr0GrnWKcm3burXzI3t5IrcdUxw==",
       "peer": true
     },
     "node_modules/emoji-regex": {
@@ -4952,9 +4952,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6196,9 +6196,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
+      "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
       "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8750,9 +8750,8 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.23.0.tgz",
-      "integrity": "sha512-RDPDHn9Bd+EPqgxaaF0k4kV+Mgk0plC3ngyfQeaUpEleOfi6wSiBIZOvzZqqWhLQtEKdf6QZ4tFT0EUsLF1Akg==",
+      "version": "git+ssh://git@github.com/tacc/core-styles.git#c6310ac2b93da9707ca4878b75b27616dfdef2fa",
+      "from": "@tacc/core-styles@github:tacc/core-styles#fix/cms-button-as-a-link-has-button-padding",
       "requires": {}
     },
     "@trysound/sax": {
@@ -9286,9 +9285,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001571",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001571.tgz",
-      "integrity": "sha512-tYq/6MoXhdezDLFZuCO/TKboTzuQ/xR5cFdgXPfDtM7/kchBO3b4VWghE/OAi/DV7tTdhmLjZiZBZi1fA/GheQ==",
+      "version": "1.0.30001576",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
       "peer": true
     },
     "chalk": {
@@ -9733,9 +9732,9 @@
       "peer": true
     },
     "cssdb": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.9.1.tgz",
-      "integrity": "sha512-fqy6ZnNfpb8qAvTT0qijWyTsUmYThsDX2F2ctMG4ceI7mI4DtsMILSiMBiuuDnVIYTyWvCctdp9Nb08p/6m2SQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.10.0.tgz",
+      "integrity": "sha512-yGZ5tmA57gWh/uvdQBHs45wwFY0IBh3ypABk5sEubPBPSzXzkNgsWReqx7gdx6uhC+QoFBe+V8JwBB9/hQ6cIA==",
       "peer": true
     },
     "cssesc": {
@@ -10005,9 +10004,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.616",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.616.tgz",
-      "integrity": "sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg==",
+      "version": "1.4.628",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.628.tgz",
+      "integrity": "sha512-2k7t5PHvLsufpP6Zwk0nof62yLOsCf032wZx7/q0mv8gwlXjhcxI3lz6f0jBr0GrnWKcm3burXzI3t5IrcdUxw==",
       "peer": true
     },
     "emoji-regex": {
@@ -12023,9 +12022,9 @@
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg=="
     },
     "postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "peer": true,
       "requires": {
         "nanoid": "^3.3.7",
@@ -12772,9 +12771,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
+      "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
       "peer": true,
       "requires": {
         "cssesc": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^2.23.0",
+    "@tacc/core-styles": "github:tacc/core-styles#fix/cms-button-as-a-link-has-button-padding",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",


### PR DESCRIPTION
## Overview

Update Core-Styles to remove padding from a `c-button--as-link` on CMS.

## Related

- caused by #782
- requires https://github.com/TACC/Core-Styles/pull/298

## Changes

- **changed** core-styles version

## Testing

0. Install [TACC/Core-Styles#298](https://github.com/TACC/Core-Styles/pull/298) into a CMS.
1. Create/Edit a page.
2. Add Text plugin instance with Source code for three types of buttons:
    ```html
    <p><button class="c-button c-button--primary">Button</button></p>
    <p><button class="c-button c-button--as-link">Button as a Link</button></p>
    <p><a class="c-button c-button--primary" href="#">Link as a Button</a></p>
    ```
3. Verify "Button" looks like [a primary button](https://tacc.utexas.edu/static/ui/components/detail/c-button--primary.html) using a `<button>`.
4. Verify "Button as a Link" looks like [a link using a `<button>`](https://tacc.utexas.edu/static/ui/components/detail/c-button--as-link.html).
4. Verify "Link as a Button" looks like [a primary button](https://tacc.utexas.edu/static/ui/components/detail/c-button--primary.html) using a `<a>`.

## UI

| Before | After |
| - | - |
| <img width="960" alt="before" src="https://github.com/TACC/Core-CMS/assets/62723358/278062fb-d9df-43cf-837a-bab4c2a56113"> | <img width="960" alt="after" src="https://github.com/TACC/Core-CMS/assets/62723358/c6c74e71-8530-4920-9ed1-463fd0f8d3c9"> |

### Before

https://github.com/TACC/Core-CMS/assets/62723358/3a3565a8-fde8-4d67-9e2f-9c5293b93350

### After

https://github.com/TACC/Core-CMS/assets/62723358/5885913c-9090-4372-98d8-051d404145a4