### PR TITLE
feat: tup-667 add instagram share platforms

### DIFF
--- a/taccsite_cms/templates/share_on_social.html
+++ b/taccsite_cms/templates/share_on_social.html
@@ -23,6 +23,13 @@
     </svg>
   </a>
   {% endif %}
+  {% if 'instagram' in platforms %}
+  <a href="https://www.instagram.com/?url={{ url }}" target="_blank" class="logos__linkedin">
+    <svg viewbox="0 0 25 25">
+      <use href="/static/site_cms/img/org_logos/instagram.svg#instagram-icon"></use>
+    </svg>
+  </a>
+  {% endif %}
   {% if 'email' in platforms %}
   <a href="mailto:?body={{ url }}" target="_blank" class="logos__email">
     <svg viewbox="0 0 25 25">


### PR DESCRIPTION
## Overview

Add "Instagram" to social media platforms.

## Related

- [TUP-667](https://tacc-main.atlassian.net/browse/TUP-667)

## Changes

- **added** `instagram` to `share_on_social.html`

## Testing / UI

N/m. Task cancelled.