### PR TITLE
feat: RT-30806 "Header Banner" static_placeholder

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -64,6 +64,7 @@
   {% cms_toolbar %}
 
   <header>
+    {% static_placeholder "header banner" %}
     {% include "header.html" %}
   </header>
 


### PR DESCRIPTION
## Overview

Allow a banner (or any content) above the header.

## Status

Cancelled, because it would not be used often enough.

## Related

- [RT #30806](https://tickets.tacc.utexas.edu/Ticket/Display.html?id=30806)
- [I privately propose the feature to our CMS admin.](https://tacc-team.slack.com/archives/DPMDKQERK/p1732295543422989)

## Changes

- **added** `static_placeholder` "header banner"

## Testing

1. Load a page.
2. Verify "Header Banner" is available in Structure.
3. Add content to "Header Banner".
3. Verify that content appears above the header.

## UI

<img width="918" alt="Header Banner" src="https://github.com/user-attachments/assets/d4c89c7e-ce83-49c0-8db1-13779965582d">

## Notes

The `static_placeholder` feature is deprecated in Django CMS 4. The solution is a new `djangocms-alias` that is only supported on Django CMS 4. So, I think there is no future-compatible solution right now i.e. both this placeholder and `footer-content` will need to be converted to `djangocms-alias` after upgrade to Django CMS 4.