### PR TITLE
deps: core-styles v2.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.39.4"
+        "@tacc/core-styles": "^2.40.0"
       },
       "engines": {
         "node": ">=16",
@@ -1279,9 +1279,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.39.4",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.39.4.tgz",
-      "integrity": "sha512-qFig8qt01JQ25EknoOl3k+uESe66B4Zl2Rgm9+pS45yltHEkpyMOxdu6BLllgUac1gpVylS4nzfWW6iDSdEQ5w==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.40.0.tgz",
+      "integrity": "sha512-wYrp4t9fwYIclOG5JvDwKZ/R/OCJxpxNYh2LlN+APQ20GaZqWP8HGobiEfbDKBzeAO7lv8dmwraq1fq7auiFcA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10272,9 +10272,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.39.4",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.39.4.tgz",
-      "integrity": "sha512-qFig8qt01JQ25EknoOl3k+uESe66B4Zl2Rgm9+pS45yltHEkpyMOxdu6BLllgUac1gpVylS4nzfWW6iDSdEQ5w==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.40.0.tgz",
+      "integrity": "sha512-wYrp4t9fwYIclOG5JvDwKZ/R/OCJxpxNYh2LlN+APQ20GaZqWP8HGobiEfbDKBzeAO7lv8dmwraq1fq7auiFcA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.39.4"
+    "@tacc/core-styles": "^2.40.0"
   }
 }


### PR DESCRIPTION
## Overview

Update Core-Styles.

## Changes

- **adds** Bootstrap 4 Pagination
- **refactors** `c-page`
- **refactors** Django CMS Pagination

## Testing & UI

> [!WARNING]
> **Skipped.** I rely on Core-Styles promise of backwards-compatibility.

1. Verify a CMS with a blog (e.g. [CTRN](https://ctrn-web.tacc.utexas.edu/)) has same pagination styles.
2. Verify a CMS using pagination (.e.g [APCD](https://github.com/TACC/Core-CMS-Custom/tree/main/apcd_cms)) on a CMS page can rely on CMS styles.