### PR TITLE
hotfix: TUP-714 news list page links not working

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -25,7 +25,9 @@ export default function findLinksAndSetTargets() {
     const isAbsolute = ( linkHref.indexOf('http') === 0 );
     const isSameHost = link.host === baseDocHost || link.host === baseDocHostWithSubdomain
 
-    console.log({ isMailto, isAbsolute, isSameHost, linkHref });
+    if (SHOULD_DEBUG) {
+      console.debug({ isMailto, isAbsolute, isSameHost, linkHref });
+    }
 
     // Links to pages at different host should open in new tab
     if ( ! isSameHost || isMailto ) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -22,8 +22,10 @@ export default function findLinksAndSetTargets() {
     }
 
     const isMailto = ( linkHref.indexOf('mailto:') === 0 );
-    const isAbsolute = ( link.href.indexOf('http') === 0 );
+    const isAbsolute = ( linkHref.indexOf('http') === 0 );
     const isSameHost = link.host === baseDocHost || link.host === baseDocHostWithSubdomain
+
+    console.log({ isMailto, isAbsolute, isSameHost, linkHref });
 
     // Links to pages at different host should open in new tab
     if ( ! isSameHost || isMailto ) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -15,12 +15,14 @@ export default function findLinksAndSetTargets() {
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
   [ ...links ].forEach( function setTarget(link) {
-    if ( ! link.href) {
+    const linkHref = link.getAttribute('href');
+
+    if ( ! linkHref ) {
       return false;
     }
 
-    const isMailto = ( link.href.indexOf('mailto:') === 0 );
-    const isAbsolute = (link.href.indexOf('http') === 0);
+    const isMailto = ( linkHref.indexOf('mailto:') === 0 );
+    const isAbsolute = ( link.href.indexOf('http') === 0 );
     const isSameHost = link.host === baseDocHost || link.host === baseDocHostWithSubdomain
 
     // Links to pages at different host should open in new tab
@@ -28,7 +30,7 @@ export default function findLinksAndSetTargets() {
       if ( link.target !== '_blank') {
         link.target = '_blank';
         if (SHOULD_DEBUG) {
-          console.debug(`Link ${link.href} now opens in new tab`);
+          console.debug(`Link ${linkHref} now opens in new tab`);
         }
       }
       if ( link.target === '_blank') {


### PR DESCRIPTION
## Overview

Use `link.getAttribute('href')` not `link.href`, so `isAbsolute` is not `true` for News list "Previous" and "Next" links.

## Related

- [TUP-714](https://tacc-main.atlassian.net/browse/TUP-714)

## Changes

- **changed** `link.getAttribute('href')` not `link.href` in `setTargetForExternalLinks.js`

## Testing

1. Use the new file on a news page with pagination.
    - **A.** Load a page with News on which you've added enough articles.
        <sup>To create less articles, set pagination threshold to be very small.</sup>
    - **B.** Edit same file on `tup_cms` container directly while running https://github.com/TACC/tup-ui.
2. Verify "Previous" or "Next" links work.

## UI

| Script | Page |
| - | - |
| ![file](https://github.com/TACC/Core-CMS/assets/62723358/0d346248-9f1f-4f82-af90-6b0d9de74212) | ![page](https://github.com/TACC/Core-CMS/assets/62723358/445d3414-2dfc-474b-a16a-05f30e6647d6) |

https://github.com/TACC/Core-CMS/assets/62723358/7aa3c93a-09f3-48a4-82de-da68d3ad97b1

