### PR TITLE
Quick: Update Makefile to support git branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ PROJECT_NAME := $(shell cat ./project_name.var)
 NEEDS_DEMO := $(shell cat ./needs_demo.var)
 BUILD_ID := $(shell git describe --always)
 
+# NOTE: The `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists.
+# NOTE: Special characters in `DOCKER_IMAGE_BRANCH` are replaced with spaces.
+DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g')
+
 .PHONY: build
 build:
 	docker-compose -f ./docker-compose.yml build
@@ -20,6 +24,8 @@ build-full:
 		--build-arg NEEDS_DEMO="$(NEEDS_DEMO)" \
 		-f ./Dockerfile .
 
+	docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE_BRANCH)
+
 .PHONY: example
 example:
 	docker-compose -f ./docker-compose.example.yml up
@@ -27,6 +33,7 @@ example:
 .PHONY: publish
 publish:
 	docker push $(DOCKER_IMAGE)
+	docker push $(DOCKER_IMAGE_BRANCH)
 
 .PHONY: publish-latest
 publish-latest:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NEEDS_DEMO := $(shell cat ./needs_demo.var)
 BUILD_ID := $(shell git describe --always)
 
 # NOTE: The `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists.
-# NOTE: Special characters in `DOCKER_IMAGE_BRANCH` are replaced with spaces.
+# NOTE: Special characters in `DOCKER_IMAGE_BRANCH` are replaced with dashes.
 DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g')
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
 
-PROJECT_NAME := $(shell cat ./project_name.var)
-NEEDS_DEMO := $(shell cat ./needs_demo.var)
-BUILD_ID := $(shell git describe --always)
-
 # NOTE: The `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists.
 # NOTE: Special characters in `DOCKER_IMAGE_BRANCH` are replaced with dashes.
 DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g')
+
+PROJECT_NAME := $(shell cat ./project_name.var)
+NEEDS_DEMO := $(shell cat ./needs_demo.var)
+BUILD_ID := $(shell git describe --always)
 
 .PHONY: build
 build:


### PR DESCRIPTION
## Overview

This PR adds a new variable to the `Makefile` context: `DOCKER_IMAGE_BRANCH`

This variable will correspond to the git tag for the commit if it exists, else the branch name for the commit, with special characters replaced with `-`.


