### PR TITLE
feat: core-styles v2 by default

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -313,7 +313,7 @@ TACC_SOCIAL_SHARE_PLATFORMS = []
 
 # Only use integer numbers (not "v1", not "0.11.0"),
 # so templates can load based on simple comparisons
-TACC_CORE_STYLES_VERSION = 0
+TACC_CORE_STYLES_VERSION = 2
 
 ########################
 # DJANGOCMS_BLOG: TACC


### PR DESCRIPTION
## Overview

Make Core-Styles v2 be the default for new client websites.

## Related

N/A

## Changes

- **changed** version of `TACC_CORE_STYLES_VERSION`

## Testing

### Core-Styles v0

1. Be on `main` with default settings.
2. `make build && make start`
3. Load website.
4. See old `site…css` stylesheets loaded.

### Core-Styles v2

1. Be on `feat/core-styles-v2-by-default` with default settings.
2. `make build && make start`
3. Load website.
4. See new `core-styles…css` stylesheets loaded.

## UI

| v0 | v2 |
| - | - |
| <img width="1194" alt="Core-Styles v0" src="https://github.com/TACC/Core-CMS/assets/62723358/df6eddcc-09c1-4468-9f54-710122c0d484"> | <img width="1194" alt="Core-Styles v2" src="https://github.com/TACC/Core-CMS/assets/62723358/582aef22-08bb-4f0a-8553-35111c8439ae"> |