### PR TITLE
refactor: delete unnecessary env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,6 @@ build
 /static
 /media
 
-# UI Pattern Demo
-/taccsite_ui/dist
-
 # Secrets and Customizations
 *secrets*.py
 *settings_default*.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,13 +46,8 @@ RUN npm ci
 
 # Build assets
 COPY . /code/
-ARG NEEDS_DEMO
 ARG BUILD_ID
-RUN if [ "$NEEDS_DEMO" = "true" ]; then \
-        npm run build --build-id="$BUILD_ID"; \
-    else \
-        npm run build:css --build-id="$BUILD_ID"; \
-    fi
+RUN npm run build --build-id="$BUILD_ID"
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then ech
 # NOTE: Special characters in `DOCKER_IMAGE_BRANCH` are replaced with dashes.
 DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g')
 
-NEEDS_DEMO := $(shell cat ./needs_demo.var)
 BUILD_ID := $(shell git describe --always)
 
 .PHONY: build
@@ -21,7 +20,6 @@ build-full:
 	docker build -t $(DOCKER_IMAGE) \
 		--target production \
 		--build-arg BUILD_ID="$(BUILD_ID)" \
-		--build-arg NEEDS_DEMO="$(NEEDS_DEMO)" \
 		-f ./Dockerfile .
 
 	docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE_BRANCH)

--- a/bin/setup-cms.sh
+++ b/bin/setup-cms.sh
@@ -103,19 +103,6 @@ for file in settings_custom settings_local secrets; do
     fi
 done
 
-# Create expected .var files if they don't exist (if enabled)
-if [ "$CREATE_VAR_FILES" = true ]; then
-    echo -e "${INF}Setting up .var files...${RST}"
-    if [ ! -f "needs_demo.var" ]; then
-        echo "false" > needs_demo.var
-        echo -e "  ${POS}Created needs_demo.var${RST}"
-    else
-        echo -e "  ${INF}needs_demo.var already exists${RST}"
-    fi
-else
-    echo -e "${INF}Skipping .var file creation (disabled)${RST}"
-fi
-
 # Build and start Docker containers (from project root)
 echo -e "${INF}Building and starting Docker containers...${RST}"
 cd "$PROJECT_ROOT"

--- a/taccsite_cms/static/site_cms/css/src/_core-styles/core-styles.demo.css
+++ b/taccsite_cms/static/site_cms/css/src/_core-styles/core-styles.demo.css
@@ -1,2 +1,0 @@
-/* TODO: Host Core-Styles static files on a CDN */
-@import url("@tacc/core-styles/dist/core-styles.demo.css");

--- a/taccsite_cms/static/site_cms/css/src/_imports/config.yml
+++ b/taccsite_cms/static/site_cms/css/src/_imports/config.yml
@@ -1,4 +1,0 @@
-# This file configures CMS-specific pattern demo directory
-label: Core CMS
-context:
-  shouldLoadCMS: true


### PR DESCRIPTION
## Overview & Changes

Delete `docker_repo.env` and related code.
<sup>CMS build job updated to always use `core-cms`. (Safe to do since #964.)</sup>

Delete `needs_demo.env` and related code.
<sup>CMS build job doesn't use this since #941.</sup>

## Related

- requires #964
- requires #941

## Testing

Build Core-CMS. Verify build and push succeed.

[Build](https://jenkins.portals.tacc.utexas.edu/job/Core_CMS_Build/324/). [Deploy](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/2269/). [Test](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/2270/).