### PR TITLE
feat: cmd-194 enable portal nav by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Set up a new local CMS instance.
         - This page will automatically be your local homepage.
 
 > **Important**
-> A local machine CMS will be empty. It will **not** have content from staging **nor** production. If you need that, follow and adapt instructions to [copy a database](https://confluence.tacc.utexas.edu/x/W4DZDg).
+> A local machine CMS will be empty. It will **not** have content from staging **nor** production. If you need that, follow and adapt instructions to [replicate a CMS database](https://tacc-main.atlassian.net/wiki/x/GwBJAg). This requires high-level server access or somoen to give you a copy of the content.
 
 > **Note**
 > A local machine CMS does **not** include **nor** integrate with an instance of [Core Portal]. To attempt to do that, follow [How to Use a Custom Docker Compose File](https://github.com/TACC/Core-CMS/wiki/How-to-Use-a-Custom-Docker-Compose-File) and [Locally Develop CMS Portal Docs](https://github.com/TACC/Core-CMS/wiki/Locally-Develop-CMS---Portal---Docs). **Help welcome.**

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Set up a new local CMS instance.
         - This page will automatically be your local homepage.
 
 > **Important**
-> A local machine CMS will be empty. It will **not** have content from staging **nor** production. If you need that, follow and adapt instructions to [replicate a CMS database](https://tacc-main.atlassian.net/wiki/x/GwBJAg). This requires high-level server access or somoen to give you a copy of the content.
+> A local machine CMS will be empty. It will **not** have content from staging **nor** production. If you need that, follow and adapt instructions to [replicate a CMS database](https://tacc-main.atlassian.net/wiki/x/GwBJAg). This requires high-level server access or somone to give you a copy of the content.
 
 > **Note**
 > A local machine CMS does **not** include **nor** integrate with an instance of [Core Portal]. To attempt to do that, follow [How to Use a Custom Docker Compose File](https://github.com/TACC/Core-CMS/wiki/How-to-Use-a-Custom-Docker-Compose-File) and [Locally Develop CMS Portal Docs](https://github.com/TACC/Core-CMS/wiki/Locally-Develop-CMS---Portal---Docs). **Help welcome.**

--- a/taccsite_cms/secrets.example.py
+++ b/taccsite_cms/secrets.example.py
@@ -33,6 +33,6 @@ HAYSTACK_CONNECTIONS = {
         'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
         'URL': ES_HOSTS,
         'INDEX_NAME': ES_INDEX_PREFIX.format('cms'),
-        'KWARGS': {'http_auth': ES_AUTH }
+        'KWARGS': {'http_auth': ES_AUTH}
     }
 }

--- a/taccsite_cms/settings_local.example.py
+++ b/taccsite_cms/settings_local.example.py
@@ -20,5 +20,6 @@ DEBUG = True
 SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
 
 # To disable the Core-Portal integration
-PORTAL_IS_TACC_CORE_PORTAL = False
-PORTAL_HAS_LOGIN = False
+# IMPORTANT: Do not disable by default, because [Core-Portal clones this file](https://github.com/TACC/Core-Portal/pull/1034)
+# PORTAL_IS_TACC_CORE_PORTAL = False
+# PORTAL_HAS_LOGIN = False


### PR DESCRIPTION
## Overview & Related

Tweaks to support https://github.com/TACC/Core-Portal/pull/1034.

## Changes

* [feat: CMD-194 enable portal nav by default](https://github.com/TACC/Core-CMS/commit/abcbcfb929d77a27a09242eb6f0a28950429383f)
* [docs: CMD-194 expand CMS database content notice](https://github.com/TACC/Core-CMS/commit/5ea38029e3bf4c40585c552a1f3a343a321819de)

## Testing

1. Load up CMS.
2. Verify CMS nav menu loads.
3. Verify Portal nav menu is absent.
    <sup>It is enabled, but there is no menu available, so CMS shows nothing.</sup>

## UI

| CMS Settings |
| - |
| <img width="960" alt="CMD-194" src="https://github.com/user-attachments/assets/28d5ff42-a2b9-4e0f-9bd0-5f5fe0b0fb50"> |