### PR TITLE
fix: migration without dependency

### DIFF
--- a/taccsite_cms/migrations/0002_remove_old_system_monitor_table.py
+++ b/taccsite_cms/migrations/0002_remove_old_system_monitor_table.py
@@ -18,6 +18,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
+        ('taccsite_cms', '0001_add_groups'),
     ]
 
     operations = [


### PR DESCRIPTION
## Overview

The migration `0002` must depend on migration `0001`.

## Related

- fixes bug from #908

## Changes

- **added** dependency to system monitor migration

## Testing

1. `make start`
2. `docker exec -it core_cms python manage.py migrate`
3. no error

## UI

### Before

> [!CAUTION]
> ```log
> docker exec -it core_cms python manage.py migrate
> /usr/local/lib/python3.11/site-packages/cms/apphook_pool.py:97: UserWarning: No registered apphook "'SearchPageApphook'" found
>   warnings.warn(_('No registered apphook "%r" found') % app_name)
> CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph: (0001_add_groups, 0002_remove_old_system_monitor_table in taccsite_cms).
> To fix them run 'python manage.py makemigrations --merge'
> ```

### After

> [!TIP]
> ```log
> docker exec -it core_cms python manage.py migrate
> /usr/local/lib/python3.11/site-packages/cms/apphook_pool.py:97: UserWarning: No registered apphook "'SearchPageApphook'" found
>  warnings.warn(_('No registered apphook "%r" found') % app_name)
> Operations to perform:
>   Apply all migrations: admin, auth, bootstrap4_alerts, bootstrap4_badge, bootstrap4_card, bootstrap4_carousel, bootstrap4_collapse, bootstrap4_content, bootstrap4_grid, bootstrap4_jumbotron, bootstrap4_link, bootstrap4_listgroup, bootstrap4_media, bootstrap4_picture, bootstrap4_tabs, bootstrap4_utilities, cms, contenttypes, djangocms_blog, djangocms_column, djangocms_file, djangocms_forms, djangocms_googlemap, djangocms_icon, djangocms_link, djangocms_page_meta, djangocms_picture, djangocms_snippet, djangocms_style, djangocms_tacc_system_monitor, djangocms_text_ckeditor, djangocms_video, easy_thumbnails, filer, menus, sessions, sites, taccsite_blockquote, taccsite_callout, taccsite_cms, taccsite_data_list, taccsite_offset, taccsite_sample, taccsite_system_specs, taggit
> Running migrations:
>   Applying taccsite_cms.0002_remove_old_system_monitor_table... OK
> ```