### PR TITLE
test: customize djangocms_blog feed ⚠️

### DIFF
--- a/apps/custom_djangocms_blog_feed/apps.py
+++ b/apps/custom_djangocms_blog_feed/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+class djangoCMSBlogFeedAppConfig(AppConfig):
+    name = 'apps.custom_djangocms_blog_feed'

--- a/apps/custom_djangocms_blog_feed/feeds.py
+++ b/apps/custom_djangocms_blog_feed/feeds.py
@@ -1,0 +1,26 @@
+from aldryn_apphooks_config.utils import get_app_instance
+from django.utils.feedgenerator import Rss201rev2Feed
+
+from djangocms_blog.feeds import LatestEntriesFeed as DjangoCMSBlogLatestEntriesFeed
+from djangocms_blog.settings import get_setting
+from djangocms_blog.cms_appconfig import BlogConfig
+
+# XXX: This file is loaded, but it does NOT override the feed
+# XXX: Logging via logger fails anywhere; via print fails inside any method
+class LatestEntriesFeed(DjangoCMSBlogLatestEntriesFeed):
+    feed_type = Rss201rev2Feed
+    feed_items_number = get_setting("FEED_LATEST_ITEMS")
+
+    def __call__(self, request, *args, **kwargs):
+        namespace = get_setting("AUTO_NAMESPACE")
+
+        self.request = request
+        self.namespace = get_setting("AUTO_NAMESPACE")
+        self.config = BlogConfig.objects.get(namespace=namespace)
+
+        return super().__call__(request, *args, **kwargs)
+
+    def items(self):
+        items = super().items()
+
+        return items

--- a/apps/custom_djangocms_blog_feed/urls.py
+++ b/apps/custom_djangocms_blog_feed/urls.py
@@ -7,6 +7,7 @@ from .feeds import LatestEntriesFeed
 app_name = 'custom_djangocms_blog_feed'
 urlpatterns = [
     # To render styled Blog feed
+    # XXX: Does NOT load page
     # XXX: Does NOT style the feed
     # XXX: Does NOT customize the feed
     # FAQ: See errors at `/blog/feed/`, items at `/blog/feed/fb`

--- a/apps/custom_djangocms_blog_feed/urls.py
+++ b/apps/custom_djangocms_blog_feed/urls.py
@@ -1,0 +1,16 @@
+from django.urls import path
+
+from .feeds import LatestEntriesFeed
+
+# from apps.custom_example.views import CustomExampleView
+
+app_name = 'custom_djangocms_blog_feed'
+urlpatterns = [
+    # To render styled Blog feed
+    # XXX: Does NOT style the feed
+    # XXX: Does NOT customize the feed
+    # FAQ: See errors at `/blog/feed/`, items at `/blog/feed/fb`
+    # FAQ: See Blog app feed root at `/news/feed/`, items at `/news/feed/fb`
+    path('feed/', LatestEntriesFeed(), name='feed'),
+    # path('feed/', CustomExampleView, name='feed'),
+]

--- a/taccsite_cms/custom_app_settings.example.py
+++ b/taccsite_cms/custom_app_settings.example.py
@@ -1,3 +1,3 @@
-CUSTOM_APPS = ['apps.custom_example']
+CUSTOM_APPS = ['apps.custom_example', 'apps.custom_djangocms_blog_feed']
 CUSTOM_MIDDLEWARE = []
 STATICFILES_DIRS = ()

--- a/taccsite_cms/urls_custom.example.py
+++ b/taccsite_cms/urls_custom.example.py
@@ -1,5 +1,5 @@
-from django.urls import path, include
+from django.urls import re_path, include
 
 custom_urls = [
-    path('custom_test/', include('apps.custom_example.urls', namespace='custom_test')),
+    re_path(r'^custom_test/', include('apps.custom_example.urls', namespace='custom_test')),
 ]


### PR DESCRIPTION
## Overview

Customize feed of Django CMS Blog to output HTML.

> [!CAUTION]
> This code does **not** work.

## Related

- possible solution for [TUP-706](https://tacc-main.atlassian.net/browse/TUP-706)
- taken from old commit of #868

## Changes

- **added** custom app
- **added** custom urls

## Testing

1. Have a Blog installed.
2. Load https://localhost:8000/blog/feed
3. ❌ See blog rendered as HTML.

> [!CAUTION]
> **Server Error.**
> > NoReverseMatch at /blog/feed/
> > '' is not a registered namespace

## UI

…

<!--
## Notes

…
-->
