### PR TITLE
feat: secrets.example.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ project_name.var
 *settings_custom*.py
 *settings_local*.py
 custom_app_settings.py
+!*.example.py
 *.custom.yml
 urls_custom.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,10 @@ project_name.var
 
 # Secrets and Customizations
 *secrets*.py
-*.custom.yml
 *settings_custom*.py
 *settings_local*.py
 custom_app_settings.py
+*.custom.yml
 urls_custom.py
 
 # Makefile var

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ Set up a new local CMS instance.
     cd Core-CMS
     ```
 
-2. Add Core CMS Settings:
+2. Add Core CMS Settings & Secrets:
 
-    Create a `taccsite_cms/settings_local.py` with content from `settings_local.example.py`, e.g.
+    Create a `taccsite_cms/*.py` for every `*.example.py`, e.g.
 
     ```sh
+    cp taccsite_cms/settings_custom.example.py taccsite_cms/settings_custom.py
+    cp taccsite_cms/secrets.example.py taccsite_cms/secrets.py
     cp taccsite_cms/settings_local.example.py taccsite_cms/settings_local.py
     ```
 

--- a/taccsite_cms/secrets.example.py
+++ b/taccsite_cms/secrets.example.py
@@ -4,16 +4,6 @@
 
 SECRET_KEY = 'CHANGE_ME'
 
-# Specify allowed hosts or use an asterisk to allow any host.
-# ALLOWED_HOSTS = ['hostname.tacc.utexas.edu', 'client.org'] # Dev/Prod/Etc
-ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']   # Local
-
-########################
-# TACC: PORTAL
-########################
-
-CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'
-
 ########################
 # STORAGE
 ########################

--- a/taccsite_cms/secrets.example.py
+++ b/taccsite_cms/secrets.example.py
@@ -1,0 +1,48 @@
+########################
+# DJANGO
+########################
+
+SECRET_KEY = 'CHANGE_ME'
+
+# Specify allowed hosts or use an asterisk to allow any host.
+# ALLOWED_HOSTS = ['hostname.tacc.utexas.edu', 'client.org'] # Dev/Prod/Etc
+ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']   # Local
+
+########################
+# TACC: PORTAL
+########################
+
+CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'
+
+########################
+# STORAGE
+########################
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'PORT': '5432',
+        'NAME': 'taccsite',
+        'USER': 'postgresadmin',
+        'PASSWORD': 'taccforever',
+        'HOST': 'core_cms_postgres'
+    }
+}
+
+########################
+# SEARCH
+########################
+
+ES_AUTH = 'username:password'
+ES_HOSTS = 'http://elasticsearch:9200'
+ES_INDEX_PREFIX = 'cms-dev-{}'
+ES_DOMAIN = 'http://localhost:8000'
+
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+        'URL': ES_HOSTS,
+        'INDEX_NAME': ES_INDEX_PREFIX.format('cms'),
+        'KWARGS': {'http_auth': ES_AUTH }
+    }
+}

--- a/taccsite_cms/settings_local.example.py
+++ b/taccsite_cms/settings_local.example.py
@@ -5,6 +5,17 @@ For a detailed walkthrough on overriding settings, see `settings_custom.example.
 https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/settings_custom.example.py
 '''
 
+# https://docs.djangoproject.com/en/4.2/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost', '*']   # Local
+# ALLOWED_HOSTS = ['hostname.tacc.utexas.edu', 'client.org'] # Dev/Prod/Etc
+
+# To manage remote CMS authentication
+CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'
+LOGIN_REDIRECT_URL = '/'
+
+# https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-DEBUG
+DEBUG = True
+
 # To hide error about using Google Recaptcha test keys
 SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
 


### PR DESCRIPTION
## Overview

Create a `secrets.example.py`.

## Related

- similar to https://github.com/TACC/Core-CMS/pull/577
- similar to [Core-Portal's `settings_secret.example.py`](https://github.com/TACC/Core-Portal/blob/v3.7.0/server/portal/settings/settings_secret.example.py)

## Changes

- **added** `secrets.example.py`
- **documented** creation of `secrets.py`
- **documented** creation of `settings_custom.py`

## Testing & UI

N/A