### PR TITLE
feat: default custom settings `settings_default`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ project_name.var
 
 # Secrets and Customizations
 *secrets*.py
+*settings_default*.py
 *settings_custom*.py
 *settings_local*.py
 custom_app_settings.py

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -754,6 +754,11 @@ DJANGOCMS_ICON_SETS = [
 ########################
 
 try:
+    from taccsite_cms.settings_default import *
+except ModuleNotFoundError:
+    pass
+
+try:
     from taccsite_cms.settings_custom import *
     import taccsite_cms.settings_custom as settings_custom
 except ModuleNotFoundError:

--- a/taccsite_cms/settings_default.example.py
+++ b/taccsite_cms/settings_default.example.py
@@ -1,0 +1,5 @@
+'''
+A `settings_default.py` file can override default values in `settings.py` before `settings_custom.py`.
+
+This allows Core-CMS client software to standardize their custom settings while still supporting `settings_custom.py` e.g. https://github.com/TACC/Core-Portal/pull/1034.
+'''

--- a/taccsite_cms/settings_default.py
+++ b/taccsite_cms/settings_default.py
@@ -1,5 +1,0 @@
-'''
-A `settings_default.py` file can override default values in `settings.py` before `settings_custom.py`.
-
-This allows Core-CMS client software to standardize their custom settings while still supporting `settings_custom.py` e.g. https://github.com/TACC/Core-Portal/pull/1034.
-'''

--- a/taccsite_cms/settings_default.py
+++ b/taccsite_cms/settings_default.py
@@ -1,0 +1,5 @@
+'''
+A `settings_default.py` file can override default values in `settings.py` before `settings_custom.py`.
+
+This allows Core-CMS client software to standardize their custom settings while still supporting `settings_custom.py` e.g. https://github.com/TACC/Core-Portal/pull/1034.
+'''


### PR DESCRIPTION
## Overview

Support default CMS customization in Core-Portal.

## Related

- [CMD-194](https://tacc-main.atlassian.net/browse/CMD-194)
- required by https://github.com/TACC/Core-Portal/pull/1034

## Changes

- **added** `settings_default.py`

## Testing

### Prerequisites
- Have a running local CMS.
- Verify **no** `settings_*.py` file has `PORTAL_HAS_SEARCH = True`.

### Steps
1. Verify search bar is **visible** in header.
2. `make stop`
3. `cp taccsite_cms/settings_default.example.py taccsite_cms/settings_default.py`
4. `echo "PORTAL_HAS_SEARCH = False" >> taccsite_cms/settings_default.py`
5. `make start`
6. Verify search bar is **absent** in header.

## UI

https://github.com/user-attachments/assets/736bfeed-8617-4c0c-91db-bade4e6841b0