### PR TITLE
refactor: retire `data-page-id`

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -6,9 +6,6 @@
   id="page-{{ request.current_page.reverse_id }}"
   {% endblock html_page_id %}
   lang="{{ lang_code }}"
-  data-page-template="{{ request.current_page.template }}"
-  {# FAQ: Only available if set in page's "Advanced" settings #}
-  data-page-id="{{ request.current_page.reverse_id }}"
   class="{% block html_page_class %}{% endblock html_page_class %}">
 
 {# SEE: https://github.com/nephila/django-meta/blob/1.7.0/docs/rendering.rst #}


### PR DESCRIPTION
## Overview

Remove `data-page-id` attribute, because it is unused — we use `#page-…`.[^1]

Also, removed `data-page-template` accidentally added in #944.

[^1]: I searched https://github.com/TACC/Core-CMS, https://github.com/TACC/Core-CMS-Resources, and https://github.com/TACC/tup-ui.