### PR TITLE
fix: WP-407 unable to edit nor create container

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -728,13 +728,11 @@ description = "Adds Bootstrap 4 components as plugins."
 category = "main"
 optional = false
 python-versions = "*"
-files = [
-    {file = "djangocms-bootstrap4-3.0.1.tar.gz", hash = "sha256:f9344ed31e83e8f38754d010f6450924c8757c55af7577ca1b70a6ffac9341e1"},
-    {file = "djangocms_bootstrap4-3.0.1-py3-none-any.whl", hash = "sha256:9536cbea4f96e80469a84da3e26b9a01ba1f424dcd20afe62b2a0946287d5dd3"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-django-cms = ">=3.7"
+django-cms = ">=3.7,<4"
 django-filer = ">=1.7"
 djangocms-attributes-field = ">=1"
 djangocms-icon = ">=1.4.0"
@@ -744,6 +742,12 @@ djangocms-text-ckeditor = ">=3.1.0"
 
 [package.extras]
 static-ace = ["djangocms-static-ace"]
+
+[package.source]
+type = "git"
+url = "https://github.com/django-cms/djangocms-bootstrap4.git"
+reference = "49983f4"
+resolved_reference = "49983f4175ec4a4e2b5076993a893cbdd79c4ab2"
 
 [[package]]
 name = "djangocms-column"
@@ -2416,4 +2420,4 @@ testing = ["func-timeout", "jaraco.itertools"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<4.0"
-content-hash = "83c6d296b1114e2bdac57d6d54515fc6b4e52c72d10151ddd3780376897d5507"
+content-hash = "529ed840a1588abfc3d1ced304803810f2ff1ca3408382bfdbb1be9bd5cf1b8e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ djangocms-admin-style = "~3.2.6"
 djangocms-apphook-setup = "0.4.1"
 djangocms-attributes-field = "2.1.0"
 djangocms-blog = "^1.2"
-djangocms-bootstrap4 = "^3.0.1"
+# TO get a commit in main (since v3.0.1) to fix Container error
+# https://github.com/django-cms/djangocms-bootstrap4/pull/164
+djangocms-bootstrap4 = {git = "https://github.com/django-cms/djangocms-bootstrap4.git", rev = "49983f4"}
 djangocms-column = "^2.0"
 djangocms-file = "3.0.0"
 djangocms-forms-maintained = { git = "https://github.com/TACC/djangocms-forms", rev = "63ead9288c2ea65139124698bffc0ad01d182afa" }


### PR DESCRIPTION
## Overview

Fix third-party bug preventing creation and edit of containers.

## Related

- [WP-407](https://tacc-main.atlassian.net/browse/WP-407)
- requires https://github.com/django-cms/djangocms-bootstrap4/pull/164

## Changes

Installed [`master` branch commit](https://github.com/django-cms/djangocms-bootstrap4/compare/3.0.1...master) of `djangocms-bootstrap4` @ 3.0.1+ (`49983f4`)

## Testing

1. Create a Container.
2. Edit a Container.

## UI

https://github.com/user-attachments/assets/231bc832-f244-4c84-80ec-88a451d7b409

https://github.com/user-attachments/assets/c8208d55-4786-4291-b419-dc26fc266329