### PR TITLE
fix: package-mode breaks Jenkins build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.poetry]
 name = "tacc-core-cms-backend"
-package-mode = false
 version = "4.25.4"
 description = "DjangoCMS backend for the TACC ACI-WMA Core-CMS Codebase."
 authors = ["TACC-WMA <wma-portals@tacc.utexas.edu>"]


### PR DESCRIPTION
https://jenkins.portals.tacc.utexas.edu/job/Core_CMS_Build/236/console

## Overview

Python project property `package-mode` defaults to `false`, but that breaks Docker.

<details>

Docker installs Python dependencies, including this project itself; but this project itself is **not** a _proper_ Python package (because it does not need to be, because we share it via Docker instead of via Python, because we weren't Python-package-savvy enough "back in the day").

</details>

## Related

- fixes bug from #908

## Changes

- **restored** `package-mode = false`

## Testing

1. `make build && make start`
2. No error.

## UI

Skipped.