### PR TITLE
feat: let custom sites overwrite app templates

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -349,8 +349,10 @@ TEMPLATES = [
         # FAQ: List custom directory first, so custom templates take precedence
         # SEE: https://docs.djangoproject.com/en/2.2/topics/templates/#configuration
         'DIRS': glob(
+            # XXX: Strange and from my ignorant implementation
             os.path.join(BASE_DIR, 'taccsite_custom')
         ) + [
+            os.path.join(BASE_DIR, 'taccsite_custom', 'templates'),
             os.path.join(BASE_DIR, 'taccsite_cms', 'templates')
         ],
         'OPTIONS': {


### PR DESCRIPTION
## Overview

Allow a custom site (e.g. [Texascale-CMS](https://github.com/TACC/Texascale-CMS)) to overwrite third-party app template (e.g. `djangocms_bootstrap4/tabs/default/tabs.html`)

## Related

- required by https://github.com/TACC/Texascale-CMS/pull/22
- tested via https://github.com/TACC/Texascale-CMS/pull/24

## Changes

- **adds** `taccsite_custom/templates` as a new available template dir
- **documents** `taccsite_custom` itself should not serve as a template dir

## Testing

1. **Texascale**: https://github.com/TACC/Texascale-CMS/pull/24
2. **Core**: Deployed to dev.cep. No change.

## UI

Skipped.