### PR TITLE
feat: data-page-template

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -6,6 +6,7 @@
   id="page-{{ request.current_page.reverse_id }}"
   {% endblock html_page_id %}
   lang="{{ lang_code }}"
+  data-page-template="{{ request.current_page.template }}"
   class="{% block html_page_class %}{% endblock html_page_class %}">
 
 {# SEE: https://github.com/nephila/django-meta/blob/1.7.0/docs/rendering.rst #}

--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -4,7 +4,7 @@
 <html
   id="{% block html_page_id %}{% if request.current_page.reverse_id %}page-{{ request.current_page.reverse_id }}{% endif %}{% endblock html_page_id %}"
   lang="{{ lang_code }}"
-  data-page-template="{{ request.current_page.template }}"
+  data-page-template="{{ request.current_page.template|cut:".html" }}"
   class="{% block html_page_class %}{% endblock html_page_class %}">
 
 {# SEE: https://github.com/nephila/django-meta/blob/1.7.0/docs/rendering.rst #}


### PR DESCRIPTION
## Overview

**Add `data-page-template` to `<html>`**, so stylesheets can target pages with specific template e.g. `[data-page-template="…"] { /* ... */ }`.

## Related

- replaces #880
- supports https://github.com/TACC/Core-CMS-Custom/pull/293

## Testing

1. Open http://localhost:8000/.
2. Verify `<html>` has `data-page-template="standard">`.

## UI

<img width="469" alt="data-page-template" src="https://github.com/user-attachments/assets/c4ea1efd-3be2-4482-93e3-ea4465e3662e" />