### PR TITLE
hotfix: v4.35.1 add missing redirect snippet but not image zoom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tacc-core-cms-backend"
-version = "4.35.0"
+version = "4.35.1"
 description = "DjangoCMS backend for the TACC ACI-WMA Core-CMS Codebase."
 authors = ["TACC-WMA <wma-portals@tacc.utexas.edu>"]
 

--- a/taccsite_cms/templates/snippets/news/open-external-articles.html
+++ b/taccsite_cms/templates/snippets/news/open-external-articles.html
@@ -1,7 +1,7 @@
 {# To open external news article, instead of internal news article #}
 {% load static %}
 
-<script id="blog-list-link-to-external-site" type="module">
+<script id="open-external-articles" type="module">
 import { changeHowExternalArticleOpens } from '{% static "site_cms/js/modules/manageExternalArticles.js" %}';
 
 // The `{{html}}` is whatever user entered into snippet "HTML:" field

--- a/taccsite_cms/templates/snippets/news/redirect-external-article.html
+++ b/taccsite_cms/templates/snippets/news/redirect-external-article.html
@@ -1,0 +1,30 @@
+{# To redirect page to given URL or external URL from known content #}
+{% load static %}
+
+<script id="redirect-external-article" type="module">
+import { getArticleExternalURL } from '{% static "site_cms/js/modules/manageExternalArticles.js" %}';
+
+let URL = '{{html}}';
+
+const params = new URLSearchParams( window.location.search );
+const isEditing = params.has('edit');
+const isNewsArticle = ( window.location.pathname.indexOf('/news') == 0 );
+
+if ( isNewsArticle && ! URL ) {
+  const extTagName = 'external';
+  const article = document.querySelector(`
+    .app-blog.has-blog-tag-${extTagName} article
+  `);
+
+  URL = getArticleExternalURL( article );
+}
+
+if ( ! URL ) {
+  console.debug('Cannot redirect to URL', URL );
+} else if ( isEditing ) {
+  console.info(`Skipping redirect to "${URL}", because user is editing`);
+} else {
+  console.debug(`Redirecting to "${URL}"`);
+  window.location.href = URL;
+}
+</script>


### PR DESCRIPTION
## Overview

- Add redirect snippet ([#973](https://github.com/TACC/Core-CMS/pull/973)).
- Do **not** add Image Zoom feature.
- Do **not** refactor `djangocms_picture`.

## Related

- mimics #973
- skips v4.36.N

## Changes

- **ports** https://github.com/TACC/Core-CMS/pull/973 to v4.35
- **documents** CMS as v4.35.1

## Testing

Same as #973.

## UI

https://github.com/user-attachments/assets/053e5a49-556c-41b2-821d-05e75fa385d3

https://github.com/user-attachments/assets/9cd43ee1-27a5-4e46-a53d-e3cfc58be5db