### PR TITLE
fix: custom app with custom url is difficult to debug

### DIFF
--- a/apps/custom_example/urls.py
+++ b/apps/custom_example/urls.py
@@ -1,7 +1,7 @@
 from django.urls import re_path
-from .views import AddedView
+from .views import CustomExampleView
 
 app_name = 'custom_example'
 urlpatterns = [
-    re_path('', AddedView, name='index'),
+    re_path('', CustomExampleView, name='index'),
 ]

--- a/apps/custom_example/views.py
+++ b/apps/custom_example/views.py
@@ -3,6 +3,6 @@ from django.conf import settings
 from django.template import loader
 
 
-def AddedView(request):
+def CustomExampleView(request):
     template = loader.get_template('custom_example/custom_example.html')
     return HttpResponse(template.render({}, request))

--- a/taccsite_cms/urls.py
+++ b/taccsite_cms/urls.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+import logging
+
 from cms.sitemaps import CMSSitemap
 from django.conf import settings
 from django.conf.urls.static import static
@@ -14,9 +16,12 @@ from django.views.static import serve
 from django.views.generic.base import TemplateView
 from taccsite_cms import remote_cms_auth as remote_cms_auth
 
+
 from django.http import request
 from django.views.generic.base import RedirectView
 admin.autodiscover()
+
+logger = logging.getLogger(f"portal.{__name__}")
 
 urlpatterns = [
     url(r'^sitemap\.xml$', sitemap,
@@ -44,7 +49,8 @@ if getattr(settings, 'PORTAL_IS_TACC_CORE_PORTAL', True):
 try:
     from .urls_custom import custom_urls
     urlpatterns += custom_urls
-except ImportError:
+except ImportError as e:
+    logger.error(f'Failed to import custom files: {e}')
     pass
 
 if getattr(settings, 'PORTAL_HAS_LOGIN', True):


### PR DESCRIPTION
## Overview

- Rename custom example app view to more familiar pattern.
- **Log error from any custom app urls.**

## Related

- helped me debug while working on [TUP-706](https://tacc-main.atlassian.net/browse/TUP-706)

## Changes

- **renamed** custom example app view
- **added** logging for custom app urls

## Testing

0. Have CMS and custom example app working.
1. Make any obvious error in the custom example app code.
2. Verify log shows the error.

## UI

Skipped.