### PR TITLE
enhance: assume local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ publish-latest:
 
 .PHONY: start
 start:
-	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml up
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml up
 
 .PHONY: stop
 stop:
-	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml down
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml down
 
 .PHONY: stop-verbose
 stop-v:
-	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml down -v
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.dev.yml down -v

--- a/README.md
+++ b/README.md
@@ -122,24 +122,26 @@ Read [Upgrade Project] for developer instructions.
 
 ### New Minor or Patch Version (or Branch)
 
-#### For Testing
-
 ```sh
 make stop
 make build
 make start
 ```
 
-#### For Developing & Testing
+<details><summary>Advanced</summary>
+
+To only update as necessary, or update since uncommon changes:
 
 | | If this changed | Run this command |
 | - | - | - |
-| 0 | Dockerfile | `make build` then re-start the container |
+| 0 | Dockerfile | `make stop`, `make build`, `make start` |
 | 1 | Python models | `docker exec -it core_cms sh -c "python manage.py migrate"` |
 | 2 | Node dependencies | `npm ci` |
 | 3 | CSS stylesheets | `npm run build:css` |
 | 4 | UI Demo | `npm run build:ui-demo` |
 | 5 |  Assets e.g.<br><sub>images, stylesheets, JavaScript, UI demo</sub> | `docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"` |
+
+</details>
 
 ## Develop Project
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Set up a new local CMS instance.
 
 3. Build & Start the Docker Containers:
 
-    | For Testing | For Developing & Testing |
-    | - | - |
-    | `make start` | `docker compose -f ./docker-compose.dev.yml up` |
+    ```sh
+    make start
+    ```
 
     > **Note**
     > This will make the terminal window busy. To run commands after this, **either** open a new terminal window **or** run `docker compose -f ./docker-compose.dev.yml up --detach` instead.


### PR DESCRIPTION
## Overview

Assume anyone running `make start` is developing locally.

<details>Our deploy process uses its own docker-compose files and Dockerfiles.</details>

## Related

- mimics https://github.com/TACC/Core-Portal/blob/v3.7.0/Makefile#L29-L39

## Changes

- **changed** Makefile to use dev compose files
- **changed** README to assume reader is a developer

## Testing

1. `make build`
2. `make start`
3. change any code
4. verify change is synced to docker compose

## UI

1. Read ["Getting Started"](https://github.com/TACC/Core-CMS/blob/chore/assume-anyone-running-make-start-within-repo-is-developing/README.md#getting-started) (specifically, "3. Build & …").
5. Read ["Update Project"](https://github.com/TACC/Core-CMS/blob/chore/assume-anyone-running-make-start-within-repo-is-developing/README.md#update-project) (specifically, "▶ Advanced").