### PR TITLE
deps: djangocms-bootstrap4 v3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -747,13 +747,15 @@ taggit-helpers = ["django-taggit-helpers"]
 
 [[package]]
 name = "djangocms-bootstrap4"
-version = "3.0.1"
+version = "3.0.2"
 description = "Adds Bootstrap 4 components as plugins."
 optional = false
 python-versions = "*"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "djangocms_bootstrap4-3.0.2-py3-none-any.whl", hash = "sha256:3b7e7eb1b7551cf433bf2bb0f3601d47645203c3bb4ad75ec097eb4bd81a34cf"},
+    {file = "djangocms_bootstrap4-3.0.2.tar.gz", hash = "sha256:e931aefadbd22ab00e6cea8b7224da767afea125df15bf0c8a8d5f7872153e64"},
+]
 
 [package.dependencies]
 django-cms = ">=3.7,<4"
@@ -766,12 +768,6 @@ djangocms-text-ckeditor = ">=3.1.0"
 
 [package.extras]
 static-ace = ["djangocms-static-ace"]
-
-[package.source]
-type = "git"
-url = "https://github.com/django-cms/djangocms-bootstrap4.git"
-reference = "49983f4"
-resolved_reference = "49983f4175ec4a4e2b5076993a893cbdd79c4ab2"
 
 [[package]]
 name = "djangocms-column"
@@ -2502,4 +2498,4 @@ testing = ["func-timeout", "jaraco.itertools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "077910c85e2fda3f3ff38d22d4275d876d2ecef54cd3e21ed2ee744c56771495"
+content-hash = "8ef7c041a1522e5e00995677cce04b851ebfd5852399795d29aa902b49526d21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,7 @@ djangocms-admin-style = "~3.2.6"
 djangocms-apphook-setup = "0.4.1"
 djangocms-attributes-field = "2.1.0"
 djangocms-blog = "^1.2"
-# TO get a commit in main (since v3.0.1) to fix Container error
-# https://github.com/django-cms/djangocms-bootstrap4/pull/164
-djangocms-bootstrap4 = {git = "https://github.com/django-cms/djangocms-bootstrap4.git", rev = "49983f4"}
+djangocms-bootstrap4 = "^3.0"
 djangocms-column = "^2.0"
 djangocms-file = "3.0.0"
 djangocms-forms-maintained = { git = "https://github.com/TACC/djangocms-forms", rev = "6b59ff366495915f06f4d6fac01a2f0aa9efecaf" }


### PR DESCRIPTION
## Overview

Pin DjangoCMS Bootstrap 4 dependency to a version not a commit.

## Related / Changes

The [only release since](https://github.com/django-cms/djangocms-bootstrap4/compare/49983f4...3.0.2) is a "Prepare release" commit.

## Testing

1. Deploy on existing (staging) site.
2. Verify container options are still available.
3. Verify container options are still working.

## UI

https://github.com/user-attachments/assets/e68ca30c-7c65-420c-95fd-4fd5893ba7e2