### PR TITLE
test: use AutoField instead of BigAutoField to avoid migrations

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -44,7 +44,7 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # whether the session cookie should be secure (https:// only)
 SESSION_COOKIE_SECURE = True
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 ########################
 # DATABASE SETTINGS


### PR DESCRIPTION
## Overview

Avoid migrations by using `AutoField` instead of `BigAutoField`.

[Background.](https://github.com/TACC/Core-CMS/pull/787#discussion_r1453963155)

## Related

- alternative to #787

## Changes

- **changed** `DEFAULT_AUTO_FIELD` from `BigAutoField` to `AutoField`

## Testing

1. check out `main` branch
2. `build` new image
4. `start` new image
6. in Docker, `… makemigrations`
7. save output
8. check out **new** branch
    - Core-CMS `deps/python-3.11`
    - TUP-UI:`chore/collectstatic-on-build`
2. `build` new image
4. `start` new image
9. in Docker, `… makemigrations`
10. save output
11. compare output

## <del>UI</del> <ins>Results</ins>

| | Core | TUP |
| - | - | - |
| before | [Core.main.-.makemigrations.log](https://github.com/TACC/Core-CMS/files/13980820/Core.main.-.makemigrations.log) | [TUP.main.-.makemigrations.log](https://github.com/TACC/Core-CMS/files/13980819/TUP.main.-.makemigrations.log) |
| `BigAutoField` | [Core.python-3.11.-BigAutoField-.makemigrations.log](https://github.com/TACC/Core-CMS/files/13980822/Core.python-3.11.-BigAutoField-.makemigrations.log) | [TUP.collectstatic-on-build.-BigAutoField-.makemigrations.log](https://github.com/TACC/Core-CMS/files/13980823/TUP.collectstatic-on-build.-BigAutoField-.makemigrations.log) |
| `AutoField` | [Core.python-3.11.-AutoField-.makemigrations.log](https://github.com/TACC/Core-CMS/files/13980821/Core.python-3.11.-AutoField-.makemigrations.log) | [TUP.collectstatic-on-build.-AutoField-.makemigrations.log](https://github.com/TACC/Core-CMS/files/13980818/TUP.collectstatic-on-build.-AutoField-.makemigrations.log) | 
