### PR TITLE
fix: blog install steps are outdated

### DIFF
--- a/taccsite_cms/custom_app_settings.example.py
+++ b/taccsite_cms/custom_app_settings.example.py
@@ -1,3 +1,15 @@
-CUSTOM_APPS = ['apps.custom_example']
+CUSTOM_APPS = [
+
+    # CUSTOM APP
+    'apps.custom_example'
+
+    # DJANGOCMS_BLOG
+    'parler',
+    'taggit',
+    'taggit_autosuggest',
+    'sortedm2m',
+    'djangocms_blog',
+
+]
 CUSTOM_MIDDLEWARE = []
 STATICFILES_DIRS = ()

--- a/taccsite_cms/settings_custom.example.py
+++ b/taccsite_cms/settings_custom.example.py
@@ -114,49 +114,11 @@ PORTAL_SEARCH_INDEX_IS_AUTOMATIC = False
 # DJANGOCMS_BLOG
 ########################
 
-from taccsite_cms.settings import INSTALLED_APPS
-
-tacc_app_index = INSTALLED_APPS.index('taccsite_cms')
-INSTALLED_APPS[tacc_app_index:tacc_app_index] = [
-    # 'aldryn_apphooks_config' # already in Core
-    # 'filer',              # already in Core
-    # 'easy_thumbnails',    # already in Core
-    'parler',
-    'taggit',
-    'taggit_autosuggest',
-    # 'meta',               # already in Core
-    'sortedm2m',
-    'djangocms_blog',
-]
-# REQ: 'taggit_autosuggest' requires the following is added to `urls.py`
-# FAQ: For local Core-CMS or any Core-CMS-Custom app, add to `urls_custom.py`
-"""
-from django.urls import re_path, include
-
-urlpatterns += [
-    # Support `taggit_autosuggest` (from `djangocms-blog`)
-    re_path(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
-]
-"""
-
-# Paths for alternate templates that user can choose for blog-specific plugin
-# - Devs can customize core templates at `templates/djangocms_blog/`.
-# - Users can choose alt. templates from `templates/djangocms_blog/plugins/*`.
-# - Devs can customize alt. templates at `templates/djangocms_blog/plugins/*`.
-BLOG_PLUGIN_TEMPLATE_FOLDERS = (
-    ('plugins', 'Default'),
-    # ('plugins/alternate', 'Alternate'),
-)
-
-# Change default values for the auto-setup of one `BlogConfig`
-# SEE: https://github.com/nephila/djangocms-blog/issues/629
 BLOG_AUTO_SETUP = True # Set to False after setup (minimize overhead)
 BLOG_AUTO_HOME_TITLE ='Home'
 BLOG_AUTO_BLOG_TITLE = 'News'
 BLOG_AUTO_APP_TITLE = 'News'
 BLOG_AUTO_NAMESPACE = 'News'
-
-# Miscellaneous settings
 BLOG_ENABLE_COMMENTS = False
 
 ########################
@@ -165,10 +127,3 @@ BLOG_ENABLE_COMMENTS = False
 
 PORTAL_BLOG_SHOW_CATEGORIES = True
 PORTAL_BLOG_SHOW_TAGS = True
-
-########################
-# DJANGOCMS_BLOG: DJANGO
-########################
-
-# TACC/Core-CMS-Resources#75: Load custom urls.py so we can add urlpatterns for taggit_autosuggest
-ROOT_URLCONF = 'taccsite_custom.example_cms.urls'

--- a/taccsite_cms/urls_custom.example.py
+++ b/taccsite_cms/urls_custom.example.py
@@ -1,5 +1,11 @@
 from django.urls import re_path, include
 
 custom_urls = [
+
+    # CUSTOM APP
     re_path(r'^custom_test/', include('apps.custom_example.urls', namespace='custom_test')),
+
+    # DJANGOCMS_BLOG
+    re_path(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
+
 ]


### PR DESCRIPTION
## Overview

Simplify blog installation steps by 100% using example settings in appropriate files.

## Related

- CTRN News (coming soon)
- [WTCS News](https://prod.wtcs.tacc.utexas.edu/news/latest-news/)

## Changes

- **moved** blog settings to relevant customization example files

## Testing

1. [Use these settings on a website.](https://github.com/TACC/Core-Portal-Deployments/compare/19cbc93...320934a)
2. Deploy that website.
3. [Verify blog is installed.](https://prod.wtcs.tacc.utexas.edu/news/latest-news/)

## UI

Skipped.