### PR TITLE
chore: do not clone bootstrap for `tacc-search-bar`

### DIFF
--- a/taccsite_cms/templates/nav_search.html
+++ b/taccsite_cms/templates/nav_search.html
@@ -14,13 +14,6 @@
 
   const template = document.getElementById('s-search-bar').firstElementChild;
 
-  {% if settings.TACC_CORE_STYLES_VERSION == 0 %}
-  /* Load necessary Bootstrap outside raw markup (reason is not documented) */
-  template.content.prepend(
-    document.getElementById('css-bootstrap').cloneNode(true)
-  );
-  {% endif %}
-
   registerCustomElement.fromTemplate(template, 'tacc-search-bar');
 </script>
 


### PR DESCRIPTION
## Overview

Injecting the TACC search bar is not affected by the presence of Bootstrap, so don't load markup inside the custom element.

## Related

- fixes bug in #856
- mirrored by https://github.com/TACC/Core-Portal/pull/971

## Changes

- **removed** cloning of markup that loads Bootstrap stylesheet

## Testing

1. Verify Bootstrap markup being cloned has no effect on UI and UX.

## UI

### With Cloned Bootstrap Markup

https://github.com/user-attachments/assets/73444042-05fb-4c27-858d-fe0a54b0ca13

## Sans Cloned Bootstrap Markup

https://github.com/user-attachments/assets/f5f392b8-6861-49b8-a30d-7844a85d2fb4

## Notes

**Why?** This may have had a purpose, and better CSS made that purpose moot. This may have had a theoretical-only purpose.