### PR TITLE
fix: CMD-162 disable 2nd-level CMS breadcrumbs

### DIFF
--- a/taccsite_cms/templates/nav_cms_breadcrumbs.html
+++ b/taccsite_cms/templates/nav_cms_breadcrumbs.html
@@ -1,7 +1,16 @@
 {# @var className #}
 {% load menu_tags %}
 
-<nav class="s-breadcrumbs  {{className}}">
+{# To adjust style of "disabled" link #}
+{# NOTE: Not using `block`, so markup is together for devs in live markup #}
+<style>
+  .s-breadcrumbs a:not([href]) {
+    opacity: 1;
+    color: unset;
+  }
+</style>
+
+<nav class="s-breadcrumbs  {{className}}" id="cms-breadcrumbs">
 
   {# To support structured data, item* attributes are used #}
   {# SEE: https://confluence.tacc.utexas.edu/x/5yMFDg #}
@@ -14,3 +23,15 @@
   </ol>
 
 </nav>
+
+{# To disable 2nd-level breadcrumb #}
+{# NOTE: Not using `block`, so markup is loaded first #}
+{# NOTE: Not using `block` nor `type="module"`, so effect is quicker #}
+<script>
+  {# FAQ: Attempts to do this server-side failed cuz useful props are blank #}
+  {# https://docs.django-cms.org/en/release-3.11.x/reference/navigation.html#properties-of-navigation-nodes-in-templates #}
+  document
+    .getElementById('cms-breadcrumbs')
+    .querySelector('li:nth-of-type(2) > a')
+    .removeAttribute('href');
+</script>


### PR DESCRIPTION
## Overview

Disable 2nd-level breadcrumbs (because they always redirects to 3rd-level).

<details><summary><strong>Details</strong></summary>

**TL;DR**: Server-side menu node properties to programmatically disable links (remove `href`) are blank, so we use JavaScript to force-disable 2nd-level breadcrumbs. The styles merely tweak disabled breadcrumb appearance.

---

In Django CMS, a page added such that it appears in the navigation. On that page, the page will appear in the breadcrumbs as text, not a link, because it is the current page. _Server-side code performs that._ A parent page can be added such that it appears in the navigation as a dropdown link. The link only opens the menu of child pages; it does not navigate user to a page. _Server-side code performs that_. If one visits a child page, the parent page will appear in the breadcrumbs as a link. Clicking that link will take user to the parent page. _Server-side code performs that._ Because the page is not intended to be navigated to — and only was able to be navigated to via link after breadcrumbs were added — CMS admin has always left such pages blank or (more commonly) made them redirect to the most relevant child page. _Server-side code allows that._ To avoid user clicking such a parent page in the breadcrumbs, we would set the `href` to blank, but attempts to do this server-side fail because useful [menu props](https://docs.django-cms.org/en/release-3.11.x/reference/navigation.html#properties-of-navigation-nodes-in-templates) are blank. So we use JavaScript to force-remove the `href` value. We add styles to tweak the appearance of a disabled breadcrumb link.

</details> 

## Related

- [CMD-162](https://tacc-main.atlassian.net/browse/CMD-162)
- integrates https://github.com/TACC/tup-ui/pull/200
- mimics https://github.com/DesignSafe-CI/portal/pull/1268

## Changes

To breadcrumbs template:
- **added** style tag
- **added** script tag

## Testing

1. Open https://localhost:8000/.
2. Create/Visit a child page of a child page or a top-level page.
    <sup>E.g. Home > Fruit > Tropical > Bananas.</sup>
3. Verify 
    - has "> Fruit >"
    - "Fruit" is not clickable
    - "Fruit" does not have link color
    - "Fruit" is opaque
    - "Fruit" is different color than current page in breadcrumbs

## UI

| before | after |
| - | - |
| <img width="740" alt="before" src="https://github.com/TACC/Core-CMS/assets/62723358/63439cfc-4432-46d9-8c41-813df9b36a92"> | <img width="740" alt="after" src="https://github.com/TACC/Core-CMS/assets/62723358/01a3005a-50f3-4303-86fa-df7977eac58b"> |

https://github.com/TACC/Core-CMS/assets/62723358/35ec039b-6fdf-4871-9509-f5a3b2bcbbf1

https://github.com/TACC/Core-CMS/assets/62723358/fe661319-1102-462e-9d9f-ac11e7ad8f6a