### PR TITLE
fix: update bootstrap on older websites

### DIFF
--- a/taccsite_cms/templates/assets_core.html
+++ b/taccsite_cms/templates/assets_core.html
@@ -5,6 +5,7 @@
   {# https://tacc-main.atlassian.net/wiki/x/hRlv #}
   @layer foundation, base, project;
 
+  /* TODO: Use same version of Bootstrap as TACC/Core-Portal (v5) */
   @import url("https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css") layer(foundation);
   @import url("{% static 'site_cms/css/build/core-styles.base.css' %}") layer(base);
 </style>

--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -2,11 +2,12 @@
 {# For assets that should be loaded after all page content. #}
 {% load static %}
 
-{# FAQ: Bootstrap can use jQuery, Popper, then its own script #}
+{# Bootstrap #}
 {# SEE: https://getbootstrap.com/docs/4.6/getting-started/introduction/#starter-template #}
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
+
+{# TACC/Core-CMS #}
 <script type="module">
   import updateEmailLinkHrefs from '{% static "site_cms/js/modules/updateEmailLinkHrefs.js" %}';
 

--- a/taccsite_cms/templates/assets_site.html
+++ b/taccsite_cms/templates/assets_site.html
@@ -17,8 +17,8 @@ FAQ: IF a script or style is better cached with markup, THEN:
   {# https://tacc-main.atlassian.net/wiki/x/hRlv #}
   @layer foundation, /* @base, */ project;
 
-  /* TODO: Use same version of Bootstrap as TACC/Core-Portal (v4.3.1) */
-  @import url("https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css") layer(foundation);
+  /* TODO: Use same version of Bootstrap as TACC/Core-Portal (v5) */
+  @import url("https://maxcdn.bootstrapcdn.com/bootstrap/4.6.2/css/bootstrap.min.css") layer(foundation);
 
   @import url("{% static 'site_cms/css/build/site.css' %}") layer(project.core);
   @import url("{% static 'site_cms/css/build/site.header.css' %}") layer(project.core);

--- a/taccsite_cms/templates/assets_site.html
+++ b/taccsite_cms/templates/assets_site.html
@@ -18,7 +18,7 @@ FAQ: IF a script or style is better cached with markup, THEN:
   @layer foundation, /* @base, */ project;
 
   /* TODO: Use same version of Bootstrap as TACC/Core-Portal (v5) */
-  @import url("https://maxcdn.bootstrapcdn.com/bootstrap/4.6.2/css/bootstrap.min.css") layer(foundation);
+  @import url("https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css") layer(foundation);
 
   @import url("{% static 'site_cms/css/build/site.css' %}") layer(project.core);
   @import url("{% static 'site_cms/css/build/site.header.css' %}") layer(project.core);

--- a/taccsite_cms/templates/assets_site_delayed.html
+++ b/taccsite_cms/templates/assets_site_delayed.html
@@ -1,17 +1,13 @@
 {# SEE: ./assets_site.md #}
 {# For assets that should be loaded after all page content. #}
-{% comment %}
-Consider asset load via `assets_custom`, not `assets_custom_delayed`:
-  - Styles should not need a delayed load time.
-  - Scripts can use `defer` or `async` attr's to manage load time.
-{% endcomment %}
 {% load static %}
 
-{# FAQ: Bootstrap can use jQuery, Popper, then its own script #}
-{# SEE: https://getbootstrap.com/docs/4.0/getting-started/introduction/#starter-template #}
-<script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+{# Bootstrap #}
+{# SEE: https://getbootstrap.com/docs/4.6/getting-started/introduction/#starter-template #}
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
+
+{# TACC/Core-CMS #}
 <script type="module">
   import updateEmailLinkHrefs from '{% static "site_cms/js/modules/updateEmailLinkHrefs.js" %}';
 


### PR DESCRIPTION
## Overview & Changes

- Bootstrap v4.0.0 → v4.6.2
- jQuery v3.2.1 → v3.5.1
- match how new & old sites load Bootstrap

## Related

- emergency security requirement

## Testing

1. Deploy on an old site e.g. https://frontera-portal.tacc.utexas.edu/.
2. <details open><summary>Verify any Bootstrap scripted UX works:</summary>

    **Portal Dropdown:**
    1. Log in.
    2. Return to homepage.
    3. Test portal nav dropdown.

    </details>
2. <details open><summary>Verify any Bootstrap UI looks the same:</summary>

    - header
    - …

    </details>

> [!IMPORTANT]
> There might be nothing more to test. I can't think of any other Bootstrap scripted UX on any **old** site.[^1]

[^1]: New sites' Bootstrap version does not change. And, even if it did, the only **new** site I know with Bootstrap scripted UX is https://tacc.utexas.edu/use-tacc/software-list/, click "Version Documentation" for a modal.

> [!NOTE]
> Affected sites: [11](https://github.com/search?q=repo%3ATACC%2FCore-Portal-Deployments+%22TACC_CORE_STYLES_VERSION+%3D+0%22&type=code)

## UI

…