### PR TITLE
feat: CMD-112 `form_name` in custom email message

### DIFF
--- a/common_apps/email_management/apps.py
+++ b/common_apps/email_management/apps.py
@@ -21,7 +21,6 @@ def send_confirmation_email(form_name, form_data):
     site_name = current_site.name
 
     def replace_word_in_file(email_content):
-
         modified_content = email_content.replace(
             '{site_name}', f'{site_name}'
         ).replace(

--- a/common_apps/email_management/apps.py
+++ b/common_apps/email_management/apps.py
@@ -22,7 +22,11 @@ def send_confirmation_email(form_name, form_data):
 
     def replace_word_in_file(email_content):
 
-        modified_content = email_content.replace('{site_name}', f'{site_name}')
+        modified_content = email_content.replace(
+            '{site_name}', f'{site_name}'
+        ).replace(
+            '{form_name}', f'{form_name}'
+        )
         return modified_content
 
     text_body = replace_word_in_file(CONF_EMAIL_TEXT)


### PR DESCRIPTION
## Overview

Support `{form_name}` in `PORTAL_CONF_EMAIL_TEXT` and `PORTAL_CONF_EMAIL_HTML`.

## Related

- [CMD-112](https://tacc-main.atlassian.net/browse/CMD-112)
- mirrored by https://github.com/TACC/Core-CMS/pull/847
- required by https://github.com/TACC/tup-ui/pull/448

## Changes

- **added** another text replacement

## Testing & UI

https://github.com/TACC/Core-CMS/pull/847