### PR TITLE
fix: add muted section to container dropdown

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -617,15 +617,23 @@ DJANGOCMS_BOOTSTRAP4_GRID_CONTAINERS = [
             _('Container + Light section')
         ),
         (
+            'container  o-section o-section--style-muted',
+            _('Container + Muted section')
+        ),
+        (
             'container  o-section o-section--style-dark',
             _('Container + Dark section')
         ),
     )),
     (_('Fluid container'), (
-        ('container-fluid', _('Fluid')), # default
+        ('container-fluid', _('Fluid container')), # default
         (
             'container-fluid  o-section o-section--style-light',
             _('Fluid container + Light section')
+        ),
+        (
+            'container-fluid  o-section o-section--style-muted',
+            _('Fluid container + Muted section')
         ),
         (
             'container-fluid  o-section o-section--style-dark',
@@ -636,6 +644,10 @@ DJANGOCMS_BOOTSTRAP4_GRID_CONTAINERS = [
         (
             'o-section o-section--style-light',
             _('Light section')
+        ),
+        (
+            'o-section o-section--style-muted',
+            _('Muted section')
         ),
         (
             'o-section o-section--style-dark',


### PR DESCRIPTION
## Overview

Add "Muted" sections to Container drop-down.

## Related

- fixes #431

## Changes

- **added** item to list

## Testing

1. Add Container.
2. Choose "Muted" option.
3. Verify muted section is added.

## UI

<img width="919" alt="Muted Option" src="https://github.com/user-attachments/assets/07054867-8e6a-4d85-b946-a895d3428915">
<img width="919" alt="Muted Render" src="https://github.com/user-attachments/assets/3335926b-30c2-4246-8207-876bcc37e0e7">
