### PR TITLE
fix: WP-602 `docker compose` with and without dash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DOCKERHUB_REPO := taccwma/$(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
+DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then echo "docker-compose"; else echo "docker compose"; fi)
 
 # NOTE: The `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists.
 # NOTE: Special characters in `DOCKER_IMAGE_BRANCH` are replaced with dashes.
@@ -13,7 +14,7 @@ BUILD_ID := $(shell git describe --always)
 
 .PHONY: build
 build:
-	docker-compose -f ./docker-compose.yml build
+	$(DOCKER_COMPOSE_CMD) -f ./docker-compose.yml build
 
 .PHONY: build-full
 build-full:
@@ -28,7 +29,7 @@ build-full:
 
 .PHONY: example
 example:
-	docker-compose -f ./docker-compose.example.yml up
+	$(DOCKER_COMPOSE_CMD) -f ./docker-compose.example.yml up
 
 .PHONY: publish
 publish:
@@ -42,12 +43,12 @@ publish-latest:
 
 .PHONY: start
 start:
-	docker-compose -f docker-compose.yml up
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml up
 
 .PHONY: stop
 stop:
-	docker-compose -f docker-compose.yml down
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml down
 
 .PHONY: stop-verbose
 stop-v:
-	docker-compose -f docker-compose.yml down -v
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml down -v

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Set up a new local CMS instance.
 
     | For Testing | For Developing & Testing |
     | - | - |
-    | `make start` | `docker-compose -f ./docker-compose.dev.yml up` |
+    | `make start` | `docker compose -f ./docker-compose.dev.yml up` |
 
     > **Note**
-    > This will make the terminal window busy. To run commands after this, **either** open a new terminal window **or** run `docker-compose -f ./docker-compose.dev.yml up --detach` instead.
+    > This will make the terminal window busy. To run commands after this, **either** open a new terminal window **or** run `docker compose -f ./docker-compose.dev.yml up --detach` instead.
 
 4. Enter the CMS Docker Container:
 


### PR DESCRIPTION
## Overview

Docker v2 has different command for `docker compose`. Adjust Makefile to handle both based on availability.

## Related

- [WP-602](https://tacc-main.atlassian.net/browse/WP-602)
- mimics https://github.com/TACC/Core-CMS-Custom/pull/295
- similar to https://github.com/TACC/Core-CMS-Custom/pull/301

## Changes

- **added** conditional `docker compose` command to Makefile
- **changed** `docker-compose` to `docker compose` in README

## Testing

1. `make build` — no error firing command from Makefile
2. `make start` — no error firing command from Makefile

## UI

Skipped.