### PR TITLE
feat: support disabling elasticsearch

### DIFF
--- a/taccsite_cms/_settings/search.py
+++ b/taccsite_cms/_settings/search.py
@@ -1,6 +1,19 @@
 """Configure search plugins"""
 
+########################
+# TACC: SEARCH
+########################
+
 PORTAL_ES_ENABLED = True
+
+SEARCH_PATH = '/search'
+
+if PORTAL_ES_ENABLED:
+    # Elasticsearch
+    SEARCH_QUERY_PARAM_NAME = 'query_string'
+else:
+    # Google
+    SEARCH_QUERY_PARAM_NAME = 'q'
 
 ########################
 # ELASTICSEARCH
@@ -37,16 +50,3 @@ if PORTAL_ES_ENABLED:
     ]
 else:
     _INSTALLED_APPS = []
-
-########################
-# TACC: SEARCH
-########################
-
-SEARCH_PATH = '/search'
-
-if PORTAL_ES_ENABLED:
-    # Elasticsearch
-    SEARCH_QUERY_PARAM_NAME = 'query_string'
-else:
-    # Google
-    SEARCH_QUERY_PARAM_NAME = 'q'

--- a/taccsite_cms/_settings/search.py
+++ b/taccsite_cms/_settings/search.py
@@ -1,0 +1,52 @@
+"""Configure search plugins"""
+
+PORTAL_ES_ENABLED = False
+
+########################
+# ELASTICSEARCH
+########################
+
+if PORTAL_ES_ENABLED:
+    ES_AUTH = 'username:password'
+    ES_HOSTS = 'http://elasticsearch:9200'
+    ES_INDEX_PREFIX = 'cms-dev-{}'
+    ES_DOMAIN = 'http://localhost:8000'
+
+    # Elasticsearch Indexing
+    HAYSTACK_ROUTERS = ['aldryn_search.router.LanguageRouter', ]
+    HAYSTACK_SIGNAL_PROCESSOR = 'taccsite_cms.signal_processor.RealtimeSignalProcessor'
+    ALDRYN_SEARCH_DEFAULT_LANGUAGE = 'en'
+    ALDRYN_SEARCH_REGISTER_APPHOOK = True
+    HAYSTACK_CONNECTIONS = {
+        'default': {
+            'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+            'URL': ES_HOSTS,
+            'INDEX_NAME': ES_INDEX_PREFIX.format('cms'),
+            'KWARGS': {'http_auth': ES_AUTH}
+        }
+    }
+
+########################
+# DJANGO CMS
+########################
+
+if PORTAL_ES_ENABLED:
+    _INSTALLED_APPS = [
+        'haystack',                # search index
+        'aldryn_apphooks_config',  # search index & django CMS Blog
+    ]
+else:
+    _INSTALLED_APPS = []
+
+########################
+# TACC: SEARCH
+########################
+
+SEARCH_PATH = '/search'
+
+if PORTAL_ES_ENABLED:
+    # Elasticsearch
+    SEARCH_QUERY_PARAM_NAME = 'query_string'
+else:
+    # Google
+    SEARCH_QUERY_PARAM_NAME = 'q'

--- a/taccsite_cms/_settings/search.py
+++ b/taccsite_cms/_settings/search.py
@@ -1,6 +1,6 @@
 """Configure search plugins"""
 
-PORTAL_ES_ENABLED = False
+PORTAL_ES_ENABLED = True
 
 ########################
 # ELASTICSEARCH

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -20,6 +20,10 @@ from taccsite_cms._settings.form_plugin import *
 from taccsite_cms._settings.form_plugin import (
     _INSTALLED_APPS as form_plugin_INSTALLED_APPS
 )
+from taccsite_cms._settings.search import *
+from taccsite_cms._settings.search import (
+    _INSTALLED_APPS as search_INSTALLED_APPS
+)
 
 ########################
 # DJANGO
@@ -172,36 +176,6 @@ CMS_PERMISSION = True
 GOOGLE_ANALYTICS_PROPERTY_ID = "UA-123ABC@%$&-#"
 GOOGLE_ANALYTICS_PRELOAD = True
 
-########################
-# TACC: SEARCH
-########################
-
-# To customize site search
-SEARCH_PATH = '/search'
-SEARCH_QUERY_PARAM_NAME = 'query_string'
-
-########################
-# ELASTICSEARCH
-########################
-
-ES_AUTH = 'username:password'
-ES_HOSTS = 'http://elasticsearch:9200'
-ES_INDEX_PREFIX = 'cms-dev-{}'
-ES_DOMAIN = 'http://localhost:8000'
-
-# Elasticsearch Indexing
-HAYSTACK_ROUTERS = ['aldryn_search.router.LanguageRouter', ]
-HAYSTACK_SIGNAL_PROCESSOR = 'taccsite_cms.signal_processor.RealtimeSignalProcessor'
-ALDRYN_SEARCH_DEFAULT_LANGUAGE = 'en'
-ALDRYN_SEARCH_REGISTER_APPHOOK = True
-HAYSTACK_CONNECTIONS = {
-    'default': {
-        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
-        'URL': ES_HOSTS,
-        'INDEX_NAME': ES_INDEX_PREFIX.format('cms'),
-        'KWARGS': {'http_auth': ES_AUTH}
-    }
-}
 
 ########################
 # TACC: BRANDING
@@ -481,9 +455,9 @@ INSTALLED_APPS = [
     'djangocms_bootstrap4.contrib.bootstrap4_tabs',
     'djangocms_bootstrap4.contrib.bootstrap4_utilities',
 
+] + search_INSTALLED_APPS + [
+
     # miscellaneous
-    'haystack',                # search index
-    'aldryn_apphooks_config',  # search index & django CMS Blog
     'test_without_migrations', # run tests faster
 
 ] + form_plugin_INSTALLED_APPS + [


### PR DESCRIPTION
## Overview

Allow a project to disable ElasticSearch.

## Related

- [WP-582](https://tacc-main.atlassian.net/browse/WP-582)
- [CMD-155](https://tacc-main.atlassian.net/browse/CMD-155)

## Changes

- **added** setting `PORTAL_ES_ENABLED`
- **moved** search settings to `_settings/search.py`
- **changed** search settings to require `PORTAL_ES_ENABLED`

## Testing

1. Create new CMS-only Portal.
2. Deploy.
3. Create homepage.
4. Verify homepage is created (no 500 error).

## UI

| Ref. | Link |
| - | - |
| Image | [`taccwma/core-cms/feat-support-disabling-elasticsearch`](https://hub.docker.com/layers/taccwma/core-cms/feat-support-disabling-elasticsearch/images/sha256-4ed2a5a3f77e3ebe2594b05c6fa073ad6f569b8d487ac8c674863846960eab09?context=explore) |
| Deploy | [Core_Portal_Deploy#405](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/405/) |
| Website | https://pprd.wtcs.tacc.utexas.edu/ (has a homepage) |