### PR TITLE
docs: deprecate docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DOCKERHUB_REPO := taccwma/$(shell cat ./docker_repo.var)
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
+# WARNING: Using `docker-compose` is deprecated
 DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then echo "docker-compose"; else echo "docker compose"; fi)
 
 # NOTE: The `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists.

--- a/docs/upgrade-project.md
+++ b/docs/upgrade-project.md
@@ -2,12 +2,23 @@
 
 ## Table of Contents
 
+- [from v4.N to v4.14](#from-v4n-to-v414)
 - [from v4.N to v4.13](#from-v4n-to-v413)
 - [from v4.N to v4.12](#from-v4n-to-v412)
 - [from v4.N to v4.7](#from-v4n-to-v47)
 - [from v3 to v4](#from-v3-to-v4)
 - [from v3.N to v3.12](#from-v3n-to-v312)
 - [from v2 to v3](#from-v2-to-v3)
+
+## from v4.N to v4.14
+
+- [Upgrade Docker Compose](#upgrade-docker-compose)
+
+### Upgrade Docker Compose
+
+Update to _at least_ the latest Docker Compose v2.
+
+The v1 `docker-compose` command has long been deprecated.
 
 ## from v4.N to v4.13
 


### PR DESCRIPTION
## Overview

Prepare developers to not use `docker-compose`.

Deprecate `docker-compose` (to be removed in v5).

## Related

- https://github.com/TACC/Core-CMS/pull/858#issuecomment-2274214435

## Changes

- **added** v4.14 upgrade step

## Testing

N/A

## UI

See [`upgrade-project.md` at from v4.N to v4.14](https://github.com/TACC/Core-CMS/blob/docs/deprecate-docker-compose-v1-command/docs/upgrade-project.md#from-v4n-to-v414).