### PR TITLE
CMD-73 Remove Taccsite Blockquote Plugin from Text Editor

### DIFF
--- a/taccsite_cms/contrib/taccsite_blockquote/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_blockquote/cms_plugins.py
@@ -19,7 +19,7 @@ class TaccsiteBlockquotePlugin(CMSPluginBase):
     render_template = 'blockquote.html'
 
     cache = True
-    text_enabled = True
+    text_enabled = False
     allow_children = False
 
     fieldsets = [


### PR DESCRIPTION
## Overview

Removes blockquote plugin from text editor

## Related

[CMD-73](https://tacc-main.atlassian.net/browse/CMD-73)

## Changes

Changes `taccsite_cms/contrib/taccsite_blockquote/cms_plugins.py` -> `text-enabled = True` to `text-enabled = False`

## Testing

1. Create a text plugin
2. In the plugin, there's a cms plugin dropdown
3. Make sure there is no Blockquote plugin under TACC Site

## UI

<img width="303" alt="Screenshot 2024-03-12 at 5 54 08 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/3a43d6ee-1f55-4d9a-96d9-7bed291be45c">



<!--
## Notes

…
-->
