### PR TITLE
fix: wp-894 portal nav dropdown menu alignment

### DIFF
--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -30,5 +30,15 @@
         'To not need this, update CMS Bootstrap from 4 to 5.'
       )
     }
+
+    const portalBootstrap5Menu = container.querySelector('.dropdown-menu-end');
+    if ( portalBootstrap5Menu ) {
+      portalBootstrap5Menu.classList.remove('dropdown-menu-end');
+      portalBootstrap5Menu.classList.add('dropdown-menu-right');
+      console.log(
+        'Replaced `dropdown-menu-end` with `dropdown-menu-right` in `#s-portal-nav`.',
+        'To not need this, update CMS Bootstrap from 4 to 5.'
+      )
+    }
   });
 </script>

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -40,5 +40,5 @@
       'Replaced `dropdown-menu-end` with `dropdown-menu-right` in `#s-portal-nav`.',
       'To not need this, update CMS Bootstrap from 4 to 5.'
     )
-  }
+  });
 </script>

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -30,15 +30,15 @@
         'To not need this, update CMS Bootstrap from 4 to 5.'
       )
     }
-
-    const portalBootstrap5Menu = container.querySelector('.dropdown-menu-end');
-    if ( portalBootstrap5Menu ) {
-      portalBootstrap5Menu.classList.remove('dropdown-menu-end');
-      portalBootstrap5Menu.classList.add('dropdown-menu-right');
-      console.log(
-        'Replaced `dropdown-menu-end` with `dropdown-menu-right` in `#s-portal-nav`.',
-        'To not need this, update CMS Bootstrap from 4 to 5.'
-      )
-    }
   });
+
+  /* Make (Portal) Bootstrap 5 menu compatible with (CMS) Bootstrap 4 */
+  [ ...container.querySelectorAll('.dropdown-menu-end') ].forEach(menu => {
+    menu.classList.remove('dropdown-menu-end');
+    menu.classList.add('dropdown-menu-right');
+    console.log(
+      'Replaced `dropdown-menu-end` with `dropdown-menu-right` in `#s-portal-nav`.',
+      'To not need this, update CMS Bootstrap from 4 to 5.'
+    )
+  }
 </script>


### PR DESCRIPTION
## Overview

Portal nav menu alignment fixed for Portal Bootstrap 5 broke it for CMS Bootstrap 4.

## Related

- [WP-894](https://tacc-main.atlassian.net/browse/WP-894)
- caused by:
    - https://github.com/TACC/Core-Portal/pull/1073
    - https://github.com/TACC/Core-Portal/pull/1066

## Changes

- **adds** script to swap JavaScript class

## Testing

1. Open Core-CMS that is served via Core-Portal.
2. Verify portal nav dropdown menu is aligned so it is not off-screen.

## UI

https://github.com/user-attachments/assets/db7e344a-0f09-4b39-80d2-15e87a0a2ee0