### PR TITLE
feat: command to list pages that use each template

### DIFF
--- a/taccsite_cms/management/commands/README.md
+++ b/taccsite_cms/management/commands/README.md
@@ -1,63 +1,78 @@
-# TACC CMS - Add Groups & Permissions
+# TACC CMS - Management Commands
 
-- [Groups & Permissions](#groups--permissions)
-- [Usage](#usage)
-- [Development](#development)
+- [How to Use](#how-to-use)
+- [List Pages Using Each Template](#list-pages-using-each-template)
+- [Set Groups & Permissions](#set-groups--permissions)
 - [Reference](#reference)
 
-## Groups & Permissions
+## How to Use
+
+1. Open a shell into the CMS container e.g.
+    ```sh
+    docker exec -it core_cms /bin/bash
+    ```
+2. In the shell, run any available command e.g.
+    ```sh
+    python manage.py filename_of_the_command
+    ```
+
+## List Pages Using Each Template
+
+This command lists all pages using each template in the CMS, along with their full URLs.
+
+Usage:
+```sh
+python manage.py list_page_templates
+```
+
+## Set Groups & Permissions
 
 Every file in [`group_perms/`](./group_perms) represents a group. Each group's intended usage is described at the top of its file. Permissions are set via function calls in each file.[^1]
 
-## Usage
+- [Usage](#usage)
+- [Development](#development)
+
+### Usage
 
 - [Add a Permissions Group](#add-a-permissions-group)
 - [Debug a Command](#debug-a-command)
 - [Assign Permissions to a User](#assign-permissions-to-a-user)
 
-### Add a Permissions Group
+#### Add a Permissions Group
 
-1. Open a shell into the CMS container e.g.
-    ```sh
-    docker exec -it core_cms /bin/bash
-    ```
-2. In the shell, run the group/permission command e.g.
+1. Run the command e.g.
     ```sh
     python manage.py set_group_perms news_writer_advanced grid_editor_basic
     ```
-3. Open the CMS admin interface e.g.
+2. Open the CMS admin interface e.g.
     [https://localhost:8000/admin/auth/group](https://localhost:8000/admin/auth/group)
-4. Verify group permissions are as you intend.
+3. Verify group permissions are as you intend.
 
 > **Note:** If group does not exist, this will **create** it. If group exists, this will **add** permissions to it, but will **not remove** permissions from it.
 
-### Debug a Command
+#### Debug a Command
 
-1. Open a shell into the CMS container e.g.
-    ```sh
-    docker exec -it core_cms /bin/bash
-    ```
-2. In the shell, open a Python shell i.e.
+1. Open a Python shell i.e.
     ```sh
     python
     ```
-3. In the Python shell, run the following commands.
+2. In the Python shell, run the following commands.
     ```py
     import os
     import django
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "taccsite_cms.settings")
     django.setup()
     ```
-4. Then run any additional debugging code or scripts you want to execute.
+3. Then run any additional debugging code or scripts you want to execute.
 
-### Assign Permissions to a User
+#### Assign Permissions to a User
 
 Add the User to one or more groups.[^1]
 
 > **Warning:**
 > If [`CMS_PERMISSION = True`](https://docs.django-cms.org/en/3.11.8/topics/permissions.html#permission-modes) ([default for Core-CMS](https://github.com/TACC/Core-CMS/blob/v4.21.0/taccsite_cms/settings.py#L164)), then assigning one of these groups to a user is **not enough** to allow them to edit a page. You must also give that user [Global or per-page permissions](https://docs.django-cms.org/en/3.11.8/topics/permissions.html#global-and-per-page-permissions); do so [via a group](https://docs.django-cms.org/en/3.11.8/topics/permissions.html#use-permissions-on-groups-not-on-users).
 
-## Development
+### Development
 
 - [Create a New Group](#create-a-new-group)
 - [Create a New Permission Set](#create-a-new-permission-set)
@@ -65,23 +80,23 @@ Add the User to one or more groups.[^1]
     - [via Existing Group in CMS Admin](#via-existing-group-in-cms-admin)
 - [Update all CMS Instances](#update-all-cms-instances)
 
-### Create a New Group
+#### Create a New Group
 
 1. Duplicate an existing group.
-2. Rename the file and gorup name. Rewrite file description.
+2. Rename the file and group name. Rewrite file description.
 3. Adjust permissions using existing sets.
 
-### Create a New Permission Set
+#### Create a New Permission Set
 
-#### via Existing Set in this Code
+##### via Existing Set in this Code
 
 1. Duplicate an existing `let_*` function in [`util.py`](./util.py).
-2. Rename the function. Rewrite its descritpion.
+2. Rename the function. Rewrite its description.
 3. Assign the permission set to a relevant group.
 
-#### via Existing Group in CMS Admin
+##### via Existing Group in CMS Admin
 
-##### 1. Get Permissions from HTML
+###### 1. Get Permissions from HTML
 
 You may **either** download an appropriate `.html` from [Django CMS - Developer Guide - User Permissions / Groups / Roles](https://tacc-main.atlassian.net/wiki/x/egtv) **or**:
 
@@ -89,7 +104,7 @@ You may **either** download an appropriate `.html` from [Django CMS - Developer 
 2. Using the browser Developer Tools, copy the `<option>`s from the `<select>` that has the permissions you chose.
 3. Save those `<options>` to a new blank file.
 
-##### 2. Convert Permissions to Python
+###### 2. Convert Permissions to Python
 
 Use regex to convert the `<option>`s from HTML to Python Django CMS instructions.
 
@@ -113,11 +128,11 @@ Use regex to convert the `<option>`s from HTML to Python Django CMS instructions
         add_perm(group, '$1', '$2', '$3')
     ```
 
-### Update all CMS Instances
+#### Update all CMS Instances
 
 Add new (reversible) migration file to `taccsite_cms/migrations`.
 
-#### Examples
+##### Examples
 
 <details><summary>Add New Permission to Existing Group</summary>
 

--- a/taccsite_cms/management/commands/list_page_templates.py
+++ b/taccsite_cms/management/commands/list_page_templates.py
@@ -1,0 +1,29 @@
+from cms.models import Page
+from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+
+class Command(BaseCommand):
+    help = 'Lists all CMS pages and their templates with full URLs'
+
+    def handle(self, *args, **options):
+        pages = Page.objects.filter(publisher_is_draft=False).order_by('node__path')
+        current_site = Site.objects.get_current()
+        domain = current_site.domain
+        protocol = 'https' if domain and domain != 'localhost' else 'http'
+
+        template_usage = {}
+
+        for page in pages:
+            template = page.template
+            if template not in template_usage:
+                template_usage[template] = []
+            url = page.get_absolute_url()
+            full_url = f"{protocol}://{domain}{url}"
+            template_usage[template].append((page.get_title(), full_url))
+
+        for template, pages in template_usage.items():
+            templateOutput = f'"{template}"' if template != 'INHERIT' else template
+            self.stdout.write(f'\nTEMPLATE: {templateOutput}')
+            self.stdout.write('PAGES:')
+            for title, url in pages:
+                self.stdout.write(f'- {title} ({url})')

--- a/taccsite_cms/management/commands/list_page_templates.py
+++ b/taccsite_cms/management/commands/list_page_templates.py
@@ -1,22 +1,23 @@
 from cms.models import Page
 from django.core.management.base import BaseCommand
-from django.contrib.sites.models import Site
 
 class Command(BaseCommand):
     help = 'Lists all CMS pages and their templates with full URLs'
 
     def handle(self, *args, **options):
         pages = Page.objects.filter(publisher_is_draft=False).order_by('node__path')
-        current_site = Site.objects.get_current()
-        domain = current_site.domain
-        protocol = 'https' if domain and domain != 'localhost' else 'http'
-
         template_usage = {}
 
         for page in pages:
             template = page.template
             if template not in template_usage:
                 template_usage[template] = []
+
+            # Get the site for this specific page
+            page_site = page.node.site
+            domain = page_site.domain
+            protocol = 'https' if domain and domain != 'localhost' else 'http'
+
             url = page.get_absolute_url()
             full_url = f"{protocol}://{domain}{url}"
             template_usage[template].append((page.get_title(), full_url))


### PR DESCRIPTION
## Overview

Add a command that lists all pages using each template in the CMS, along with their full URLs.

## Related

- help admins locate pages using [Texascale deprecated templates](https://github.com/TACC/Core-Portal-Deployments/blob/e7d2496/texascale/camino/cms.settings_custom.py#L18-L25)
- help admins refactor or test page templates

## Changes

- **adds** management command
- **documents** new command
- **improves** documentation for management commands

## Testing

0. (if you have no instance) `make setup`
1. `make start`
2. `docker exec -it core_cms sh -c "python manage.py list_page_templates"`
3. (optional) test with multisite
    <sup>see https://github.com/TACC/Core-CMS/pull/873</sup>

## UI

```log
docker exec -it core_cms sh -c "python manage.py list_page_templates"

TEMPLATE: "fullwidth.html"
PAGES:
- Home (https://localhost:8000/)
- Home (https://127.0.0.1:8000/)

TEMPLATE: "standard.html"
PAGES:
- Site 1 News (https://localhost:8000/news/)
- Site 2 News (https://127.0.0.1:8000/news/)
- Site 1 Page (https://localhost:8000/site-1-page/)

TEMPLATE: INHERIT
PAGES:
- Site 2 Page (https://127.0.0.1:8000/site-2-page/)
- Remote Site 1 News (https://127.0.0.1:8000/remote-site-1-news/)
```