### PR TITLE
feat: custom nav width via PORTAL_NAV_WIDTH

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -291,6 +291,11 @@ PORTAL_IS_CORE = True
 PORTAL_HAS_LOGIN = True
 PORTAL_HAS_SEARCH = True
 
+# Only use one of these values: 'sm', 'md', 'lg', 'xl'
+# SEE: https://getbootstrap.com/docs/4.0/components/navbar/#responsive-behaviors
+# FAQ: A falsy value will trigger default logic for nav width
+PORTAL_NAV_WIDTH = False
+
 LOGOUT_REDIRECT_URL = '/'
 
 # using container name to avoid cep.dev dns issues locally
@@ -764,6 +769,7 @@ SETTINGS_EXPORT = deprecated_SETTINGS_EXPORT + [
     'PORTAL_IS_CORE',
     'PORTAL_HAS_LOGIN',
     'PORTAL_HAS_SEARCH',
+    'PORTAL_NAV_WIDTH',
     'GOOGLE_ANALYTICS_PROPERTY_ID',
     'GOOGLE_ANALYTICS_PRELOAD',
     'TACC_CORE_STYLES_VERSION',

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -9,9 +9,18 @@
 
 {% with settings.PORTAL_HAS_LOGIN as SHOW_PORTAL %}
 {% with settings.PORTAL_HAS_SEARCH as SHOW_SEARCH %}
+{% with settings.PORTAL_NAV_WIDTH as NAV_WIDTH %}
 
 <!-- Navigation Bar -->
-<nav id="s-header" class="s-header  navbar {% if SHOW_PORTAL or SHOW_SEARCH %}navbar-expand-xl{% else %}navbar-expand-lg{% endif %} navbar-dark">
+<nav id="s-header" class="s-header  navbar navbar-dark
+  {% if NAV_WIDTH %}
+  navbar-expand-{{NAV_WIDTH}}
+  {% elif SHOW_PORTAL or SHOW_SEARCH %}
+  navbar-expand-xl
+  {% else %}
+  navbar-expand-lg
+  {% endif %}
+">
   <!-- Portal Logo -->
   {% include "header_logo.html" %}
 
@@ -36,5 +45,6 @@
   </div>
 </nav>
 
+{% endwith %}
 {% endwith %}
 {% endwith %}


### PR DESCRIPTION
## Overview

Allow user to set custom nav width (Bootstrap-based).

## Related

- to introduce via #792

## Changes

- **added** `PORTAL_NAV_WIDTH` (`sm`, `md`, `lg`, `xl`, default `False`)

## Testing

1. Have working CMS.
2. Set `PORTAL_NAV_WIDTH` to `sm`.
3. Open website at different window widths.
4. Navigation should not collapse until width is very narrow.

## UI

https://github.com/TACC/Core-CMS/assets/62723358/b5d91b63-5fc4-4e1d-927f-afb7e4d8d86e