### PR TITLE
fix: typo in our djangocms-picture css selector

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -38,7 +38,7 @@ img.align-center {
   max-width: 100%;
   height: auto;
 }
-:is(figure, a).rounded {
+:is(figure, a).rounded img {
   /* NOTE: Bootstrap used 0.25rem */
   border-radius: 1rem !important; /* overwrite Bootstrap (uses !important) */
 }


### PR DESCRIPTION
## Overview

Missing ` img` in a selector.

## Related

- noticed during https://github.com/TACC/Core-CMS-Custom/pull/416[^1]

[^1]: While testing retrofitting this code for a Core-Styles v0 Core-CMS site, I noticed this code has this bug.</sup>