### PR TITLE
feat: CMD-112 `form_name` in custom email message — off v4.10.2

### DIFF
--- a/common_apps/email_management/apps.py
+++ b/common_apps/email_management/apps.py
@@ -21,7 +21,6 @@ def send_confirmation_email(form_name, form_data):
     site_name = current_site.name
 
     def replace_word_in_file(email_content):
-
         modified_content = email_content.replace(
             '{site_name}', f'{site_name}'
         ).replace(

--- a/common_apps/email_management/apps.py
+++ b/common_apps/email_management/apps.py
@@ -22,7 +22,11 @@ def send_confirmation_email(form_name, form_data):
 
     def replace_word_in_file(email_content):
 
-        modified_content = email_content.replace('{site_name}', f'{site_name}')
+        modified_content = email_content.replace(
+            '{site_name}', f'{site_name}'
+        ).replace(
+            '{form_name}', f'{form_name}'
+        )
         return modified_content
 
     text_body = replace_word_in_file(CONF_EMAIL_TEXT)


### PR DESCRIPTION
## Overview

Support `{form_name}` in `PORTAL_CONF_EMAIL_TEXT` and `PORTAL_CONF_EMAIL_HTML`.

## Related

- [CMD-112](https://tacc-main.atlassian.net/browse/CMD-112)
- mirrors https://github.com/TACC/Core-CMS/pull/846
- required by https://github.com/TACC/tup-ui/pull/448

## Changes

- **added** another text replacement

## Testing & UI

https://github.com/TACC/tup-ui/pull/448

| | | |
| - | - | - |
| <img width="664" alt="1" src="https://github.com/TACC/Core-CMS/assets/62723358/aa2a0d1b-70d5-47ef-ba52-66a40f2ea81f"> | <img width="664" alt="2" src="https://github.com/TACC/Core-CMS/assets/62723358/4a259c06-6937-415b-9b7a-05a5ff7cb0ff"> | <img width="664" alt="3" src="https://github.com/TACC/Core-CMS/assets/62723358/dcc67848-8c2b-4c01-9879-adff42acb12e"> |