### PR TITLE
feat: unpublished page viewer group

### DIFF
--- a/taccsite_cms/management/commands/group_perms/unpublished_page_viewer.py
+++ b/taccsite_cms/management/commands/group_perms/unpublished_page_viewer.py
@@ -1,0 +1,18 @@
+"""
+To view unpublished pages (can see page and structure, but can not edit)
+"""
+
+from django.contrib.auth.models import Group
+
+from ..util import (
+    let_view_page_and_structure
+)
+
+GROUP_NAME = 'Unpublished Page Viewer'
+
+def set_group_perms():
+    group, was_created = Group.objects.get_or_create(
+        name=GROUP_NAME
+    )
+
+    let_view_page_and_structure(group)


### PR DESCRIPTION
## Overview

Add group "Unpublished Page Viewer".

## Related

- supported by #914
- documented by [Django CMS - Developer Guide - Permissions & Groups](https://tacc-main.atlassian.net/wiki/x/egtv?atlOrigin=eyJpIjoiYzM1NTRlNzkwOWQ0NDI5ZmFjMzlkMWVkYjU2ZmY3MDUiLCJwIjoiYyJ9)

## Changes

- **added** new group

## Testing

> [!NOTE]
> I tested manually on TUP prod, which uses this permission set for "Unpublished Page Viewer".

0. Create/Find ["Unpublished Page Viewer" Group](https://tacc.utexas.edu/admin/auth/group/38/change/).
1. Add Page global permission for that Group that "Can edit" (and optionally "View restricted").
2. To that Group, add permissions of `let_view_page_and_structure`.
3. Give a User that group, and only that Group.
4. Create [an unpublished page](https://tacc.utexas.edu/tacc-user-portal/hetdex-access-request/?edit).
5. Login with User from above.
6. Verify User can see [the unpublished page](https://tacc.utexas.edu/tacc-user-portal/hetdex-access-request/?edit).

## UI

| not logged in - page hidden | logged in - can view page | logged in - can view structure |
| - | - | - |
| <img width="1130" alt="not logged in - can not view" src="https://github.com/user-attachments/assets/c9073b1a-e919-42a3-8244-ee4b2f611d6d" /> | <img width="1130" alt="logged in - can view page" src="https://github.com/user-attachments/assets/77c118b8-3248-48be-bd9e-a9de041283aa" /> | <img width="1130" alt="logged in - can view structure" src="https://github.com/user-attachments/assets/8c594a21-7c71-48ec-8c72-b4efa00a4f81" /> |
