### PR TITLE
feat: ctrn layout design test

### DIFF
--- a/taccsite_cms/templates/split.html
+++ b/taccsite_cms/templates/split.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block title %}{% page_attribute "page_title" %}{% endblock title %}
+
+{% block content %}
+<style>
+  /* To strech content vertically */
+  body {
+    display: flex;
+    flex-direction: column;
+  }
+  #cms-content {
+    flex-grow: 1;
+  }
+  .cms-content-panel > [class*="container"] {
+    height: 100%;
+  }
+
+  /* To split the layout */
+  #cms-content {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+  #cms-breadcrumbs {
+    grid-column-start: 1;
+    grid-column-end: -1;
+    grid-row: 1;
+    z-index: 1;
+  }
+  #cms-content-left {
+    grid-column-start: 1;
+    grid-row: 1;
+  }
+  #cms-content-right {
+    grid-column-start: 2;
+    grid-row: 1;
+  }
+
+  /* To fix section seemingly missing its background color */
+  :where(.o-section, [class*=section--]) {
+    box-shadow: none;
+  }
+
+  /* To angle any background color */
+  #cms-content-left {
+    clip-path: polygon(0% 0%, 100% 0%, 90% 100%, 0% 100%);
+  }
+
+  /* To improve legibility of breadcrumbs atop sections */
+  #cms-breadcrumbs {
+    color: var(--global-color-primary--x-light);
+    mix-blend-mode: exclusion;
+    text-align: center;
+  }
+
+  /* To allow columns to touch footer */
+  body > main {
+    margin-bottom: 0;
+  }
+
+  /* To remove borders on muted sections */
+  .o-section--style-muted {
+    border-top: none;
+    border-bottom: none;
+  }
+</style>
+
+  {% block breadcrumbs %}
+    {% include "nav_cms_breadcrumbs.html" with className="container-fluid" %}
+  {% endblock breadcrumbs %}
+
+  {% block cms_content %}
+    <div id="cms-content-left" class="cms-content-panel">
+      {% placeholder "left" %}
+    </div>
+    <div id="cms-content-right" class="cms-content-panel">
+      {% placeholder "right" %}
+    </div>
+  {% endblock cms_content %}
+
+  {% block app_content %}{% endblock app_content %}
+{% endblock content %}


### PR DESCRIPTION
## Overview

Demo layout that stakeholder imagines for CTRN website.

> [!CAUTION]
> Good features. Design unapproved. Closing in favor of #882.

## Related

- [RT #100172](https://consult.tacc.utexas.edu/Ticket/Display.html?id=100172)

## Changes

- **added** template with Left and Right placeholders
- **added** styles for breadcrumbs overlapping layout
- **added** styles for angled background

## Testing

0. Add/Edit to `settings_custom.py` or `settings_local.py` with:

    ```py
    CMS_TEMPLATES = (
        ('standard.html', 'Standard'),
        ('fullwidth.html', 'Full Width'),
        ('split.html', 'Split (Two-Side)'),
    )
    ```

1. Create/Update page to have "Split (Two-Side)" layout.
2. Create/Update structure to have different color fluid containers with text.
    <img width="460" alt="structure" src="https://github.com/user-attachments/assets/665fc86f-1b20-46b6-b710-5f5994b1f7bc">
    - In the "Left" add a Container "Fluid container + Muted section" with child Text.
    - In the "Right" add a Container "Fluid container + Light section" with child Text.

## UI

| Stakeholder Inspiration | Basic Implementation |
| - | - |
| <img width="395" alt="sample target design" src="https://github.com/user-attachments/assets/622a6eea-2be9-4d5c-a922-760e577857f6"> | <img width="920" alt="angle bkgd, tall page" src="https://github.com/user-attachments/assets/d03944fb-04b7-4139-be72-3aaabe3a9be9"> |

| Short Page | Tall Page |
| - | - |
| <img width="920" alt="angle bkgd, short page" src="https://github.com/user-attachments/assets/7319dae0-a8f8-43ce-85a8-0df501c9b25f"> | <img width="920" alt="angle bkgd, tall page" src="https://github.com/user-attachments/assets/d03944fb-04b7-4139-be72-3aaabe3a9be9"> |

| Muted & Light Section | Dark & Light Section |
| - | - |
| <img width="920" alt="angle bkgd, tall page" src="https://github.com/user-attachments/assets/d03944fb-04b7-4139-be72-3aaabe3a9be9"> | <img width="920" alt="breadcrumbs on dark and light" src="https://github.com/user-attachments/assets/9394faf2-ac27-4fd2-9843-d306ea0a1f21"> |