### PR TITLE
feat: split layout template

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/template.split.css
+++ b/taccsite_cms/static/site_cms/css/src/template.split.css
@@ -1,0 +1,51 @@
+@import url("@tacc/core-styles/src/lib/_imports/objects/o-section.selectors.css");
+
+@custom-selector :--django-cms-edit-mode   [class*="cms-structure-mode-"];
+
+/* To strech content vertically */
+body {
+  display: flex;
+  flex-direction: column;
+}
+#cms-content {
+  flex-grow: 1;
+}
+.cms-content-panel > [class*="container"] {
+  height: 100%;
+}
+
+/* To split the layout */
+#cms-content {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+#cms-content-left {
+  grid-column-start: 1;
+  grid-row: 1;
+}
+#cms-content-right {
+  grid-column-start: 2;
+  grid-row: 1;
+}
+
+/* To fix section seemingly missing its background color */
+/* TODO: Invetigate and fix bug */
+:--o-section {
+  box-shadow: none;
+}
+
+/* To allow columns to touch footer */
+body > main {
+  margin-bottom: 0;
+}
+
+/* To remove borders on muted section touching container */
+.cms-content-panel > :--o-section--muted {
+  &:first-child {
+    border-top: none;
+  }
+  &:last-child,
+  :--django-cms-edit-mode &:has(+ .cms-placeholder) {
+    border-bottom: none;
+  }
+}

--- a/taccsite_cms/templates/split.html
+++ b/taccsite_cms/templates/split.html
@@ -44,7 +44,7 @@
     }
 
     /* To remove borders on muted section touching container */
-    .cms-content-panel > .o-section--style-muted {
+    .cms-content-panel > [class*="section--style-muted"] {
       &:first-child {
         border-top: none;
       }

--- a/taccsite_cms/templates/split.html
+++ b/taccsite_cms/templates/split.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load cms_tags static %}
 
-{% block title %}{% page_attribute "page_title" %}{% endblock title %}
-
 {% block assets_custom %}
 	{{ block.super }}
   <link rel="stylesheet" href="{% static 'site_cms/css/build/template.split.css' %}">

--- a/taccsite_cms/templates/split.html
+++ b/taccsite_cms/templates/split.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block title %}{% page_attribute "page_title" %}{% endblock title %}
+
+{# To remove container and breadcrumbs #}
+{% block content %}
+
+  <style>
+    /* To strech content vertically */
+    body {
+      display: flex;
+      flex-direction: column;
+    }
+    #cms-content {
+      flex-grow: 1;
+    }
+    .cms-content-panel > [class*="container"] {
+      height: 100%;
+    }
+
+    /* To split the layout */
+    #cms-content {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+    }
+    #cms-content-left {
+      grid-column-start: 1;
+      grid-row: 1;
+    }
+    #cms-content-right {
+      grid-column-start: 2;
+      grid-row: 1;
+    }
+
+    /* To fix section seemingly missing its background color */
+    :where(.o-section, [class*=section--]) {
+      box-shadow: none;
+    }
+
+    /* To allow columns to touch footer */
+    body > main {
+      margin-bottom: 0;
+    }
+
+    /* To remove borders on muted section touching container */
+    .cms-content-panel > .o-section--style-muted {
+      &:first-child {
+        border-top: none;
+      }
+      &:last-child,
+      [class*="cms-structure-mode-"] &:has(+ .cms-placeholder) {
+        border-bottom: none;
+      }
+    }
+  </style>
+
+  {% block cms_content %}
+  <div id="cms-content-left" class="cms-content-panel">
+    {% placeholder "left" %}
+  </div>
+  <div id="cms-content-right" class="cms-content-panel">
+    {% placeholder "right" %}
+  </div>
+  {% endblock cms_content %}
+
+  {% block app_content %}{% endblock app_content %}
+
+{% endblock content %}
+

--- a/taccsite_cms/templates/split.html
+++ b/taccsite_cms/templates/split.html
@@ -1,60 +1,15 @@
 {% extends "base.html" %}
-{% load cms_tags %}
+{% load cms_tags static %}
 
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}
 
+{% block assets_custom %}
+	{{ block.super }}
+  <link rel="stylesheet" href="{% static 'site_cms/css/build/template.split.css' %}">
+{% endblock assets_custom %}
+
 {# To remove container and breadcrumbs #}
 {% block content %}
-
-  <style>
-    /* To strech content vertically */
-    body {
-      display: flex;
-      flex-direction: column;
-    }
-    #cms-content {
-      flex-grow: 1;
-    }
-    .cms-content-panel > [class*="container"] {
-      height: 100%;
-    }
-
-    /* To split the layout */
-    #cms-content {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-    }
-    #cms-content-left {
-      grid-column-start: 1;
-      grid-row: 1;
-    }
-    #cms-content-right {
-      grid-column-start: 2;
-      grid-row: 1;
-    }
-
-    /* To fix section seemingly missing its background color */
-    /* TODO: Invetigate and fix bug */
-    :where(.o-section, [class*=section--]) {
-      box-shadow: none;
-    }
-
-    /* To allow columns to touch footer */
-    body > main {
-      margin-bottom: 0;
-    }
-
-    /* To remove borders on muted section touching container */
-    .cms-content-panel > [class*="section--style-muted"] {
-      &:first-child {
-        border-top: none;
-      }
-      &:last-child,
-      [class*="cms-structure-mode-"] &:has(+ .cms-placeholder) {
-        border-bottom: none;
-      }
-    }
-  </style>
 
   {% block cms_content %}
   <div id="cms-content-left" class="cms-content-panel">

--- a/taccsite_cms/templates/split.html
+++ b/taccsite_cms/templates/split.html
@@ -34,6 +34,7 @@
     }
 
     /* To fix section seemingly missing its background color */
+    /* TODO: Invetigate and fix bug */
     :where(.o-section, [class*=section--]) {
       box-shadow: none;
     }


### PR DESCRIPTION
## Overview

Layout that offers left- and right-side content.

## Status

> [!IMPORTANT]
> Replaced by:
> - #888
> - #889

- [ ] Verify whether this is useful.
    <sup>Django CMS Bootstrap grid already provides this and lets editor handle narrow screen layout.</sup>
- [ ] Support narrow screen layout.

## Related

- [CMD-186](https://tacc-main.atlassian.net/browse/CMD-186)
- replaces #881

## Changes

- **added** template with Left and Right placeholders
- **added** styles for breadcrumbs overlapping layout
- **added** styles for angled background

## Testing

> [!NOTE]
> Available to test on https://pprd.lccf.tacc.utexas.edu/ctrn-web/.

0. Checkout this branch and run:

    ```shell
    npm run build:css
    docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"
    
    ```

1. Add/Edit to `settings_custom.py` or `settings_local.py` with:

    ```py
    CMS_TEMPLATES = (
        ('standard.html', 'Standard'),
        ('fullwidth.html', 'Full Width'),
        ('split.html', 'Split (Two-Side)'),
    )
    ```

2. Create/Update page to have "Split (Two-Side)" layout.
3. Create/Update structure to have different color fluid containers with text.
    <img width="460" alt="structure" src="https://github.com/user-attachments/assets/665fc86f-1b20-46b6-b710-5f5994b1f7bc">
    - In the "Left" add a Container "Fluid container + Muted section" with child Text.
    - In the "Right" add a Container "Fluid container + Light section" with child Text.

## UI

| Muted & Light Section | Dark & Light Section |
| - | - |
| <img width="920" alt="Muted + Light" src="https://github.com/user-attachments/assets/7826344d-917e-4fe7-b5e4-98007511f5ed"> | <img width="920" alt="Dark + Light" src="https://github.com/user-attachments/assets/3c3dc6c9-7e4a-4f8c-afa7-fa968920c711"> |