### PR TITLE
fix: CMD-162 error if no second breadcrumb

### DIFF
--- a/taccsite_cms/templates/nav_cms_breadcrumbs.html
+++ b/taccsite_cms/templates/nav_cms_breadcrumbs.html
@@ -30,8 +30,7 @@
 <script>
   {# FAQ: Attempts to do this server-side failed cuz useful props are blank #}
   {# https://docs.django-cms.org/en/release-3.11.x/reference/navigation.html#properties-of-navigation-nodes-in-templates #}
-  document
-    .getElementById('cms-breadcrumbs')
-    .querySelector('li:nth-of-type(2) > a')
-    .removeAttribute('href');
+  const crumbs = document.getElementById('cms-breadcrumbs');
+  const secondLink = crumbs && crumbs.querySelector('li:nth-of-type(2) > a');
+  if (secondLink) secondLink.removeAttribute('href');
 </script>


### PR DESCRIPTION
## Overview

Do not try to remove 2nd-level breadcrumb link if it does not exist.

## Related

- [CMD-162](https://tacc-main.atlassian.net/browse/CMD-162)
- fixes #838

## Changes

- **add** checks for element existence before accessing

## Testing

1. Open a page whose only parent page is home.
    <sup>E.g. https://pprd.frontera-portal.tacc.utexas.edu/system/</sup>
2. Verify no error in console.
    <sup>E.g. `Cannot read properties of null (reading 'removeAttribute')`</sup>

## UI

| Before | After |
| - | - |
| <img width="618" alt="CMD-162 before" src="https://github.com/user-attachments/assets/778eda5c-0d15-49b8-979e-3c8de65825e8"> | <img width="618" alt="CMD-162 after" src="https://github.com/user-attachments/assets/37b44a95-a158-45ae-8201-13cb5b302d67"> |