### PR TITLE
fix: media editor adv unable to view/use folders

### DIFF
--- a/taccsite_cms/management/commands/group_perms/media_editor_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/media_editor_advanced.py
@@ -107,6 +107,13 @@ def set_group_perms():
     content_type = ContentType.objects.get(app_label='filer', model=model_name)
     group.permissions.add( Permission.objects.get(name='Can delete file', content_type=content_type) )
 
+    model_name = 'Folder'.lower().replace(' ', '')
+    content_type = ContentType.objects.get(app_label='filer', model=model_name)
+    group.permissions.add( Permission.objects.get(name='Can use directory listing', content_type=content_type) )
+    model_name = 'Folder'.lower().replace(' ', '')
+    content_type = ContentType.objects.get(app_label='filer', model=model_name)
+    group.permissions.add( Permission.objects.get(name='Can view Folder', content_type=content_type) )
+
     model_name = 'image'.lower().replace(' ', '')
     content_type = ContentType.objects.get(app_label='filer', model=model_name)
     group.permissions.add( Permission.objects.get(name='Can change image', content_type=content_type) )


### PR DESCRIPTION
## Overview

A "Media Editor (Advanced)" did not have "use directory listing" nor "view folders" permissions, yet a "Media Editor (Basic)" did.

## Related

None. I found this bug while preparing permission set for WTCS.

## Changes

- **added** permissions to "Media Editor (Advanced)"

## Testing & UI

Skipped.