### PR TITLE
TUP-703 TACC Home Banner Links Open in New Window

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -58,7 +58,8 @@ export default function findLinksAndSetTargets(options) {
 
       const isInternalLink = link.host === baseDocumentHost || link.host === baseDocumentHostWithWWW
 
-      if (!isInternalLink || isMailto || shouldForceSetTarget ) {  
+      //shouldForceSetTarget could be used in this if statement if passing in options.
+      if (!isInternalLink || isMailto ) {    
         if (link.target !== '_blank') {
           link.target = '_blank';
           if (SHOULD_DEBUG) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -5,12 +5,6 @@
 const SHOULD_DEBUG = window.DEBUG;
 
 /**
- * Function to perform after setting link target
- * @callback setTargetCallback
- * @param {HTMLElement} link
- */
-
-/**
  * Set external links (automatically discovered) to open in new tab
  */
 export default function findLinksAndSetTargets() {
@@ -27,7 +21,7 @@ export default function findLinksAndSetTargets() {
 
       const isInternalLink = link.host === baseDocumentHost || link.host === baseDocumentHostWithSubdomain
 
-      if (!isInternalLink || isMailto ) {    
+      if (!isInternalLink || isMailto ) {
         if (link.target !== '_blank') {
           link.target = '_blank';
           if (SHOULD_DEBUG) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -1,37 +1,4 @@
-/**
- * Whether to log debug info to console
- * @const {string}
- */
-const SHOULD_DEBUG = window.DEBUG;
-
-/**
- * Function to perform after setting link target
- * @callback setTargetCallback
- * @param {HTMLElement} link
- */
-
-/**
- * Set external links (automatically discovered) to open in new tab
- * @param {object} [options] - Optional parameters
- * @param {array.<string>} [options.pathsToExernalSite=[]] - (DEPRECATED) A list of relative URL paths that should be treated like external URLs
- * @param {array.<string|RegExp>} [options.pathsToForceSetTarget=[]] - A list of relative URL paths (or patterns) that should trigger setting a target
- * @param {HTMLElement|Document} [options.scopeElement=document] - The element within which to search for links
- * @param {setTargetCallback} [options.setTargetCallback] - A callback for after a target is set
- */
-export default function findLinksAndSetTargets(options) {
-  const defaults = {
-    target: '_blank',
-    pathsToExernalSite: [],
-    pathsToForceSetTarget: [],
-    scopeElement: document
-  }
-  const {target, pathsToExernalSite, scopeElement, setTargetCallback} = {...defaults, ...options};
-  let {pathsToForceSetTarget} = {...defaults, ...options};
-
-  if ( pathsToExernalSite.length && ! pathsToForceSetTarget.length ) {
-    pathsToForceSetTarget = pathsToExernalSite;
-  }
-
+export default function findLinksAndSetTargets() {
   const links = scopeElement.getElementsByTagName('a');
   const baseDocumentHost = document.location.host;
   const baseDocumentHostWithSubdomain= `www.${baseDocumentHost}`;

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -33,11 +33,11 @@ export default function findLinksAndSetTargets(options) {
   }
 
   const links = scopeElement.getElementsByTagName('a');
+  const baseDocumentHost = document.location.host;
+  const baseDocumentHostWithWWW = `www.${baseDocumentHost}`;
+
   [ ...links ].forEach( function setTarget(link) {
       if ( ! link.href) {
-        return false;
-      }
-      if (link.href.indexOf('javascript') === 0) {
         return false;
       }
 
@@ -55,14 +55,10 @@ export default function findLinksAndSetTargets(options) {
         }
         return shouldForce;
       });
-      // FAQ: I am literally double-checking, because I don't trust JavaScript
-      const isExternal = (link.origin !== document.location.origin);
-      const isInternal = (link.host === document.location.host);
-      const shouldSetTarget = shouldForceSetTarget || (
-          ! isInternal && isExternal && ! isMailto
-      );
 
-      if ( shouldSetTarget ) {  
+      const isInternalLink = link.host === baseDocumentHost || link.host === baseDocumentHostWithWWW
+
+      if (!isInternalLink || isMailto || shouldForceSetTarget ) {  
         if (link.target !== '_blank') {
           link.target = '_blank';
           if (SHOULD_DEBUG) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -34,7 +34,7 @@ export default function findLinksAndSetTargets(options) {
 
   const links = scopeElement.getElementsByTagName('a');
   const baseDocumentHost = document.location.host;
-  const baseDocumentHostWithWWW = `www.${baseDocumentHost}`;
+  const baseDocumentHostWithSubdomain= `www.${baseDocumentHost}`;
 
   [ ...links ].forEach( function setTarget(link) {
       if ( ! link.href) {
@@ -42,23 +42,9 @@ export default function findLinksAndSetTargets(options) {
       }
 
       const isMailto = (link.href.indexOf('mailto:') === 0);
-      const shouldForceSetTarget = pathsToForceSetTarget.some(path => {
-        let shouldForce;
-        if (path instanceof RegExp) {
-          shouldForce = path.test(link.pathname);
-        }
-        if (typeof path === 'string') {
-          shouldForce = _doPathsMatch(path, link.pathname);
-        }
-        if (SHOULD_DEBUG && shouldForce) {
-          console.debug(`Path "${link.pathname}" matches "${path}"`);
-        }
-        return shouldForce;
-      });
 
-      const isInternalLink = link.host === baseDocumentHost || link.host === baseDocumentHostWithWWW
+      const isInternalLink = link.host === baseDocumentHost || link.host === baseDocumentHostWithSubdomain
 
-      //shouldForceSetTarget could be used in this if statement if passing in options.
       if (!isInternalLink || isMailto ) {    
         if (link.target !== '_blank') {
           link.target = '_blank';
@@ -74,22 +60,4 @@ export default function findLinksAndSetTargets(options) {
         }
       }
   });
-}
-
-/**
- * Does redirect path match link path (ignoring "/" link path)
- * @param {string} redirectPath - A path known to redirect to an external site
- * @param {string} testLinkPath - A path found on the page being updated
- */
-function _doPathsMatch(redirectPath, testLinkPath) {
-  if (testLinkPath === '/') {
-    return false;
-  }
-
-  const isMatch = redirectPath === testLinkPath
-    || redirectPath === testLinkPath.slice(1)
-    || redirectPath === testLinkPath.slice(0, -1)
-    || redirectPath === testLinkPath.slice(1).slice(0, -1);
-
-  return isMatch;
 }

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -1,3 +1,18 @@
+/**
+ * Whether to log debug info to console
+ * @const {string}
+ */
+const SHOULD_DEBUG = window.DEBUG;
+
+/**
+ * Function to perform after setting link target
+ * @callback setTargetCallback
+ * @param {HTMLElement} link
+ */
+
+/**
+ * Set external links (automatically discovered) to open in new tab
+ */
 export default function findLinksAndSetTargets() {
   const links = scopeElement.getElementsByTagName('a');
   const baseDocumentHost = document.location.host;


### PR DESCRIPTION
## Overview

Prevent banner links from opening in new windows.

## Related

- [TUP-703](https://tacc-main.atlassian.net/browse/TUP-703)

## Changes

Changes what is considered an external link. Looks for the host name with or without www., then opens in new window if it isn't matching to the document's host.

## Testing

A) If you'd like to troubleshoot in TUP-UI Repo:
1. Comment out code on Core CMS
2. Follow https://github.com/TACC/Core-CMS/wiki/Locally-Develop-CMS-and-TUP-CMS
3. Make snippet with code in TUP -> look at attachment for example
4. Add snippet to Django and import it in the footer

B) If you'd like to just test these changes in TUP-UI using Core_CMS
1. Follow https://github.com/TACC/Core-CMS/wiki/Locally-Develop-CMS-and-TUP-CMS

## UI

…

## Notes 

The `shouldForceSetTarget` function below:

```
      const shouldForceSetTarget = pathsToForceSetTarget.some(path => {
        let shouldForce;
        if (path instanceof RegExp) {
          shouldForce = path.test(link.pathname);
        }
        if (typeof path === 'string') {
          shouldForce = _doPathsMatch(path, link.pathname);
        }
        if (SHOULD_DEBUG && shouldForce) {
          console.debug(`Path "${link.pathname}" matches "${path}"`);
        }
        return shouldForce;
      });
```

does not allow external links to open in a new window. 

For instance. If you're in localhost, and have a `tacc.utexas.edu` link - it should open in a new window because it doesn't match the host. 

 _This might be something you test in tup-ui repo using the A) testing steps above_
