### PR TITLE
chore: CMD-143 retire deprecated templates

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -159,14 +159,6 @@ CMS_TEMPLATES = (
     ('fullwidth.html', 'Full Width'),
 
     ('guide.html', 'Guide'),
-    ('guides/portal_technology.html', 'Guide: Portal Technology Stack'),
-
-    # TODO: WP-394: Retire deprecated page templates
-    ('guides/getting_started.v3.html', 'Guide: Getting Started (v3)'),
-    ('guides/getting_started.tam.html', 'Guide: Getting Started (TAM)'),
-    ('guides/getting_started.v2.html', 'Guide: Getting Started (v2)'),
-    ('guides/data_transfer.html', 'Guide: Data Transfer'),
-    ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
 )
 
 CMS_PERMISSION = True

--- a/taccsite_cms/static/site_cms/img/guides/README.md
+++ b/taccsite_cms/static/site_cms/img/guides/README.md
@@ -1,0 +1,3 @@
+# TACC CMS - Static Files - Images - Guides
+
+All of these images are for guides that are deprecated, and none of which should be in use. They are retained in case the templates are used. They should be deleted in version 5.

--- a/taccsite_cms/templates/guides/README.md
+++ b/taccsite_cms/templates/guides/README.md
@@ -1,0 +1,3 @@
+# TACC CMS - Templates - Guides
+
+All of these templates are deprecated. None of them should be in use. They are retained in case they are used. They should be deleted in version 5.


### PR DESCRIPTION
## Overview

Retire deprecated templates (that will still work).

## Related

- [CMD-143](https://tacc-main.atlassian.net/browse/CMD-143)
- quick n’ safe version of #854

## Changes

- **deleted** "Guide" templates from default choices

## Testing

**None.** If template is already set to one of these, it will still work. Pages simply cannot be newly set (nor re-set) to these templates.

## UI

Skipped.