### PR TITLE
chore!: remove taccsite_custom submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ build
 ## environment variables
 docker_repo.var
 needs_demo.var
-project_name.var
 
 # Static and Media folders
 /static

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "taccsite_custom"]
-	path = taccsite_custom
-	url = git@github.com:TACC/Core-CMS-Resources.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,13 +46,12 @@ RUN npm ci
 
 # Build assets
 COPY . /code/
-ARG PROJECT_NAME
 ARG NEEDS_DEMO
 ARG BUILD_ID
 RUN if [ "$NEEDS_DEMO" = "true" ]; then \
-        npm run build --project="$PROJECT_NAME" --build-id="$BUILD_ID"; \
+        npm run build --build-id="$BUILD_ID"; \
     else \
-        npm run build:css --project="$PROJECT_NAME" --build-id="$BUILD_ID"; \
+        npm run build:css --build-id="$BUILD_ID"; \
     fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then ech
 # NOTE: Special characters in `DOCKER_IMAGE_BRANCH` are replaced with dashes.
 DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g')
 
-PROJECT_NAME := $(shell cat ./project_name.var)
 NEEDS_DEMO := $(shell cat ./needs_demo.var)
 BUILD_ID := $(shell git describe --always)
 
@@ -21,7 +20,6 @@ build:
 build-full:
 	docker build -t $(DOCKER_IMAGE) \
 		--target production \
-		--build-arg PROJECT_NAME="$(PROJECT_NAME)" \
 		--build-arg BUILD_ID="$(BUILD_ID)" \
 		--build-arg NEEDS_DEMO="$(NEEDS_DEMO)" \
 		-f ./Dockerfile .

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The base CMS code for TACC WMA Workspace Portals & Websites
 - [Core Portal], the base Portal code for TACC WMA CMS Websites
 - [Core Styles], the shared UI pattern code for TACC WMA CMS Websites
 - [Core CMS Template], a template for creating new TACC WMA CMS projects
-- [Core CMS Resources], the old solution for extensions of the [Core CMS] project
 - [Core CMS Custom], the new solution for extensions of the [Core CMS] project
 - [Core Portal Deployments], private repository that facilitates deployments of [Core Portal] images via [Camino] and Jenkins
 
@@ -36,7 +35,6 @@ The base CMS code for TACC WMA Workspace Portals & Websites
 | `apps` | additional Django applications |
 | `bin` | scripts e.g. build CSS |
 | `taccsite_cms` | settings for [Core CMS] |
-| `taccsite_custom` | [Git submodule][Git Submodules] of [Core CMS Resources] |
 
 ## Prerequisites
 
@@ -201,7 +199,6 @@ To contribute, first read [How to Contirbute][Contributing].
 [Camino]: https://github.com/TACC/Camino
 [Core CMS]: https://github.com/TACC/Core-CMS
 [Core Styles]: https://github.com/TACC/Core-Styles
-[Core CMS Resources]: https://github.com/TACC/Core-CMS-Resources
 [Core CMS Template]: https://github.com/TACC/Core-CMS-Template
 [Core CMS Custom]: https://github.com/TACC/Core-CMS-Custom
 [Core Portal]: https://github.com/TACC/Core-Portal

--- a/bin/build-css.js
+++ b/bin/build-css.js
@@ -2,73 +2,33 @@
 
 /** Build CSS using the Core-Styles API */
 
-const fs = require('fs');
 const buildStylesheets = require('@tacc/core-styles').buildStylesheets;
 const mininmist = require('minimist');
 
 const ROOT = __dirname + '/..';
-const CORE_NAME = 'core-cms';
 const ARGS = mininmist( process.argv.slice( 2 ) );
-
-const PROJECT_NAME = ARGS['project'] || '';
 const BUILD_ID = ARGS['build-id'] || '';
 
-/** Build stylesheets for Core and (optional) project */
+/** Build stylesheets */
 (() => {
-  // Get style paths
-  const corePath = _getPath('taccsite_cms', 'site_cms');
-  const projPath = _getPath(`taccsite_custom/${PROJECT_NAME}`, PROJECT_NAME );
-  const hasProject = ( PROJECT_NAME && PROJECT_NAME !== CORE_NAME );
-
-  // Get config paths
-  const coreConfPath = `${ROOT}/${corePath}/.postcssrc.yml`;
-  const projConfPath = `${ROOT}/${projPath}/.postcssrc.yml`;
-  const confPaths = [coreConfPath];
-
-  // Always add relevant available project config
-  // FAQ: Project can customize Core build (e.g. theme changes CSS env. values)
-  if ( hasProject && fs.existsSync( projConfPath ) ) {
-    confPaths.push( projConfPath );
-  }
-
-  // Prepare for build
-  defaultOpts = {
-    verbose: true,
-    buildId: BUILD_ID
-  }
+  const stylePath = _getPath('taccsite_cms', 'site_cms');
 
   // Build styles
-  _build('Core', {
-    input: `${ROOT}/${corePath}/src/**/*.css`,
-    output: `${ROOT}/${corePath}/build`,
-    opts: {...defaultOpts, ...{
-      customConfigs: confPaths
-    }}
-  });
-  if ( hasProject ) {
-    _build( PROJECT_NAME, {
-      input: `${ROOT}/${projPath}/src/**/*.css`,
-      output: `${ROOT}/${projPath}/build`,
-      opts: {...defaultOpts, ...{
-        customConfigs: confPaths
-      }}
-    });
-  }
+  buildStylesheets(
+    /* input */
+    `${ROOT}/${stylePath}/src/**/*.css`,
+    /* output */
+    `${ROOT}/${stylePath}/build`,
+    /* opts */
+    {
+      verbose: true,
+      buildId: BUILD_ID,
+      customConfigs: [
+        `${ROOT}/${stylePath}/.postcssrc.yml`
+      ]
+    }
+  );
 })();
-
-/**
- * Execute command to build stylesheets
- * @param {string} name - The name of the project
- * @param {object} opts - The value to identify the build
- * @param {string} opts.input - The path to project source CSS
- * @param {string} opts.output - The path to put the built CSS
- * @param {@tacc/core-styles.buildStylesheets.opts} opts.opts - Advanced options
- */
-function _build( name, opts ) {
-  console.log(`Overriding config with:`, opts.opts.customConfigs );
-  console.log(`Building "${name}" styles:`);
-  buildStylesheets( opts.input, opts.output, opts.opts );
-}
 
 /**
  * Get path to CSS resources

--- a/bin/setup-cms.sh
+++ b/bin/setup-cms.sh
@@ -112,12 +112,6 @@ if [ "$CREATE_VAR_FILES" = true ]; then
     else
         echo -e "  ${INF}needs_demo.var already exists${RST}"
     fi
-    if [ ! -f "project_name.var" ]; then
-        echo "core-cms" > project_name.var
-        echo -e "  ${POS}Created project_name.var${RST}"
-    else
-        echo -e "  ${INF}project_name.var already exists${RST}"
-    fi
     if [ ! -f "docker_repo.var" ]; then
         echo "core-cms" > docker_repo.var
         echo -e "  ${POS}Created docker_repo.var${RST}"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,8 +13,6 @@ services:
       #   Any `.../build` dirs are populated by `npm … build` command
       #   HACK: No confirmed support for dir globbing, so block all of `static/`
       - /code/taccsite_cms/static
-      #   CAVEAT: CMS projects must add a line to ignore thier `...build/` dirs
-      - /code/taccsite_custom/example_cms/static
 
   postgres:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
       #   Any `.../build` dirs are populated by `npm … build` command
       #   HACK: No confirmed support for dir globbing, so block all of `static/`
       - /code/taccsite_cms/static
-      #   CAVEAT: CMS projects must add a line to ignore thier `...build/` dirs
-      - /code/taccsite_custom/example_cms/static
 
   postgres:
     extends:

--- a/docs/develop-custom-project.md
+++ b/docs/develop-custom-project.md
@@ -3,76 +3,12 @@
 | You can do these actions | via this resource | (status) |
 | - | - | - |
 | **customize** static assets | [Core CMS Custom] | active |
-| **customize** templates, static assets, settings | [Core CMS Resources](#via-core-cms-resources) | deprecated |
 | **customize** templates, static assets, custom apps, URLs, middleware | [Core CMS Template] | active |
 | **create** or **customize** an app | [Develop a Custom App/Plugin](./develop-custom-app.md) | active |
-
-## via [Core CMS Resources]
-
-> [!DANGER]
-> Deprecated solution.
-
-> [!TIP]
-> Use [Core CMS Custom] or [Core CMS Template] instead.
-
-### Update Project
-
-To update `/taccsite_custom` to have **pinned** content from [Core CMS Resources]:
-
-1. `git submodule update`
-
-To update `/taccsite_custom` to have **new** content from [Core CMS Resources]:
-
-1. `cd taccsite_custom`
-2. Checkout desired [Core CMS Resources] branch.
-3. `git pull`
-4. `cd ../`
-
-To make CMS on local machine register changes to files in `/taccsite_custom`:
-
-| types of files changed | action to take |
-| - | - |
-| `static/css` | [build css] |
-| `static/` | [collect static files] |
-| `templates/` | [restart server] |
-
-### Build CSS
-
-To compile CSS static files:
-
-- **from** source files **in** `src` directories
-- **to** compiled files **in** `build` directories
-
-```sh
-npm run build:css --project="custom_project_dir"
-docker exec -it core_cms sh -c "python manage.py collectstatic --no-input"
-
-```
-
-This process allows use of future-proof CSS via [Core Styles].
-
-### Commit Changes
-
-To commit changes to a custom project:
-
-1. `cd taccsite_custom`
-2. Checkout or create a [Core CMS Resources] branch.
-3. Commit changes.
-4. `cd ../`
-5. Add `/taccsite_custom` change.
-6. Commit changes to a [Core CMS] branch.
-
-> [!NOTE]
-> For a more thorough walkthrough, read [How to Change Submodule Branch Commit](https://github.com/TACC/Core-CMS/wiki/How-to-Change-Submodule-Branch-Commit).
 
 <!-- Link Aliases -->
 
 [Core CMS]: https://github.com/TACC/Core-CMS
 [Core Styles]: https://github.com/TACC/Core-Styles
 [Core CMS Custom]: https://github.com/TACC/Core-CMS-Custom
-[Core CMS Resources]: https://github.com/TACC/Core-CMS-Resources
 [Core CMS Template]: https://github.com/TACC/Core-CMS-Template
-
-[restart server]: https://github.com/TACC/Core-CMS/wiki/How-to-Restart-the-CMS-Server
-[collect static files]: ./develop-project.md#collect-static-files
-[build css]: [#build-css]

--- a/docs/develop-project.md
+++ b/docs/develop-project.md
@@ -36,11 +36,8 @@ This allows use of future-proof CSS via [Core Styles].
 2. Build Styles:
 
     ```sh
-    npm run build:css --project="core-cms"
+    npm run build:css
     ```
-
-    > **Important**
-    > If you are developing a [Core CMS Resources] project, use `--project="custom_project_dir"`
 
 3. [Collect Static Files](#collect-static-files):
 
@@ -108,7 +105,6 @@ See [Locally Develop CMS and Styles](https://github.com/TACC/Core-Styles/wiki/De
 
 [Core CMS]: https://github.com/TACC/Core-CMS
 [Core Styles]: https://github.com/TACC/Core-Styles
-[Core CMS Resources]: https://github.com/TACC/Core-CMS-Resources
 
 [restart server]: https://github.com/TACC/Core-CMS/wiki/How-to-Restart-the-CMS-Server
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "git@github.com:TACC/Core-CMS.git",
   "scripts": {
     "build": "npm run build:css",
-    "build:css": "bin/build-css.js --project=$npm_config_project --build-id=$npm_config_build_id",
+    "build:css": "bin/build-css.js --build-id=$npm_config_build_id",
     "postbuild:css": "cp -r node_modules/@tacc/core-styles/src/lib/fonts/* taccsite_cms/static/site_cms/fonts"
   },
   "homepage": "https://github.com/TACC/Core-CMS",

--- a/taccsite_cms/settings_custom.example.py
+++ b/taccsite_cms/settings_custom.example.py
@@ -18,12 +18,7 @@ Unless modifying default behavior for the CMS Core (and thus all custom Projects
 # WALKTHROUGH
 ########################
 
-# To change LDAP auth settings for a custom CMS Project (e.g. `frontera-cms`):
-# 1. Copy the setting from `settings.py`
-# 2. Assign the new value in `Core-CMS/taccsite_custom/frontera-cms/settings_custom.py`.
 AUTH_LDAP_SERVER_URI = "ldap://cluster.ldap.tacc.utexas.edu"
-
-# The same goes for other more commonly customized values like below.
 
 ########################
 # DJANGO_CMS

--- a/taccsite_cms/static/site_cms/css/.postcssrc.yml
+++ b/taccsite_cms/static/site_cms/css/.postcssrc.yml
@@ -1,16 +1,6 @@
 # Merged on top of Core-Styles base config
 # SEE: https://github.com/TACC/Core-Styles/blob/main/src/.postcssrc.base.yml
 plugins:
-  postcss-import:
-    # HELP: Do not use implicit load ever, and then remove it
-    # NOTE: Last found use was in taccsite_custom/…/migrate.v1_v2.css
-    #       via repo-wide regex `@import url\("(?!./|../|http|@tacc|\{%)`
-    #       on 2023-05-08 @ 11:45 am on TACC/Core-CMS-Resources#177
-    # In any source file, every @import path, not prepended with "./" nor "../",
-    # is relative to only one of these directories in this order.
-    path:
-      - 'taccsite_cms/static/site_cms/css/src' # Core-CMS CSS source files
-      - 'node_modules/@tacc/core-styles/src/lib' # Core-Styles CSS source files
   postcss-replace:
     # @tacc/core-styles 'src/' uses `("../../fonts/` or `('../../fonts/`
     # @tacc/core-styles 'dist/' uses `(fonts/`

--- a/taccsite_cms/templates/snippets/README.md
+++ b/taccsite_cms/templates/snippets/README.md
@@ -6,12 +6,8 @@ _This directory can alleviate danger #1 of [Why a Snippet Is Dangerous](#why-a-s
 
 ## Important
 
-1. The Core CMS __must not__ use any snippets __for production__. _They __should only__ be for testing._
-2. A CMS project __should not__ use any snippets. _They __may only__ be temporarily._
-3. A CMS project snippet __must__ be saved into its respective snippets directory, `/code/taccsite_custom/name-of-project/templates/snippets`.
-4. Any snippet file __must__ be kept up to date with its snippet.[^1]
-
-[^1]: For now, maintain snippet source code via internal team process.
+1. A Core CMS project __must minimize__ use of snippets.
+2. Any snippet __must__ be version-controlled in a `snippets/` directory.
 
 ## What a Snippet Is
 

--- a/taccsite_custom/README.md
+++ b/taccsite_custom/README.md
@@ -1,9 +1,12 @@
 # TACC CMS - Custom Instance
 
-A placeholder directory into which the original remaining custom instances of TACC CMS —
+A functional placeholder directory into which the original remaining custom instances of TACC CMS —
 
 - [TUP UI](https://github.com/TACC/tup-ui)
 - [APCD CMS](https://github.com/TACC/APCD-CMS)
 - [Texascale CMS](https://github.com/TACC/Texascale-CMS)
 
-— add unique files and functionality. This directory is a vestige of [Core CMS Resources](https://github.com/TACC/Core-CMS-Resources/tree/151ef91f).
+— add unique files and functionality. This directory has special logic and support in `settings.py`.
+
+> [!NOTE]
+> This directory is a vestige of archived [Core CMS Resources](https://github.com/TACC/Core-CMS-Resources/tree/151ef91f) and we may re-evaluate whether to continue to use it.

--- a/taccsite_custom/README.md
+++ b/taccsite_custom/README.md
@@ -1,0 +1,9 @@
+# TACC CMS - Custom Instance
+
+A placeholder directory into which the original remaining custom instances of TACC CMS —
+
+- [TUP UI](https://github.com/TACC/tup-ui)
+- [APCD CMS](https://github.com/TACC/APCD-CMS)
+- [Texascale CMS](https://github.com/TACC/Texascale-CMS)
+
+— add unique files and functionality. This directory is a vestige of [Core CMS Resources](https://github.com/TACC/Core-CMS-Resources/tree/151ef91f).


### PR DESCRIPTION
## Overview

Delete Git submodule [TACC/Core-CMS-Resources](https://github.com/TACC/Core-CMS-Resources/) at `taccsite_custom`.

> [!NOTE]
> All projects that were in that Git submodule have been migrated to [TACC/Core-CMS-Custom](https://github.com/TACC/Core-CMS-Custom) or their own repo (these repos still rely on `taccsite_custom`).

## Changes

…

## Testing

1.

## UI

…