### PR TITLE
deps: core-styles v2.33.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@frctl/fractal": "^1.5.14",
         "@frctl/mandelbrot": "^1.10.1",
-        "@tacc/core-styles": "^2.33.0",
+        "@tacc/core-styles": "^2.33.1",
         "minimist": "^1.2.6"
       },
       "engines": {
@@ -1236,9 +1236,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.33.0.tgz",
-      "integrity": "sha512-4Zo3MOlFiubTxUV1u4YU4A+uXy0dRZ48m6I3EVu451vaxIxsw9oly/HorqXEONQGjQgBGZTnpEktPFyAAeijbQ==",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.33.1.tgz",
+      "integrity": "sha512-1YRY9Tj13lqOOrVXVStXtUK7c6/QIfm3UuWfGMkuP96YN0lyBDDaeobMs8LV432p/4cpVydlQHEhPD+JHh3Ycw==",
       "bin": {
         "core-styles": "src/cli.js"
       },
@@ -10048,9 +10048,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.33.0.tgz",
-      "integrity": "sha512-4Zo3MOlFiubTxUV1u4YU4A+uXy0dRZ48m6I3EVu451vaxIxsw9oly/HorqXEONQGjQgBGZTnpEktPFyAAeijbQ==",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.33.1.tgz",
+      "integrity": "sha512-1YRY9Tj13lqOOrVXVStXtUK7c6/QIfm3UuWfGMkuP96YN0lyBDDaeobMs8LV432p/4cpVydlQHEhPD+JHh3Ycw==",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@frctl/fractal": "^1.5.14",
     "@frctl/mandelbrot": "^1.10.1",
-    "@tacc/core-styles": "^2.33.0",
+    "@tacc/core-styles": "^2.33.1",
     "minimist": "^1.2.6"
   },
   "repository": "git@github.com:TACC/Core-CMS.git",


### PR DESCRIPTION
## Overview

Update to Core-Styles v2.33.1, which restores v2 Portal message styles.

## Testing & UI

See https://github.com/TACC/tup-ui/pull/476 at "Portal Message Style is Unchanged".