### PR TITLE
chore: do not allow `page-` as `<html>`'s id

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -2,8 +2,11 @@
 {% get_current_language as lang_code %}
 <!doctype html>
 <html
-  id="page-{% block html_page_id %}{{ request.current_page.reverse_id }}{% endblock html_page_id %}"
+  {% block html_page_id %}
+  id="page-{{ request.current_page.reverse_id }}"
+  {% endblock html_page_id %}
   lang="{{ lang_code }}"
+  data-page-template="{{ request.current_page.template }}"
   {# FAQ: Only available if set in page's "Advanced" settings #}
   data-page-id="{{ request.current_page.reverse_id }}"
   class="{% block html_page_class %}{% endblock html_page_class %}">


### PR DESCRIPTION
## Overview

The `<html>` ID of page with no reverse ID set **was** `page-`. **Now** it is nothing.
