### PR TITLE
hotfix: do not let editors publish by default

### DIFF
--- a/taccsite_cms/management/commands/group_perms/media_editor_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/media_editor_advanced.py
@@ -12,9 +12,6 @@ def set_group_perms():
     group.permissions.add( Permission.objects.get(name='Can change page', content_type=content_type) )
     model_name = 'page'.lower().replace(' ', '')
     content_type = ContentType.objects.get(app_label='cms', model=model_name)
-    group.permissions.add( Permission.objects.get(name='Can publish page', content_type=content_type) )
-    model_name = 'page'.lower().replace(' ', '')
-    content_type = ContentType.objects.get(app_label='cms', model=model_name)
     group.permissions.add( Permission.objects.get(name='Can view page', content_type=content_type) )
 
     model_name = 'placeholder'.lower().replace(' ', '')

--- a/taccsite_cms/management/commands/group_perms/text_editor_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/text_editor_advanced.py
@@ -12,9 +12,6 @@ def set_group_perms():
     group.permissions.add( Permission.objects.get(name='Can change page', content_type=content_type) )
     model_name = 'page'.lower().replace(' ', '')
     content_type = ContentType.objects.get(app_label='cms', model=model_name)
-    group.permissions.add( Permission.objects.get(name='Can publish page', content_type=content_type) )
-    model_name = 'page'.lower().replace(' ', '')
-    content_type = ContentType.objects.get(app_label='cms', model=model_name)
     group.permissions.add( Permission.objects.get(name='Can view page', content_type=content_type) )
 
     model_name = 'placeholder'.lower().replace(' ', '')


### PR DESCRIPTION
## Overview

Do not let editors publish by default.

<details>The permission to publish must only be given via "Page Publisher" group, so it is obvious who has publishing, the most dangerous permission.</details>

_P.S. News Editor can still publish, because publishing articles is really just editing a boolean option on the article; thus, for News, edit article equals publish article._

## Related

N/A. I just noticed this while testing publish permission for a user that mysteriously already had permission.

## Changes

- **deleted** publish permission form editor perm. scripts

## Testing

1. Create CMS without these groups.
2. Add these groups via script.
3. Create a test staff user assigned to these groups.
4. Give this group permission to publish only the home page.
5. Verify staff user cannot publish.
4. Add "Publish page" permission to this group.
5. Verify staff user **can** publish.

## UI

Skipped.