### PR TITLE
fix: WP-895 portal nav with bootstrap5 does not open

### DIFF
--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -13,5 +13,22 @@
 
   const container = document.getElementById('portal-nav');
 
-  importHTML.insertFromURL('/core/markup/nav', container);
+  await importHTML.insertFromURL('/core/markup/nav', container);
+
+  /* Make (Portal) Bootstrap 5 toggle compatible with (CMS) Bootstrap 4 */
+  [ ...container.querySelectorAll('[data-bs-toggle]')].forEach(toggle => {
+    const portalUsesBootstrap5Toggle = (
+      toggle.dataset.bsToggle !== undefined &&
+      toggle.dataset.toggle === undefined
+    )
+
+    if ( portalUsesBootstrap5Toggle ) {
+      toggle.dataset.toggle = toggle.dataset.bsToggle;
+      delete toggle.dataset.bsToggle;
+      console.log(
+        'Replaced `data-bs-toggle` with `data-toggle` in `#portal-nav`.',
+        'To not need this, update Bootstrap from 4 to 5.'
+      )
+    }
+  });
 </script>


### PR DESCRIPTION
## Overview

Make Bootstrap5-powered portal nav still work on CMS which uses Bootstrap4.

## Related

- [WP-895](https://tacc-main.atlassian.net/browse/WP-895)

## Changes

- **added** JavaScript to repair menu

## Testing

1. Run Core-Portal with this Core-CMS.
2. Open CMS page.
3. Verify portal nav dropdown menu location is underneath its toggle.

## UI

https://github.com/user-attachments/assets/80a93d74-b1ef-4510-8306-4128bfda9a3f

https://github.com/user-attachments/assets/cfcaf3e3-6e7f-4b9e-9aec-1bf2bb7fdb94