### PR TITLE
fix: custom_example app not working

### DIFF
--- a/taccsite_cms/urls_custom.example.py
+++ b/taccsite_cms/urls_custom.example.py
@@ -1,5 +1,5 @@
-from django.urls import path, include
+from django.urls import re_path, include
 
 custom_urls = [
-    path('custom_test/', include('apps.custom_example.urls', namespace='custom_test')),
+    re_path(r'^custom_test/', include('apps.custom_example.urls', namespace='custom_test')),
 ]


### PR DESCRIPTION
## Overview

Ensure `custom_example` app will render.

## Related

This bug kept confusing me when I use the app as reference but it does not work.

## Changes

- **changed** path syntax for url

## Testing

1. In `custom_app_settings.py`, add `custom_example` app e.g.
    ```py
    CUSTOM_APPS = ['apps.custom_example']
    ```
2. In `urls_custom.py`, add `custom_example` app e.g.
    ```py
    re_path(r'^custom_test/', include('apps.custom_example.urls', namespace='custom_test')),
    ```
3. Open https://localhost:8000/custom_test.
4. See "CUSTOM APP" page rendered.

## UI

<img width="920" alt="custom_test" src="https://github.com/user-attachments/assets/c8bbe7b0-466e-48b4-9f88-dfd9fb368d72">
