### PR TITLE
deps: s-footer updates via core-styles 2.33.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "github:TACC/Core-Styles#enhance/white-headings-in-s-footer",
+        "@tacc/core-styles": "^2.33.0",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -1236,8 +1236,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.32.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#c71cd0a7b3d657d5dc3ce1bbf5f7b87a083478db",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.33.0.tgz",
+      "integrity": "sha512-4Zo3MOlFiubTxUV1u4YU4A+uXy0dRZ48m6I3EVu451vaxIxsw9oly/HorqXEONQGjQgBGZTnpEktPFyAAeijbQ==",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -10047,8 +10048,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#c71cd0a7b3d657d5dc3ce1bbf5f7b87a083478db",
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#enhance/white-headings-in-s-footer",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.33.0.tgz",
+      "integrity": "sha512-4Zo3MOlFiubTxUV1u4YU4A+uXy0dRZ48m6I3EVu451vaxIxsw9oly/HorqXEONQGjQgBGZTnpEktPFyAAeijbQ==",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "github:TACC/Core-Styles#enhance/white-headings-in-s-footer",
+    "@tacc/core-styles": "^2.33.0",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",


### PR DESCRIPTION
## Overview

Update to Core-Styles [v2.33.0](https://github.com/TACC/Core-Styles/releases/tag/v2.33.0) to get `s-footer` enhancements.

## Testing & UI

- https://github.com/TACC/tup-ui/pull/476