### PR TITLE
refactor: rename a group perm utility function

### DIFF
--- a/taccsite_cms/management/commands/group_perms/grid_editor_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/grid_editor_advanced.py
@@ -5,7 +5,7 @@ To edit, move, add, and delete layout elements (Containers, Rows, Columns)
 from django.contrib.auth.models import Group
 
 from ..util import (
-    let_view_and_change_page_structure,
+    let_view_page_and_structure,
     let_view_and_change_grid,
     let_add_and_delete_grid
 )
@@ -17,6 +17,6 @@ def set_group_perms():
         name=GROUP_NAME
     )
 
-    let_view_and_change_page_structure(group)
+    let_view_page_and_structure(group)
     let_view_and_change_grid(group)
     let_add_and_delete_grid(group)

--- a/taccsite_cms/management/commands/group_perms/grid_editor_basic.py
+++ b/taccsite_cms/management/commands/group_perms/grid_editor_basic.py
@@ -5,7 +5,7 @@ To edit and move layout elements (Containers, Rows, Columns)
 from django.contrib.auth.models import Group
 
 from ..util import (
-    let_view_and_change_page_structure,
+    let_view_page_and_structure,
     let_view_and_change_grid
 )
 
@@ -16,5 +16,5 @@ def set_group_perms():
         name=GROUP_NAME
     )
 
-    let_view_and_change_page_structure(group)
+    let_view_page_and_structure(group)
     let_view_and_change_grid(group)

--- a/taccsite_cms/management/commands/group_perms/media_editor_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/media_editor_advanced.py
@@ -5,7 +5,7 @@ To edit, move, add, and delete images, videos, thumbnail sizes, and folders
 from django.contrib.auth.models import Group
 
 from ..util import (
-    let_view_and_change_page_structure,
+    let_view_page_and_structure,
     let_view_and_change_media_plugins,
     let_add_and_delete_media_plugins,
     let_view_and_change_adv_media_plugins,
@@ -22,7 +22,7 @@ def set_group_perms():
         name=GROUP_NAME
     )
 
-    let_view_and_change_page_structure(group)
+    let_view_page_and_structure(group)
     let_view_and_change_media_plugins(group)
     let_add_and_delete_media_plugins(group)
     let_view_and_change_adv_media_plugins(group)

--- a/taccsite_cms/management/commands/group_perms/media_editor_basic.py
+++ b/taccsite_cms/management/commands/group_perms/media_editor_basic.py
@@ -5,7 +5,7 @@ To edit and move images, videos, thumbnail sizes, and folders
 from django.contrib.auth.models import Group
 
 from ..util import (
-    let_view_and_change_page_structure,
+    let_view_page_and_structure,
     let_view_and_change_media_plugins,
     let_view_and_change_adv_media_plugins,
     let_view_thumbnail_option,
@@ -20,7 +20,7 @@ def set_group_perms():
         name=GROUP_NAME
     )
 
-    let_view_and_change_page_structure(group)
+    let_view_page_and_structure(group)
     let_view_and_change_media_plugins(group)
     let_view_and_change_adv_media_plugins(group)
     let_view_folder(group)

--- a/taccsite_cms/management/commands/group_perms/news_writer_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/news_writer_advanced.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import Group
 
 from ..util import (
     add_perm,
-    let_view_and_change_page_structure,
+    let_view_page_and_structure,
     let_view_and_change_plugin,
     let_view_and_change_text,
     let_add_and_delete_text,
@@ -24,7 +24,7 @@ def set_group_perms():
         name=GROUP_NAME
     )
 
-    let_view_and_change_page_structure(group)
+    let_view_page_and_structure(group)
     let_view_and_change_plugin(group)
 
     let_view_and_change_text(group)

--- a/taccsite_cms/management/commands/group_perms/news_writer_basic.py
+++ b/taccsite_cms/management/commands/group_perms/news_writer_basic.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import Group
 
 from ..util import (
     add_perm,
-    let_view_and_change_page_structure,
+    let_view_page_and_structure,
     let_view_and_change_plugin,
     let_view_and_change_text,
     let_add_and_delete_text,
@@ -22,7 +22,7 @@ def set_group_perms():
         name=GROUP_NAME
     )
 
-    let_view_and_change_page_structure(group)
+    let_view_page_and_structure(group)
     let_view_and_change_plugin(group)
 
     let_view_and_change_text(group)

--- a/taccsite_cms/management/commands/group_perms/text_editor_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/text_editor_advanced.py
@@ -5,7 +5,7 @@ To edit, move, add, and delete textual elements, folders, and files
 from django.contrib.auth.models import Group
 
 from ..util import (
-    let_view_and_change_page_structure,
+    let_view_page_and_structure,
     let_view_and_change_text,
     let_add_and_delete_text,
     let_view_and_change_folder,
@@ -21,7 +21,7 @@ def set_group_perms():
         name=GROUP_NAME
     )
 
-    let_view_and_change_page_structure(group)
+    let_view_page_and_structure(group)
     let_view_and_change_text(group)
     let_add_and_delete_text(group)
     let_view_and_change_folder(group)

--- a/taccsite_cms/management/commands/group_perms/text_editor_basic.py
+++ b/taccsite_cms/management/commands/group_perms/text_editor_basic.py
@@ -5,7 +5,7 @@ To edit and move textual elements blocks, folders, and files
 from django.contrib.auth.models import Group
 
 from ..util import (
-    let_view_and_change_page_structure,
+    let_view_page_and_structure,
     let_view_and_change_text,
     let_view_and_change_folder,
     let_view_and_change_file,
@@ -18,7 +18,7 @@ def set_group_perms():
         name=GROUP_NAME
     )
 
-    let_view_and_change_page_structure(group)
+    let_view_page_and_structure(group)
     let_view_and_change_text(group)
     let_view_and_change_folder(group)
     let_view_and_change_file(group)

--- a/taccsite_cms/management/commands/util.py
+++ b/taccsite_cms/management/commands/util.py
@@ -34,9 +34,10 @@ def add_perm(group, app_label, model_name, perm_name):
 
 
 # Page
-def let_view_and_change_page_structure(group):
+def let_view_page_and_structure(group):
     """
-    Add permissions to edit a page
+    Add permissions to view a page and its structure
+    (Any user that should edit content must also have this permission)
     """
     add_perm(group, 'cms', 'page', 'Can view page')
     add_perm(group, 'cms', 'page', 'Can change page')

--- a/taccsite_cms/management/commands/util.py
+++ b/taccsite_cms/management/commands/util.py
@@ -39,6 +39,8 @@ def let_view_page_and_structure(group):
     Add permissions to view a page and its structure
     (Any user that should edit content must also have this permission)
     """
+    # The functional permission of these 'Can … page' is only 'Can change page',
+    # but 'Can view page' makes sense (even though testing suggests it is moot)
     add_perm(group, 'cms', 'page', 'Can view page')
     add_perm(group, 'cms', 'page', 'Can change page')
 


### PR DESCRIPTION
## Overview

Rename a utility function.

## Related

- supports #915

## Changes

- **renamed** `let_view_and_change_page_structure` to `let_view_page_and_structure`

## Testing

Skipped.

## UI

N/A

## Notes

- Goal is to not mislead developers when a new group has only this perm.
- A user with only this permission can not edit content.
- A user that will edit content must have this permission.