### PR TITLE
feat: tup 590 change position and style of social media

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -143,41 +143,41 @@ Styleguide Components.DjangoCMS.Blog.App
 .app-blog .logos--social {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  column-gap: 0.25em;
-  padding-inline: var(--sidebar-margin);
-
-  /* To add border and space above */
-  margin-top: var(--sidebar-margin);
-  border-top: var(--global-color-primary--light) var(--global-border-width--normal) solid;
-  padding-top: var(--sidebar-margin);
+  justify-self: end;
 }
 
 .app-blog .logos--social > a {
   display: flex; /* to vertically center the svg (as needed) */
+
+  @media (pointer: coarse) {
+    padding-inline: 0.5em;
+  }
+  @media not (pointer: coarse) {
+    padding-inline: 0.25em;
+  }
 }
+
 .app-blog .logos__text-before {
   white-space: nowrap;
-  transform: translateY(2px); /* to better vertically center text */
-
-  /* To mimic .byline-title */
-  color: #999;
-  font-size: 12px;
-
-  /* To push logos beneath this text */
-  flex-basis: 100%;
-  padding-bottom: 10px;
+  margin-right: 0.25em;
 }
 
 .app-blog .logos--social svg {
   fill: var(--global-color-primary--x-dark);
-  height: var(--global-font-size--large);
-  width: var(--global-font-size--x-large);
+
+  @media (pointer: coarse) {
+    height: var(--global-font-size--xx-large);
+    width: var(--global-font-size--xx-large);
+  }
+  @media (pointer: fine), (pointer: none) {
+    height: var(--global-font-size--large);
+    width: var(--global-font-size--large);
+  }
 }
-.app-blog .logos__facebook svg:hover { fill: #0866ff; }
-.app-blog .logos__linkedin svg:hover { fill: #0a66c2; }
-.app-blog .logos__email svg:hover { fill: #0000ff; }
-.app-blog .logos__instagram svg:hover { fill: #bc1888; }
+.app-blog a.logos__facebook:hover svg { fill: #0866ff; }
+.app-blog a.logos__linkedin:hover svg { fill: #0a66c2; }
+.app-blog a.logos__email:hover svg { fill: #0000ff; }
+.app-blog a.logos__instagram:hover svg { fill: #bc1888; }
 
 
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -135,6 +135,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 :--article-item .attrs {
   color: var(--global-color-primary--dark);
+  justify-self: end;
 }
 :--article-item .attrs a {
   color: inherit;


### PR DESCRIPTION
## Overview

Redesign social media share links.

## Related

- [TUP-590](https://tacc-main.atlassian.net/browse/TUP-590)

## Changes

- **added** color change on hover
- **added** different size icons for "touch" vs **not** "touch"
- **changed** layout of share links

## Testing

1. Create news article.
2. Open news article.
3. Review share links style and layout.
4. Open developer tools.
5. Change to view page as if on mobile (touch) or desktop (touch).
6. Review share links size.

## UI

| Before | After |
| - | - |
| <img width="1155" alt="page before" src="https://github.com/TACC/Core-CMS/assets/62723358/ebe16116-7adb-4aeb-ba63-994c23d04ead"> | <img width="1155" alt="page after - desktop" src="https://github.com/TACC/Core-CMS/assets/62723358/3f1ee52b-418b-4fb3-a42e-d3158f23c62a"> |

| Mouse<br /><sup>e.g. typical Desktop</sup> | Touch<br /><sup>e.g. typical Mobile</sup> |
| - | - |
| <img width="1155" alt="page after - desktop" src="https://github.com/TACC/Core-CMS/assets/62723358/1dd8ce73-b3cc-455f-a7be-29b24bcdbf7b"> | <img width="1155" alt="page after - mobile" src="https://github.com/TACC/Core-CMS/assets/62723358/64231ffe-df0c-4d43-9728-cfa4be461255"> |