### PR TITLE
fix: importHTML.replaceFromURL can return null

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/importHTML.js
+++ b/taccsite_cms/static/site_cms/js/modules/importHTML.js
@@ -1,13 +1,20 @@
 /**
  * Create element from HTML string
  * @param {String} - HTML representing a single element
- * @return {Element}
+ * @return {Element|null} - Created element or null if HTML is empty
  * @see https://stackoverflow.com/a/35385518
  */
 export function htmlToElement(html) {
+  const trimmedHtml = html ? html.trim() : '';
+
+  // To never return a text node of whitespace
+  if (!trimmedHtml) {
+    return null;
+  }
+
   var template = document.createElement('template');
-  html = html.trim(); // Never return a text node of whitespace as the result
-  template.innerHTML = html;
+  template.innerHTML = trimmedHtml;
+
   return template.content.firstChild;
 }
 
@@ -68,8 +75,13 @@ export function replaceFromURL(markupURL, placeholder) {
   if (markupURL) {
     return getFromURL(markupURL).then(markup => {
       const newElement = htmlToElement(markup);
-      placeholder.replaceWith(newElement);
-      return placeholder;
+
+      if (newElement) {
+        placeholder.replaceWith(newElement);
+        return newElement;
+      } else {
+        return placeholder;
+      }
     });
   } else {
     return Promise.reject(new Error('No `markupURL` provided'));

--- a/taccsite_cms/static/site_cms/js/modules/importHTML.js
+++ b/taccsite_cms/static/site_cms/js/modules/importHTML.js
@@ -75,12 +75,14 @@ export function replaceFromURL(markupURL, placeholder) {
   if (markupURL) {
     return getFromURL(markupURL).then(markup => {
       const newElement = htmlToElement(markup);
+      const emptyNode = document.createTextNode('');
 
       if (newElement) {
         placeholder.replaceWith(newElement);
         return newElement;
       } else {
-        return placeholder;
+        placeholder.replaceWith(emptyNode);
+        return emptyNode;
       }
     });
   } else {


### PR DESCRIPTION
## Overview

Fix bug of rendering `null` above header on Portal if CMS has no header branding.

## Related

Noticed on https://pprd.lccf-portal.tacc.utexas.edu/workbench.

## Changes

- **changed** JavaScript logic

## Testing

0. Ensure `null` is rendered on a full Portal (after login).
1. Deploy CMS with image from this branch onto that portal.
2. Verify `null` does not show on that portal (after login).

## UI

| before | after |
| - | - |
| <img width="845" alt="before" src="https://github.com/user-attachments/assets/94313b4f-1ca4-4742-b629-cddd0539a499"> | <img width="845" alt="after" src="https://github.com/user-attachments/assets/3122ea62-99d2-4350-8802-53eb24d424d5"> |