### PR TITLE
feat: target for ext link respects more subdomains

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -18,7 +18,10 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
   shouldFilter: true,
 }) {
   const baseDocHost = document.location.host;
-  const baseDocHostWithSubdomain= `www.${ baseDocHost }`;
+  const standardSubdomains = ['www', 'pprd', 'prod', 'dev'];
+  const similarHosts = standardSubdomains.map(
+    subdomain => `${subdomain}.${baseDocHost}`
+  );
 
   if ( opts.shouldDebug ) {
     console.log({ links, opts });
@@ -33,7 +36,10 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
 
     const isMailto = ( linkHref.indexOf('mailto:') === 0 );
     const isAbsolute = ( linkHref.indexOf('http') === 0 );
-    const isSameHost = ( link.host === baseDocHost || link.host === baseDocHostWithSubdomain );
+    const isSameHost = (
+      link.host === baseDocHost ||
+      similarHosts.includes( link.host )
+    );
     const shouldOpenInNewTab = ( ! isSameHost || isMailto );
 
     if (opts.shouldDebug) {

--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -5,6 +5,29 @@
 export const DEFAULT_LINKS = document.querySelectorAll('body > :is(header, main, footer) a');
 
 /**
+ * Check if two hosts are effectively the same domain
+ * @param {string} linkHost - The host from the link
+ * @param {string} baseHost - The current page's host
+ * @param {string[]} subdomains - List of valid subdomains
+ * @returns {boolean}
+ */
+function isSameDomain(linkHost, baseHost, subdomains) {
+  // Direct match
+  if (linkHost === baseHost) return true;
+
+  // Link is to subdomain of base host
+  if (subdomains.some(subdomain => linkHost === `${subdomain}.${baseHost}`)) return true;
+
+  // Link is to root domain while we're on subdomain
+  if (subdomains.some(subdomain => 
+    baseHost.startsWith(`${subdomain}.`) && 
+    linkHost === baseHost.replace(`${subdomain}.`, '')
+  )) return true;
+
+  return false;
+}
+
+/**
  * Make links with absolute URLs open in new tab, and:
  * - add accessible markup
  * - fix absolute URLs that should be relative paths
@@ -36,10 +59,7 @@ export default function findLinksAndSetTargets( links = DEFAULT_LINKS, opts = {
 
     const isMailto = ( linkHref.indexOf('mailto:') === 0 );
     const isAbsolute = ( linkHref.indexOf('http') === 0 );
-    const isSameHost = (
-      link.host === baseDocHost ||
-      similarHosts.includes( link.host )
-    );
+    const isSameHost = isSameDomain(link.host, baseDocHost, standardSubdomains);
     const shouldOpenInNewTab = ( ! isSameHost || isMailto );
 
     if (opts.shouldDebug) {


### PR DESCRIPTION
## Overview

Update the `setTargetForExternalLinks.js` script to consider `www`, `dev`, `pprd`, and `prod` subdomains as the same host when deciding whether a link is external.

## Status

> [!IMPORTANT]
> Should we really do this? Maybe the author of the "not working" links should be using relative links instead. [You explained to them why relative links may be better.](https://tacc-team.slack.com/archives/DTC2VS9MX/p1746146572671549)

## Changes

- **changed** a condition in `setTargetForExternalLinks.js`

## Testing & UI

https://github.com/user-attachments/assets/6aab3d0c-968c-4106-ab99-08b4339629a2

https://github.com/user-attachments/assets/fce90489-1b1f-4951-8f62-ee3e2b5481d7