### PR TITLE
fix: tup-694 abs URLs to same domain should be rel

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -5,7 +5,9 @@
 const SHOULD_DEBUG = window.DEBUG;
 
 /**
- * Set external links (automatically discovered) to open in new tab
+ * Make links with absolute URLs open in new tab, and:
+ * - add accessible markup
+ * - fix absolute URLs that should be relative paths
  */
 export default function findLinksAndSetTargets() {
   const links = document.getElementsByTagName('a');
@@ -18,10 +20,10 @@ export default function findLinksAndSetTargets() {
       }
 
       const isMailto = (link.href.indexOf('mailto:') === 0);
-
+      const isAbsolute = (link.href.indexOf('http') === 0);
       const isInternalLink = link.host === baseDocumentHost || link.host === baseDocumentHostWithSubdomain
 
-      if (!isInternalLink || isMailto ) {
+      if (!isInternalLink || isMailto) {
         if (link.target !== '_blank') {
           link.target = '_blank';
           if (SHOULD_DEBUG) {
@@ -31,9 +33,11 @@ export default function findLinksAndSetTargets() {
         if (link.target === '_blank') {
           link.setAttribute('aria-description', 'Opens in new window.');
         }
-        if (typeof setTargetCallback === 'function') {
-          setTargetCallback( link );
-        }
+      }
+
+      // Links w/ absolute URL to page on same domain should use relative path
+      if (isAbsolute && isInternalLink) {
+        link.href = link.pathname;
       }
   });
 }

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -37,7 +37,7 @@ export default function findLinksAndSetTargets() {
     }
 
     // Links w/ absolute URL to page on same domain should use relative path
-    if ( isAbsolute && isInternalLink ) {
+    if ( isAbsolute && isSameHost ) {
       link.href = link.pathname;
     }
   });

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -10,7 +10,7 @@ const SHOULD_DEBUG = window.DEBUG;
  * - fix absolute URLs that should be relative paths
  */
 export default function findLinksAndSetTargets() {
-  const links = document.getElementsByTagName('a');
+  const links = document.querySelectorAll('body > :is(header, main, footer) a');
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 


### PR DESCRIPTION
## Overview

Make `setTargetForExternalLinks` also change link URL to relative if it is absolute yet on same host.

## Related

- fixes [TUP-694](https://tacc-main.atlassian.net/browse/TUP-694)

## Changes

- **added** feature to script `setTargetForExternalLinks`

## Testing

Set up:

1. Check out branch `fix/tup-694-absolute-urls-to-same-domain-should-be-relative`.
2. Update local CMS with new code (e.g. rebuild or "collectstatic").

    <details><summary>Commands</summary>

    - **either** `make stop && make build && make start`
    -  **or** `docker-compose -f ./docker-compose.dev.yml up --detach && docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"`

    </details>

3. Open CMS e.g. http://localhost:8000/.

Test fix:

4. Create/Identify a link that **both** is to a different page on the same host **and** uses an absolute URL.
5. Verify markup of link has `href` with absolute path.
6. Refresh page (to run JavaScript on new markup). Verify markup of link has `href` with a relative path.
7. Click link. Verify page still opens.

## UI

| 4 | 5 | 6 | 7 |
| - | - | - | - |
| <img width="1280" alt="4 create link" src="https://github.com/TACC/Core-CMS/assets/62723358/ae7451c5-3eb3-40fb-9d90-bf15ce34157c"> | <img width="1280" alt="5 markup has absolute url" src="https://github.com/TACC/Core-CMS/assets/62723358/e3231630-2dd3-4e1a-9b12-4be8cfced825"> | <img width="1280" alt="6 markup has relative link" src="https://github.com/TACC/Core-CMS/assets/62723358/a2184b3f-e0f4-4de7-b4c4-8c5f8138747b"> | <img width="1280" alt="7 new link opens" src="https://github.com/TACC/Core-CMS/assets/62723358/5f1404e5-5c91-4185-8b81-34b559be90ea"> |
