### PR TITLE
docs(readme): clarify "Getting Started" steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,23 @@ How to set up a new local CMS instance.
 
 ### Quick Setup
 
-1. Clone and open the project.
-2. To remove previous setup **entirely**:
+0. Enter CMS project:
+    ```sh
+    cd cms
+    ```
+1. (optional) To remove previous setup **entirely**:
     ```sh
     make clean
     ```
-3. Run the setup script:
+2. Run the setup script:
     ```sh
     make setup
     ```
     You will be prompted for information.
+3. [Add Content](#add-content).
 
 ### Manual Setup
 
-0. [Clone this Repository.](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
 1. Enter the Repository Clone:
 
     ```sh
@@ -117,12 +120,15 @@ How to set up a new local CMS instance.
 
     ```
 
-6. Open Django CMS:
-    1. Open http://localhost:8000/.
-    2. Login with the credentials you defined in step 2.
-    3. Create one CMS page.\
-        (With "New page" highlighted, click "Next" button.)
-        - This page will automatically be your local homepage.
+6. [Add Content](#add-content).
+
+#### Add Content
+
+1. Open http://localhost:8000/.
+2. Login with the credentials you defined in step 2.
+3. Create one CMS page.\
+    (With "New page" highlighted, click "Next" button.)
+    - This page will automatically be your local homepage.
 
 > **Important**
 > A local machine CMS will be empty. It will **not** have content from staging **nor** production. If you need that, follow and adapt instructions to [replicate a CMS database](https://tacc-main.atlassian.net/wiki/x/GwBJAg). This requires high-level server access or somone to give you a copy of the content.

--- a/README.md
+++ b/README.md
@@ -73,13 +73,10 @@ How to set up a new local CMS instance.
 
 ### Manual Setup
 
-1. Enter the Repository Clone:
+> [!NOTE]
+> If [Quick Start](#quick-start) process fails, report the error to your team, and follow these steps for now.
 
-    ```sh
-    cd Core-CMS
-    ```
-
-2. Add Core CMS Settings & Secrets:
+1. Configure [Django] Application:
 
     Create a `taccsite_cms/*.py` for every `*.example.py`, e.g.
 
@@ -89,7 +86,7 @@ How to set up a new local CMS instance.
     cp taccsite_cms/settings_local.example.py taccsite_cms/settings_local.py
     ```
 
-3. Build & Start the Docker Containers:
+2. Start [Docker] Containers:
 
     ```sh
     make start
@@ -98,16 +95,12 @@ How to set up a new local CMS instance.
     > **Note**
     > This will make the terminal window busy. To run commands after this, **either** open a new terminal window **or** run `make start ARGS="--detach"` instead.
 
-4. Enter the CMS Docker Container:
-
-    (This opens a command prompt within the container.)
+3. Prepare [Django] Application:
 
     ```sh
     docker exec -it core_cms /bin/bash
     # This opens a command prompt within the container
     ```
-
-5. Update the Django Application:
 
     (Run these commands within the container.)
 
@@ -120,7 +113,7 @@ How to set up a new local CMS instance.
 
     ```
 
-6. [Add Content](#add-content).
+4. [Add Content](#add-content).
 
 #### Add Content
 
@@ -219,8 +212,11 @@ To contribute, first read [How to Contirbute][Contributing].
 [Docker]: https://docs.docker.com/get-docker/
 [Docker Compose]: https://docs.docker.com/compose/install/
 
-[Build & Deploy Project]: https://tacc-main.atlassian.net/wiki/x/2AVv
+[Django]: https://www.djangoproject.com/
+[Django CMS]: https://www.django-cms.org/
 [Django CMS User Guide]: https://tacc-main.atlassian.net/wiki/x/phdv
+
+[Build & Deploy Project]: https://tacc-main.atlassian.net/wiki/x/2AVv
 
 [Develop a Custom Project]: ./docs/develop-custom-project.md
 [Develop a Custom App/Plugin]: ./docs/develop-custom-app.md


### PR DESCRIPTION
## Overview

Improve clarity in Readme "Getting Started".

## Related

- mimics https://github.com/TACC/Core-CMS-Template/pull/8

## Changes

- do **not** tell reader to clone repo
    <sup>Some assumptions should be made of reader skill level.</sup>
- tell reader to enter `cms` directory
- tell reader `make clean` is optional
- tell reader "Manual Setup" is a fallback
- tell reader adding content is part of either method
- simplify manual setup steps
- rearrange link aliases