### PR TITLE
deps: upgrade debian from buster to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # PYTHON BASE IMAGE
-FROM python:3.11-buster as python-base
+FROM python:3.11-bullseye as python-base
 LABEL maintainer="TACC-ACI-WMA <wma_prtl@tacc.utexas.edu>"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Overview

Update Dockerfile base.

## Related / Testing

- tested Debian "bullseye" via [jenkins:Core_CMS_Build#322](https://jenkins.portals.tacc.utexas.edu/job/Core_CMS_Build/322/)
- tested Debian "bookworm" via https://github.com/TACC/Core-CMS/pull/490
- tested Debian "bookworm" via https://github.com/TACC/Texascale-CMS/pull/13

## Changes

Changed Docker base from Python on Debian Buster to Pythonon Debian Bullseye ([like Portal](https://github.com/TACC/Core-Portal/blob/0353772fef26688b7b99426feb1ba49a88e8a83d/server/conf/docker/Dockerfile)).

## Testing

1. Build.
2. No fail.
3. **No errors in log.**
    <sub>Build can succeed yet fail; only visible in log.</sub>
