### PR TITLE
feat: TV3-181/cmd-79 change FAVICON & LOGO prefix

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -266,7 +266,7 @@ BRANDING = [TACC_BRANDING, UTEXAS_BRANDING]
 # TACC: LOGO & FAVICON
 ########################
 
-TACC_LOGO = {
+PORTAL_LOGO = {
     "img_file_src": "site_cms/img/org_logos/portal.png",
     "is_remote": False,
     "img_class": "", # additional class names
@@ -274,9 +274,9 @@ TACC_LOGO = {
     "link_target": "_self",
     "img_alt_text": "Portal Logo",
     "img_crossorigin": "anonymous",
-} # To hide logo, set `TACC_LOGO = False`
+} # To hide logo, set `PORTAL_LOGO = False`
 
-TACC_FAVICON = {
+PORTAL_FAVICON = {
     "img_file_src": "site_cms/img/favicons/favicon.ico",
     "is_remote": False
 }
@@ -718,7 +718,7 @@ if 'LOGO' not in locals():
 if 'FAVICON' not in locals():
     FAVICON = False
 else:
-    TACC_FAVICON = FAVICON
+    PORTAL_FAVICON = FAVICON
 
 # Export expected settings
 SETTINGS_EXPORT = [
@@ -726,8 +726,8 @@ SETTINGS_EXPORT = [
     'BRANDING',
     'LOGO',       # deprecated
     'FAVICON',    # deprecated
-    'TACC_LOGO',
-    'TACC_FAVICON',
+    'PORTAL_LOGO',
+    'PORTAL_FAVICON',
     'INCLUDES_CORE_PORTAL',
     'INCLUDES_PORTAL_NAV',
     'INCLUDES_SEARCH_BAR',

--- a/taccsite_cms/templates/assets_custom.html
+++ b/taccsite_cms/templates/assets_custom.html
@@ -12,7 +12,7 @@ FAQ: IF a script or style is better cached with markup, THEN:
 
 
 <!-- Custom Site Assets: Favicon. -->
-{% with settings.TACC_FAVICON as favicon %}
+{% with settings.PORTAL_FAVICON as favicon %}
 <link rel="icon" href="{% if favicon.is_remote %}{{ favicon.img_file_src }}{% else %}{% static favicon.img_file_src %}{% endif %}" type="image/x-icon" />
 {% endwith %}
 

--- a/taccsite_cms/templates/header_logo.html
+++ b/taccsite_cms/templates/header_logo.html
@@ -15,7 +15,7 @@
 
 {% else %}
 
-{% with settings.TACC_LOGO as logo %}
+{% with settings.PORTAL_LOGO as logo %}
   <a
     id="header-logo"
     class="navbar-brand {{className}}"


### PR DESCRIPTION
## Overview / Changes

Change prefixes on renamed settings.

| Before | After |
| - | - |
| `TACC_FAVICON`</br>`TACC_LOGO` | `PORTAL_FAVICON`</br>`PORTAL_LOGO` |

## Related

- [TV3-181](https://tacc-main.atlassian.net/browse/TV3-181)
- [CMD-79](https://tacc-main.atlassian.net/browse/CMD-79)
- changes prefix from https://github.com/TACC/Core-CMS/pull/783/

## Testing

0. [x] [Build new CMS image.](https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/1373)
1. [x] [Update Core-Portal-Deployments to use new prefix for PTDataX.](https://github.com/TACC/Core-Portal-Deployments/commit/a744485)
2. [x] [Deploy PTDataX Pre-Prod.](https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/3783/)
3. [x] [Verify logo and favicon are unchanged / still work.](https://pprd.ptdatax.tacc.utexas.edu/)

## UI

<img width="960" alt="pprd ptdatax" src="https://github.com/TACC/Core-CMS/assets/62723358/3456a2e1-40db-4eac-94be-d217ce345c11">