### PR TITLE
CMD-107 News Feed Main Page Should Use Page Title

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -1,6 +1,6 @@
 {# https://github.com/nephila/djangocms-blog/blob/1.1.1/djangocms_blog/templates/djangocms_blog/post_list.html #}
 {% extends "djangocms_blog/base.html" %}
-{% load i18n easy_thumbnails_tags %}{% spaceless %}
+{% load i18n easy_thumbnails_tags cms_tags %}{% spaceless %}
 
 {% block canonical_url %}<link rel="canonical" href="{{ view.get_view_url }}"/>{% endblock canonical_url %}
 
@@ -24,23 +24,23 @@
         {# /TACC #}
         {# TACC (reformat headings): #}
         {% if author %}
-          <strong>{% trans "News" %}</strong>
+          <strong>{% page_attribute "page_title" %}</strong>
           <em>{% trans "Articles by" %} {{ author.get_full_name }}</em>
         {% elif archive_date %}
-          <strong>{% trans "News" %}</strong>
+          <strong>{% page_attribute "page_title" %}</strong>
           <span>{% trans "Archive" %}</span>
           <em>{% if month %}{{ archive_date|date:'F' }} {% endif %}{{ year }}</em>
         {% elif tagged_entries %}
-          <strong>{% trans "News" %}</strong>
+          <strong>{% page_attribute "page_title" %}</strong>
           <span>{% trans "Tag" %}</span>
           <em>{{ tagged_entries|capfirst }}</em>
         {% elif category %}
-          <strong>{% trans "News" %}</strong>
+          <strong>{% page_attribute "page_title" %}</strong>
           <span>{% trans "Category" %}</span>
           <em>{{ category }}</em>
         {# TACC (add default heading): #}
         {% else %}
-          {% trans "News" %}
+        {% page_attribute "page_title" %}
         {% endif %}
         {# /TACC #}
         {# /TACC #}


### PR DESCRIPTION
## Overview

The News header should match the title of the page. Not just be the word "News".

## Related

https://tacc-main.atlassian.net/browse/CMD-107

## Changes

Changes the template from hard-coding, only using "News" to using the page title.

## Testing

1. Create a news section
2. Navigate to page settings under the Page menu
3. Select Page Settings
4. Change the Page Title
5. Make sure the heading of the page changes in correlation to the Page Title

## UI

| Before | After |
| --- | --- |
| <img width="2560" alt="Screenshot 2024-03-19 at 5 41 57 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/030f2397-9dcc-47e9-9b75-e5333de64d22"> | <img width="2560" alt="Screenshot 2024-03-19 at 5 42 55 PM" src="https://github.com/TACC/Core-CMS/assets/63771558/57b17d9a-bc66-4ec3-a44c-029681ffdf87"> |

<!--
## Notes

…
-->
