### PR TITLE
refactor: simplify custom url debugging

### DIFF
--- a/taccsite_cms/urls.py
+++ b/taccsite_cms/urls.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-import logging
-
 from cms.sitemaps import CMSSitemap
 from django.conf import settings
 from django.conf.urls.static import static
@@ -20,8 +18,6 @@ from taccsite_cms import remote_cms_auth as remote_cms_auth
 from django.http import request
 from django.views.generic.base import RedirectView
 admin.autodiscover()
-
-logger = logging.getLogger(f"portal.{__name__}")
 
 urlpatterns = [
     url(r'^sitemap\.xml$', sitemap,
@@ -49,8 +45,7 @@ if getattr(settings, 'PORTAL_IS_TACC_CORE_PORTAL', True):
 try:
     from .urls_custom import custom_urls
     urlpatterns += custom_urls
-except ImportError as e:
-    logger.error(f'Failed to import custom files: {e}')
+except ModuleNotFoundError:
     pass
 
 if getattr(settings, 'PORTAL_HAS_LOGIN', True):


### PR DESCRIPTION
## Overview

Simplify code that allows debugging custom url failure.

## Related

- simplifies #851
- mimics #485

## Changes

- **removed** logging from `urls.py`
- **changed** an `ImportError` to `ModuleNotFoundError`

## Testing

1. Have CMS and custom example app working.
2. Make any obvious error in the custom example app code.
3. Verify log shows the error.

## UI

Skipped.
