### PR TITLE
fix: do not show branding if setting is false-y

### DIFF
--- a/taccsite_cms/templates/header_branding.html
+++ b/taccsite_cms/templates/header_branding.html
@@ -26,7 +26,7 @@
 </div>
 {% endwith %}
 
-{% else %}
+{% elif settings.PORTAL_BRANDING %}
 
 {% with settings.PORTAL_BRANDING as brands %}
 <div id="header-branding" class="branding-header {{className}}">


### PR DESCRIPTION
## Overview

Be able to hide branding bar just by setting `PORAL_BRANDING` to false.

## Related

- achieves documented promise/lie in #841

## Changes

- **changed** template logic `else` to an `elif`

## Testing

1. Set `PORTAL_BRANDING = False`.
2. Load website.
3. Verify branding bar markup is not rendered.
    <sup>(Best to test on a site that is **not** hiding branding bar via CSS.)</sup>

## UI

| before | after |
| - | - |
| <img width="919" alt="BEFORE" src="https://github.com/user-attachments/assets/61222c14-efcb-41b7-8a15-9453c4dd63e1"> | <img width="919" alt="AFTER" src="https://github.com/user-attachments/assets/16581e9c-0df3-4865-afd5-ff30f828dd9f"> |

> [!NOTE]
> This site hides branding bar via CSS, so I test for markup presence.