### PR TITLE
feat: CMD-193 custom links for findLinksAndSetTargets

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -1,5 +1,5 @@
 /**
- * The standard lnsk to open in new windows
+ * The standard links that should open in a new tab
  * @const {string}
  */
 export const DEFAULT_LINKS = document.querySelectorAll('body > :is(header, main, footer) a');
@@ -20,7 +20,9 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
-  console.log({ links, opts });
+  if (opts.shouldDebug) {
+    console.log({ links, opts });
+  }
 
   links.forEach( function setTarget( link ) {
     const linkHref = link.getAttribute('href');
@@ -35,7 +37,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
     const shouldOpenInNewTab = ( ! isSameHost || isMailto );
 
     if (opts.shouldDebug) {
-      console.debug({ isMailto, isAbsolute, isSameHost, linkHref });
+      console.debug({ isMailto, isAbsolute, isSameHost, linkHref, shouldOpenInNewTab });
     }
 
     // So either all or some links open in new tab

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -15,12 +15,12 @@ export const DEFAULT_LINKS = document.querySelectorAll('body > :is(header, main,
  */
 export default function findLinksAndSetTargets( links = DEFAULT_LINKS, {
   shouldDebug = false,
-  shouldFilter = true
+  shouldFilter = true,
 }) {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
-  console.log({ shouldDebug, links });
+  console.log({ shouldDebug, links, options });
 
   links.forEach( function setTarget( link ) {
     const linkHref = link.getAttribute('href');

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -20,6 +20,8 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS ) {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
+  console.log({ SHOULD_DEBUG, links });
+
   links.forEach( function setTarget( link ) {
     const linkHref = link.getAttribute('href');
 

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -8,13 +8,15 @@ const SHOULD_DEBUG = window.DEBUG;
  * Make links with absolute URLs open in new tab, and:
  * - add accessible markup
  * - fix absolute URLs that should be relative paths
+ * @param {NodeList} moreLinks - additional links to open in new tab
  */
-export default function findLinksAndSetTargets() {
+export default function findLinksAndSetTargets( moreLinks ) {
   const links = document.querySelectorAll('body > :is(header, main, footer) a');
+  const allLinks = [ ...links, ...moreLinks ];
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
-  [ ...links ].forEach( function setTarget(link) {
+  allLinks.forEach( function setTarget( link ) {
     const linkHref = link.getAttribute('href');
 
     if ( ! linkHref ) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -20,7 +20,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, options =
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
-  console.log({ shouldDebug, links, options });
+  console.log({ links, options });
 
   links.forEach( function setTarget( link ) {
     const linkHref = link.getAttribute('href');

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -1,10 +1,4 @@
 /**
- * Whether to log debug info to console
- * @const {string}
- */
-const SHOULD_DEBUG = window.DEBUG;
-
-/**
  * The standard lnsk to open in new windows
  * @const {string}
  */
@@ -14,13 +8,17 @@ export const DEFAULT_LINKS = document.querySelectorAll('body > :is(header, main,
  * Make links with absolute URLs open in new tab, and:
  * - add accessible markup
  * - fix absolute URLs that should be relative paths
- * @param {NodeList} links - additional links to open in new tab
+ * @param {NodeList} links - Custom links to open in new tab
+ * @param {object} options
+ * @param {boolean} options.shouldDebug - Whether to log debug statements
  */
-export default function findLinksAndSetTargets( links = DEFAULT_LINKS ) {
+export default function findLinksAndSetTargets( links = DEFAULT_LINKS, {
+  shouldDebug = false
+}) {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
-  console.log({ SHOULD_DEBUG, links });
+  console.log({ shouldDebug, links });
 
   links.forEach( function setTarget( link ) {
     const linkHref = link.getAttribute('href');
@@ -35,7 +33,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS ) {
     const isDefaultLink = Array.from( DEFAULT_LINKS ).includes( link );
     const shouldOpenInNewTab = ( ! isSameHost || isMailto );
 
-    if (SHOULD_DEBUG) {
+    if (shouldDebug) {
       console.debug({ isMailto, isAbsolute, isSameHost, linkHref, isDefaultLink });
     }
 
@@ -43,7 +41,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS ) {
     if ( ! isDefaultLink || shouldOpenInNewTab ) {
       if ( link.target !== '_blank') {
         link.target = '_blank';
-        if (SHOULD_DEBUG) {
+        if (shouldDebug) {
           console.debug(`Link ${linkHref} now opens in new tab`);
         }
       }

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -9,18 +9,18 @@ export const DEFAULT_LINKS = document.querySelectorAll('body > :is(header, main,
  * - add accessible markup
  * - fix absolute URLs that should be relative paths
  * @param {NodeList} links - Custom links to open in new tab
- * @param {object} options
- * @param {boolean} [options.shouldDebug=false] - Whether to log debug statements
- * @param {boolean} [options.shouldFilter=true] - Whether to filter which links to adjust
+ * @param {object} opts
+ * @param {boolean} [opts.shouldDebug=false] - Whether to log debug statements
+ * @param {boolean} [opts.shouldFilter=true] - Whether to filter which links to adjust
  */
-export default function findLinksAndSetTargets( links = DEFAULT_LINKS, options = {
+export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
   shouldDebug: false,
   shouldFilter: true,
 }) {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
-  console.log({ links, options });
+  console.log({ links, opts });
 
   links.forEach( function setTarget( link ) {
     const linkHref = link.getAttribute('href');
@@ -34,15 +34,15 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, options =
     const isSameHost = ( link.host === baseDocHost || link.host === baseDocHostWithSubdomain );
     const shouldOpenInNewTab = ( ! isSameHost || isMailto );
 
-    if (shouldDebug) {
+    if (opts.shouldDebug) {
       console.debug({ isMailto, isAbsolute, isSameHost, linkHref });
     }
 
     // So either all or some links open in new tab
-    if ( ! shouldFilter || ( shouldFilter && shouldOpenInNewTab )) {
+    if ( ! opts.shouldFilter || ( opts.shouldFilter && shouldOpenInNewTab )) {
       if ( link.target !== '_blank') {
         link.target = '_blank';
-        if (shouldDebug) {
+        if (opts.shouldDebug) {
           console.debug(`Link ${linkHref} now opens in new tab`);
         }
       }

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -13,9 +13,9 @@ export const DEFAULT_LINKS = document.querySelectorAll('body > :is(header, main,
  * @param {boolean} [options.shouldDebug=false] - Whether to log debug statements
  * @param {boolean} [options.shouldFilter=true] - Whether to filter which links to adjust
  */
-export default function findLinksAndSetTargets( links = DEFAULT_LINKS, {
-  shouldDebug = false,
-  shouldFilter = true,
+export default function findLinksAndSetTargets( links = DEFAULT_LINKS, options = {
+  shouldDebug: false,
+  shouldFilter: true,
 }) {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -20,7 +20,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
 
-  if (opts.shouldDebug) {
+  if ( opts.shouldDebug ) {
     console.log({ links, opts });
   }
 

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -11,11 +11,11 @@ export const DEFAULT_LINKS = document.querySelectorAll('body > :is(header, main,
  * @param {NodeList} links - Custom links to open in new tab
  * @param {object} options
  * @param {boolean} [options.shouldDebug=false] - Whether to log debug statements
- * @param {boolean} [options.shouldFilterLinks=true] - Whether to filter which links to adjust
+ * @param {boolean} [options.shouldFilter=true] - Whether to filter which links to adjust
  */
 export default function findLinksAndSetTargets( links = DEFAULT_LINKS, {
   shouldDebug = false,
-  shouldFilterLinks = true
+  shouldFilter = true
 }) {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
@@ -32,15 +32,14 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, {
     const isMailto = ( linkHref.indexOf('mailto:') === 0 );
     const isAbsolute = ( linkHref.indexOf('http') === 0 );
     const isSameHost = ( link.host === baseDocHost || link.host === baseDocHostWithSubdomain );
-    const isDefaultLink = Array.from( DEFAULT_LINKS ).includes( link );
     const shouldOpenInNewTab = ( ! isSameHost || isMailto );
 
     if (shouldDebug) {
-      console.debug({ isMailto, isAbsolute, isSameHost, linkHref, isDefaultLink });
+      console.debug({ isMailto, isAbsolute, isSameHost, linkHref });
     }
 
     // So either all or some links open in new tab
-    if ( ! shouldFilterLinks || ( shouldFilterLinks && shouldOpenInNewTab )) {
+    if ( ! shouldFilter || ( shouldFilter && shouldOpenInNewTab )) {
       if ( link.target !== '_blank') {
         link.target = '_blank';
         if (shouldDebug) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -18,7 +18,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
   shouldFilter: true,
 }) {
   const baseDocHost = document.location.host;
-  const baseDocHostWithSubdomain= `www.${baseDocHost}`;
+  const baseDocHostWithSubdomain= `www.${ baseDocHost }`;
 
   if ( opts.shouldDebug ) {
     console.log({ links, opts });
@@ -45,7 +45,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
       if ( link.target !== '_blank') {
         link.target = '_blank';
         if (opts.shouldDebug) {
-          console.debug(`Link ${linkHref} now opens in new tab`);
+          console.debug(`Link "${ linkHref }" now opens in new tab`);
         }
       }
       if ( link.target === '_blank') {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -10,10 +10,12 @@ export const DEFAULT_LINKS = document.querySelectorAll('body > :is(header, main,
  * - fix absolute URLs that should be relative paths
  * @param {NodeList} links - Custom links to open in new tab
  * @param {object} options
- * @param {boolean} options.shouldDebug - Whether to log debug statements
+ * @param {boolean} [options.shouldDebug=false] - Whether to log debug statements
+ * @param {boolean} [options.shouldFilterLinks=true] - Whether to filter which links to adjust
  */
 export default function findLinksAndSetTargets( links = DEFAULT_LINKS, {
-  shouldDebug = false
+  shouldDebug = false,
+  shouldFilterLinks = true
 }) {
   const baseDocHost = document.location.host;
   const baseDocHostWithSubdomain= `www.${baseDocHost}`;
@@ -37,8 +39,8 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, {
       console.debug({ isMailto, isAbsolute, isSameHost, linkHref, isDefaultLink });
     }
 
-    // So custom links or links to pages at different host open in new tab
-    if ( ! isDefaultLink || shouldOpenInNewTab ) {
+    // So either all or some links open in new tab
+    if ( ! shouldFilterLinks || ( shouldFilterLinks && shouldOpenInNewTab )) {
       if ( link.target !== '_blank') {
         link.target = '_blank';
         if (shouldDebug) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -44,7 +44,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
     if ( ! opts.shouldFilter || ( opts.shouldFilter && shouldOpenInNewTab )) {
       if ( link.target !== '_blank') {
         link.target = '_blank';
-        if (opts.shouldDebug) {
+        if ( opts.shouldDebug ) {
           console.debug(`Link "${ linkHref }" now opens in new tab`);
         }
       }


### PR DESCRIPTION
## Overview

Allow `findLinksAndSetTargets` to be performed on given links.

## Related

- [CMD-193](https://tacc-main.atlassian.net/browse/CMD-193)

## Changes

- **added** parameter `links` to `findLinksAndSetTargets()`

## Testing

1. <details><summary>Load on a Core-CMS website.</summary>

    1. Login as admin to website.
    2. Create a snippet:
        ```html
        <script type="module">
        /* TODO: After deploy of Core-CMS version that has https://github.com/TACC/Core-CMS/pull/902, change this snippet to load `/static/site_cms/js/modules/setTargetForExternalLinks.js` */
        import findLinksAndSetTargets from 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS@582f626e/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js';

        const links = document.querySelectorAll(
            'a[href*="/core/internal-docs/"]'
        );
        findLinksAndSetTargets( links, {
            shouldDebug: window.DEBUG, shouldFilterLinks: true
        });
        </script>
        ```

    </details>
2. Pass a known internal link.
3. Verify internal link opens in new tab.
4. Verify external links **still** open in new tab.

> [!TIP]
> Tested via [snippet](https://pprd.ptdatax.tacc.utexas.edu/admin/djangocms_snippet/snippet/2) that loads [script](https://github.com/TACC/Core-CMS-Custom/blob/f9ac653e/ptdatax_assets/open-certain-links-in-new-tab.js) that uses this updated script.

## UI

| should open in new tab |
| - |
| <img width="845" alt="should open in new tab" src="https://github.com/user-attachments/assets/7adcb3f9-bcd1-4bc7-9c9a-9aecf417c351"> |

https://github.com/user-attachments/assets/8f588e01-7bf4-49e4-9f30-bf2309d806e6

Skipped UI for —

> Verify external links **still** open in new tab.

— but I tested that too (successfully).