### PR TITLE
deps: core-styles v2.39.4 (header font swap)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.39.3"
+        "@tacc/core-styles": "^2.39.4"
       },
       "engines": {
         "node": ">=16",
@@ -1279,9 +1279,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.39.3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.39.3.tgz",
-      "integrity": "sha512-5HT5LdWvco/wDjOlxDkw9+U6Y0frb0tHtAQv2nkdhtZA5xgfVIWuEi3DjJ8v4wG69x1gLXE4+w6ozFes6EmCiw==",
+      "version": "2.39.4",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.39.4.tgz",
+      "integrity": "sha512-qFig8qt01JQ25EknoOl3k+uESe66B4Zl2Rgm9+pS45yltHEkpyMOxdu6BLllgUac1gpVylS4nzfWW6iDSdEQ5w==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10272,9 +10272,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.39.3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.39.3.tgz",
-      "integrity": "sha512-5HT5LdWvco/wDjOlxDkw9+U6Y0frb0tHtAQv2nkdhtZA5xgfVIWuEi3DjJ8v4wG69x1gLXE4+w6ozFes6EmCiw==",
+      "version": "2.39.4",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.39.4.tgz",
+      "integrity": "sha512-qFig8qt01JQ25EknoOl3k+uESe66B4Zl2Rgm9+pS45yltHEkpyMOxdu6BLllgUac1gpVylS4nzfWW6iDSdEQ5w==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.39.3"
+    "@tacc/core-styles": "^2.39.4"
   }
 }


### PR DESCRIPTION
## Overview

Update Core-Styles to swap header font from Benton to Roboto.

## Related

- caused by https://github.com/TACC/Core-Styles/pull/470
- used by https://github.com/TACC/Core-Portal/pull/1068
