### PR TITLE
fix: data-page-template should not be "INHERIT"

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -3,7 +3,7 @@
 <!doctype html>
 <html
   id="{% block html_page_id %}{% if request.current_page.reverse_id %}page-{{ request.current_page.reverse_id }}{% endif %}{% endblock html_page_id %}"
-  data-page-template="{{ request.current_page.template|cut:".html" }}"
+  data-page-template="{{ request.current_page.get_template|cut:'.html' }}"
   class="{% block html_page_class %}{% endblock html_page_class %}"
   lang="{{ lang_code }}"
 >


### PR DESCRIPTION
## Overview

Always use template name, never `INHERIT`.

## Related

- fixes #946

## Changes

- **changes** function/property used to get template

## Testing

1. Open page that directly uses Standard template.
2. Verify `<html>` tag has `data-page-template="standard"`.
3. Open child page that inherits template.
4. Verify `<html>` tag has `data-page-template="standard"`.

## UI

### Standard

| before | after |
| - | - |
| <img width="469" alt="parent before and after" src="https://github.com/user-attachments/assets/b1103f72-9230-490d-a62f-95ad6f25395f" /> | <img width="469" alt="parent before and after" src="https://github.com/user-attachments/assets/b1103f72-9230-490d-a62f-95ad6f25395f" /> |

### Inherited

| before | after |
| - | - |
| <img width="469" alt="inherit before" src="https://github.com/user-attachments/assets/0556451b-3167-42cf-ae34-c4e6a2c3fd38" /> | <img width="469" alt="inherit after" src="https://github.com/user-attachments/assets/c356ad92-04fc-44ae-9ea0-5f71ed0602e5" /> |