### PR TITLE
fix: u-image-zoom validation

### DIFF
--- a/taccsite_cms/djangocms_picture/extend.py
+++ b/taccsite_cms/djangocms_picture/extend.py
@@ -40,7 +40,7 @@ def extendPicturePlugin():
         would_render_link = whether_to_render_link(instance)
         should_add_zoom_effect = ZOOM_TEMPLATE_NAME in instance.template
         parent_plugin = instance.parent.get_plugin_instance()[0] if instance.parent else None
-        is_in_link = isinstance(parent_plugin, LinkPlugin) if parent_plugin else False
+        is_in_link = instance.parent.plugin_type == 'LinkPlugin' if instance.parent else False
 
         if (should_add_zoom_effect and not would_render_link and not is_in_link):
             errors['template'] = ZOOM_TEMPLATE_ERROR
@@ -53,12 +53,6 @@ def extendPicturePlugin():
         Calculate boolean context variables to simplify template logic.
         Returns a dictionary of context variables.
         """
-        # Link (set 1)
-        has_explicit_link = bool(instance.get_link())
-        parent_plugin = instance.parent.get_plugin_instance()[0] if instance.parent else None
-        is_in_link_plugin = isinstance(parent_plugin, LinkPlugin) if parent_plugin else False
-        has_any_link = has_explicit_link or is_in_link_plugin
-
         # Figure/Caption
         has_caption_text = bool(instance.caption_text)
         has_child_plugins = bool(instance.child_plugin_instances)
@@ -67,7 +61,7 @@ def extendPicturePlugin():
         # Template
         is_zoom_template = ZOOM_TEMPLATE_NAME in instance.template
 
-        # Link (set 2)
+        # Link
         should_render_link = whether_to_render_link(instance)
 
         # Zoom Effect


### PR DESCRIPTION
## Overview

Fix validation logic error in "Zoom image" templates.

## Related

- fixes #968

## Changes

- **fixes** parent plugin comparison
- **deletes** unused variables

## Testing

1. Open https://dev.cep.tacc.utexas.edu/test/image-picture-block/?edit (or similar test page).
2. Edit and save Image at "Template: `zoom_effect` • External image: 🚫 • Within a Link: ✅": "[in a **Link**] Attrs"
    - Save should have **no** validation error.
    - Image should zoom on hover.
3. Edit and save Image at "Template: `zoom_effect_no_link_to_ext_image` • External image: 🚫 • Within a Link: ✅": "[in a **Link**] Attrs"
    - Save should have **no** validation error.
    - Image should zoom on hover.

## UI

### Template: `zoom_effect` • External image: 🚫 • Within a Link: ✅

https://github.com/user-attachments/assets/e520007a-21f8-43e8-9a22-60749230fd3d

https://github.com/user-attachments/assets/31b11caf-2c05-4a2a-938c-3c9aebd49f1c

### Template: `zoom_effect_no_link_to_ext_image` • External image: ✅ • Within a Link: ✅

https://github.com/user-attachments/assets/9f02c7b6-8167-402c-8a73-5f15999a632d

https://github.com/user-attachments/assets/2e3367f3-7720-4fee-bb8a-c4272c340a1c

