### PR TITLE
feat: tup-584 re-order share platforms

### DIFF
--- a/taccsite_cms/templates/share_on_social.html
+++ b/taccsite_cms/templates/share_on_social.html
@@ -9,27 +9,29 @@
   {% block text_before %}
   <span class="logos__text-before">share this:</span>
   {% endblock text_before %}
-  {% if 'facebook' in platforms %}
-  <a href="https://www.facebook.com/sharer/sharer.php?u={{ url }}" target="_blank" class="logos__facebook">
-    <svg viewbox="0 0 25 25">
-      <use href="/static/site_cms/img/org_logos/facebook.svg#facebook-icon"></use>
-    </svg>
-  </a>
-  {% endif %}
-  {% if 'linkedin' in platforms %}
-  <a href="https://www.linkedin.com/cws/share?url={{ url }}" target="_blank" class="logos__linkedin">
-    <svg viewbox="0 0 25 25">
-      <use href="/static/site_cms/img/org_logos/linkedin.svg#linkedin-icon"></use>
-    </svg>
-  </a>
-  {% endif %}
-  {% if 'email' in platforms %}
-  <a href="mailto:?body={{ url }}" target="_blank" class="logos__email">
-    <svg viewbox="0 0 25 25">
-      <use href="/static/site_cms/img/org_logos/email.svg#email-icon"></use>
-    </svg>
-  </a>
-  {% endif %}
+  {% for platform in platforms %}
+    {% if platform == 'facebook' %}
+    <a href="https://www.facebook.com/sharer/sharer.php?u={{ url }}" target="_blank" class="logos__facebook">
+      <svg viewbox="0 0 25 25">
+        <use href="/static/site_cms/img/org_logos/facebook.svg#facebook-icon"></use>
+      </svg>
+    </a>
+    {% endif %}
+    {% if platform == 'linkedin' %}
+    <a href="https://www.linkedin.com/cws/share?url={{ url }}" target="_blank" class="logos__linkedin">
+      <svg viewbox="0 0 25 25">
+        <use href="/static/site_cms/img/org_logos/linkedin.svg#linkedin-icon"></use>
+      </svg>
+    </a>
+    {% endif %}
+    {% if platform == 'email' %}
+    <a href="mailto:?body={{ url }}" target="_blank" class="logos__email">
+      <svg viewbox="0 0 25 25">
+        <use href="/static/site_cms/img/org_logos/email.svg#email-icon"></use>
+      </svg>
+    </a>
+    {% endif %}
+  {% endfor %}
   {% block text_after %}
   {% endblock text_after %}
 {% endif %}


### PR DESCRIPTION
## Overview

Re-order share platforms.

## Related

- part of closed [TUP-667](https://tacc-main.atlassian.net/browse/TUP-667)
- untracked task of [TUP-584](https://tacc-main.atlassian.net/browse/TUP-584)

## Changes

- **changed** social media share platform order to match order of items in setting list

## Testing

0. Add to `settings_local.py`:
    ```
    TACC_SOCIAL_SHARE_PLATFORMS = ['instagram', 'facebook', 'email']
    ```
1. Create news article.
2. Open news article.
3. Verify icons are present and working and in this order:
    1. instagram
    2. facebook
    3. email

## UI

| before | after |
| - | - |
| <img width="1194" alt="before" src="https://github.com/TACC/Core-CMS/assets/62723358/9b45516a-689c-425a-ac77-477bf3cb56b0"> | <img width="1194" alt="after" src="https://github.com/TACC/Core-CMS/assets/62723358/a0f59e95-702f-4165-8355-900b26c2e748"> |