### PR TITLE
fix: do not allow `id="page-None"`

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -2,9 +2,7 @@
 {% get_current_language as lang_code %}
 <!doctype html>
 <html
-  {% block html_page_id %}
-  id="page-{{ request.current_page.reverse_id }}"
-  {% endblock html_page_id %}
+  id="{% block html_page_id %}{% if request.current_page.reverse_id %}page-{{ request.current_page.reverse_id }}{% endif %}{% endblock html_page_id %}"
   lang="{{ lang_code }}"
   class="{% block html_page_class %}{% endblock html_page_class %}">
 


### PR DESCRIPTION
## Overview

Do not allow `id="page-None"` in `<html>` tag.

## Related

- fixes #944
- failed in #944

## Testing

1. Do **not** set **Id** (`reverse_id`) for Home page.
2. Visit http://localhost:8000/.
3. Verify `<html id lang="en" class>`.
4. **Do** set **Id** (`reverse_id`) for Home page.
5. Visit http://localhost:8000/.
6. Verify `<html id="page-home" lang="en" class>`.

## UI

| not set | set id | has id |
| - | - | - |
| <img width="283" alt="no id" src="https://github.com/user-attachments/assets/18ea3050-dbc2-465c-99b4-c91c16576725" /> | <img width="283" alt="set id" src="https://github.com/user-attachments/assets/57e8b2dd-e140-49d3-abeb-382024c88272" /> | <img width="283" alt="has id" src="https://github.com/user-attachments/assets/52a3f3e8-5834-4336-bc03-cc11c6debf28" /> |