### PR TITLE
fix: space under span.u-image-zoom img

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.46.1"
+        "@tacc/core-styles": "github:TACC/Core-Styles#fix/u-image-zoom-compatibility-issues"
       },
       "engines": {
         "node": ">=16",
@@ -1133,8 +1133,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.46.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.46.1.tgz",
-      "integrity": "sha512-ln6ihKWtMTwDxQKmBL1H/2P2+mLut1h2n/KziKUlpQ7+PEaBFHaC1XFE8FuROmX+H/aZnpCW8xXALIcUQcErnw==",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#f249d9267b5c9760a5c2f66b82e5a55b2e0af820",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4733,10 +4732,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.46.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.46.1.tgz",
-      "integrity": "sha512-ln6ihKWtMTwDxQKmBL1H/2P2+mLut1h2n/KziKUlpQ7+PEaBFHaC1XFE8FuROmX+H/aZnpCW8xXALIcUQcErnw==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#f249d9267b5c9760a5c2f66b82e5a55b2e0af820",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#fix/u-image-zoom-compatibility-issues",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "github:TACC/Core-Styles#fix/u-image-zoom-compatibility-issues"
+        "@tacc/core-styles": "^2.46.2"
       },
       "engines": {
         "node": ">=16",
@@ -1132,8 +1132,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.46.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#f249d9267b5c9760a5c2f66b82e5a55b2e0af820",
+      "version": "2.46.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.46.2.tgz",
+      "integrity": "sha512-b3MTccuLswbJM19ysX85vHYt6l/hHtvEgR3ZhKZZvoVXPBZjyfhl9zvnOrnQPB5tnLMt59nKdyHo+XcEj67lgA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4732,9 +4733,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#f249d9267b5c9760a5c2f66b82e5a55b2e0af820",
+      "version": "2.46.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.46.2.tgz",
+      "integrity": "sha512-b3MTccuLswbJM19ysX85vHYt6l/hHtvEgR3ZhKZZvoVXPBZjyfhl9zvnOrnQPB5tnLMt59nKdyHo+XcEj67lgA==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#fix/u-image-zoom-compatibility-issues",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "github:TACC/Core-Styles#fix/u-image-zoom-compatibility-issues"
+    "@tacc/core-styles": "^2.46.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.46.1"
+    "@tacc/core-styles": "github:TACC/Core-Styles#fix/u-image-zoom-compatibility-issues"
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -170,6 +170,15 @@ Styleguide Components.DjangoCMS.Blog.App.Page
   margin-inline: auto;
 }
 
+/* To add space under aligned images */
+/* NOTE: All images should be aligned by news editor,
+         so missing space is considered news editor error */
+:--article-page .blog-content .align-right,
+:--article-page .blog-content .align-center,
+:--article-page .blog-content .align-left {
+  margin-bottom: var(--global-space--grid-gap);
+}
+
 /* To always align Bootstrap blockquote text left */
 /* FAQ: Boostrap, loaded in foundation layer, used !important */
 /* TODO: When extending Core-Styles c-news, .blockquote... is only for CMS */


### PR DESCRIPTION
## Overview

There should **not** be space under an image that is within a `.u-zoom-image` element.

## Related

- required by https://github.com/TACC/Core-Styles/pull/536

## Changes

- **adds** space below aligned blog article images
    <sup>migrated from Core-Styles</sup>
- **updates** Core-Styles version

## Testing

1. Verify blog article images have space below them.
2. Verify **no** extra space under an image wrapped in a `<span class="u-image-zoom--on-hover">`.

## UI

Skipped.