### PR TITLE
fix: TUP-725 wrong a11y attribute for links

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -38,7 +38,7 @@ export default function findLinksAndSetTargets() {
         }
       }
       if ( link.target === '_blank') {
-        link.setAttribute('aria-description', 'Opens in new window.');
+        link.setAttribute('aria-label', 'Opens in new window.');
       }
     }
 


### PR DESCRIPTION
## Overview

Change `aria-description` to `aria-label` for links that open in new window.

## Related

- [TUP-725](https://tacc-main.atlassian.net/browse/TUP-725)

## Changes

- **changed** an attribute in a script

## Testing & UI

Skipped.