### PR TITLE
fix: django-cms-blog pagination font too small

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "github:TACC/Core-Styles#5d29bed"
+        "@tacc/core-styles": "^2.40.1"
       },
       "engines": {
         "node": ">=16",
@@ -1279,8 +1279,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.40.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#5d29bedbb6d5a700c07ca412146f4d8c32e06876",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.40.1.tgz",
+      "integrity": "sha512-lLtt/pACRlzZ6oeBpel68e2ROUrJ8feQMq/0Prhg1KGGC0NjXIeaTDaQ3pyuVyshZgTeAx3TDtwsvzlp5jBqUA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10271,9 +10272,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#5d29bedbb6d5a700c07ca412146f4d8c32e06876",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.40.1.tgz",
+      "integrity": "sha512-lLtt/pACRlzZ6oeBpel68e2ROUrJ8feQMq/0Prhg1KGGC0NjXIeaTDaQ3pyuVyshZgTeAx3TDtwsvzlp5jBqUA==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#5d29bed",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.40.0"
+        "@tacc/core-styles": "github:TACC/Core-Styles#5d29bed"
       },
       "engines": {
         "node": ">=16",
@@ -1280,8 +1280,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.40.0.tgz",
-      "integrity": "sha512-wYrp4t9fwYIclOG5JvDwKZ/R/OCJxpxNYh2LlN+APQ20GaZqWP8HGobiEfbDKBzeAO7lv8dmwraq1fq7auiFcA==",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#5d29bedbb6d5a700c07ca412146f4d8c32e06876",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10272,10 +10271,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.40.0.tgz",
-      "integrity": "sha512-wYrp4t9fwYIclOG5JvDwKZ/R/OCJxpxNYh2LlN+APQ20GaZqWP8HGobiEfbDKBzeAO7lv8dmwraq1fq7auiFcA==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#5d29bedbb6d5a700c07ca412146f4d8c32e06876",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#5d29bed",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "github:TACC/Core-Styles#5d29bed"
+    "@tacc/core-styles": "^2.40.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.40.0"
+    "@tacc/core-styles": "github:TACC/Core-Styles#5d29bed"
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -9,7 +9,7 @@ Reference:
 
 Styleguide Components.DjangoCMS.Blog.App
 */
-@import url("@tacc/core-styles/src/lib/_imports/components/bootstrap.pagination.css");
+@import url("@tacc/core-styles/dist/djangocms-blog/cms-pagination.css");
 @import url("@tacc/core-styles/src/lib/_imports/components/c-tag.css");
 
 @import url("./django.cms.blog.app.page.css");


### PR DESCRIPTION
## Overview

Fix styles for pagination on Blog/News page.

## Related

- fixes #919

## Changes

- **changes** which pagination stylesheet is loaded

## Testing & UI

### Before

https://github.com/user-attachments/assets/ecda5ac6-4dd2-4fcd-96d2-7501ddcedb1c

### After

https://github.com/user-attachments/assets/5b344f15-2664-4e98-a400-92a526603850

> [!NOTE]
> The "Next" link gets closer to "Page X of Y" text. That's fine.[^1]

[^1]: The Django CMS Blog pagination styles were always "do our best with what we got, cuz we don't have real pagination". But a font-size change was an actual bug.