### PR TITLE
fix: make setup remote fallback assumes branch

### DIFF
--- a/bin/setup-cms.sh
+++ b/bin/setup-cms.sh
@@ -14,12 +14,11 @@ IMP='\033[1m'    # important
 # Define paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${SCRIPT_DIR}/../"
-SRC_ROOT="${SCRIPT_DIR}/../"
+SRC_ROOT="${SCRIPT_DIR}/../src"
 
 # Configure fallback for settings
 VERSION="main"
-BASE_URL="https://raw.githubusercontent.com/TACC/Core-CMS/refs/tags/${VERSION}"
-# BASE_URL="https://cdn.jsdelivr.net/gh/TACC/Core-CMS@${VERSION}"
+BASE_URL="https://cdn.jsdelivr.net/gh/TACC/Core-CMS@${VERSION}"
 CREATE_VAR_FILES=false
 
 # Functions


### PR DESCRIPTION
## Overview / Changes

Change `make setup` script remote settings URL to CDN one because it works with branch or tag with same URL.

> [!IMPORTANT]
> This does not affect Core-CMS. It only affects https://github.com/TACC/Core-CMS-Template and any repo that newly uses that template.

## Related

- mimics https://github.com/TACC/Core-CMS-Template/pull/5

## Testing

See https://github.com/TACC/Core-CMS-Template/pull/5.