### PR TITLE
feat: TUP-707 do not show "TAG - " in news filter

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -57,6 +57,8 @@ Styleguide Components.DjangoCMS.Blog.App
 .app-blog .tags       { grid-area: tags }
 .app-blog .links      { grid-area: link }
 
+:--article-list h1 span { display: none }
+
 .app-blog ul.post-detail {
   list-style: none;
 

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -22,12 +22,27 @@
         {% endif %}
         {# /TACC #}
         {# /TACC #}
-        {% if author %}{% trans "Articles by" %} {{ author.get_full_name }}
-        {% elif archive_date %}{% trans "Archive" %} &ndash; {% if month %}{{ archive_date|date:'F' }} {% endif %}{{ year }}
-        {% elif tagged_entries %}{% trans "Tag" %} &ndash; {{ tagged_entries|capfirst }}
-        {% elif category %}{% trans "Category" %} &ndash; {{ category }}
+        {# TACC (reformat headings): #}
+        {% if author %}
+          {% trans "Articles by" %}
+          {{ author.get_full_name }}
+        {% elif archive_date %}
+          {% trans "Archive" %} |
+          <span>{% trans "Archive" %}</span>
+          {% if month %}{{ archive_date|date:'F' }} {% endif %}{{ year }}
+        {% elif tagged_entries %}
+          {% trans "Tag" %} |
+          <span>{% trans "Tag" %}</span>
+          {{ tagged_entries|capfirst }}
+        {% elif category %}
+          {% trans "Category" %} |
+          <span>{% trans "Category" %}</span>
+          {{ category }}
         {# TACC (add default heading): #}
-        {% else %}{% trans "News" %}{% endif %}
+        {% else %}
+          {% trans "News" %}
+        {% endif %}
+        {# /TACC #}
         {# /TACC #}
         {# TACC (use greater heading level): #}
         {# TACC (do not use large header until core-styles.cms.css): #}


### PR DESCRIPTION
## Overview

Do not show "TAG - " or "ARCHIVE - " et cetera in filtered News.

## Related

- [TUP-707](https://tacc-main.atlassian.net/browse/TUP-707)

## Changes

- **changed** whitespace in template
- **added** markup to wrap text to hide
- **added** css to hide text

## Testing

1. …

## UI

…

<!--
## Notes

…
-->
