### PR TITLE
hotfix: setTargetForExternalLinks missing scopeElement

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -8,7 +8,7 @@ const SHOULD_DEBUG = window.DEBUG;
  * Set external links (automatically discovered) to open in new tab
  */
 export default function findLinksAndSetTargets() {
-  const links = scopeElement.getElementsByTagName('a');
+  const links = document.getElementsByTagName('a');
   const baseDocumentHost = document.location.host;
   const baseDocumentHostWithSubdomain= `www.${baseDocumentHost}`;
 


### PR DESCRIPTION
## Overview

Fix error with `setTargetForExternalLinks.js` change from #805

> Uncaught ReferenceError: scopeElement is not defined
>     at findLinksAndSetTargets (setTargetForExternalLinks.js:11:17)
>     at software-list/:928:3

## Related

- fixes #805

## Changes

- **replaced** `scopeElement` with `document`

## Testing

1. Copy edited script to https://github.com/TACC/tup-ui clone at `/apps/tup-cms/src/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js`.
2. On TUP-UI clone, ran `npx nx build tup-cms`.
3. On TUP-UI clone, ran `npx nx serve tup-cms`.
4. On TUP-UI clone, ran `docker exec -it tup_cms sh -c "python manage.py collectstatic --no-input --clear --ignore assets/*/font*.css"`.

## UI

| before | after |
| - | - |
| <img width="960" alt="before" src="https://github.com/TACC/Core-CMS/assets/62723358/749051ef-7bb7-4582-9497-c30f5c0f5350"> | <img width="960" alt="after" src="https://github.com/TACC/Core-CMS/assets/62723358/6a559a1a-44ab-450b-8e74-060d47c28156"> |