### PR TITLE
chore: v4.28.0 & retire unused version instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,6 @@ atlassian-ide-plugin.xml
 *.sqlite
 *.sql
 
-# Version file for source distribution
-RELEASE-VERSION
-
 # Dependencies
 node_modules
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-git-tag-version=false

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -39,15 +39,12 @@ Our [production site] is built from a specific commit.
 
 Only appointed team members may release versions.
 
-1. Update version:
-  - `npm version N.N.N`
-  - edit `version` in `pyproject.toml`
 1. Review. Commit. Push.
-1. Create release and tag on GitHub.
-1. Annotate Github's tag:\
+2. Create release and tag on GitHub.
+3. Annotate Github's tag:\
   `bin/annotate-tag.sh vN.N.N`\
-  (where `N.N.N` is the version tag)
-1. Overwrite remote tag with annotated one:\
+  (where `vN.N.N` is the version tag)
+4. Overwrite remote tag with annotated one:\
   `git push --tags --force`
 
 <!-- Link Aliases -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "@tacc/core-cms",
-  "version": "4.28.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tacc/core-cms",
-      "version": "4.28.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@frctl/fractal": "^1.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@tacc/core-cms",
-  "version": "4.28.0-alpha.5",
   "license": "MIT",
   "author": "TACC ACI WMA <wma-portals@tacc.utexas.edu>",
   "contributors": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.poetry]
 name = "tacc-core-cms-backend"
-version = "4.28.0-alpha.5"
 description = "DjangoCMS backend for the TACC ACI-WMA Core-CMS Codebase."
 authors = ["TACC-WMA <wma-portals@tacc.utexas.edu>"]
 


### PR DESCRIPTION
## Overview

- Prepare for v4.28.0 release.
- Delete unused instances of version.
- Un-document unnecessary release steps.