### PR TITLE
fix: restore empty Container

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -649,7 +649,7 @@ DJANGOCMS_BOOTSTRAP4_GRID_CONTAINERS = [
             _('Fluid container + Dark section')
         ),
     )),
-    (_('No container'), (
+    (_('Section only'), (
         (
             'o-section',
             _('Section (transparent / margin)')
@@ -666,6 +666,12 @@ DJANGOCMS_BOOTSTRAP4_GRID_CONTAINERS = [
             'o-section o-section--style-dark',
             _('Dark section')
         ),
+    )),
+    (_('Empty'), (
+        (
+            '',
+            _('No container, No section')
+        )
     )),
 ]
 


### PR DESCRIPTION
## Overview

Restore ability to add a container that has no classes.

## Related

- WeTeach CS website

## Changes

- **changed** value in a setting
- **added** values to a setting

## Testing

1. Verify Container select menu has changed (see settings diff).

## UI

Skipped.