### PR TITLE
fix: do not install common email features app

### DIFF
--- a/common_apps/email_management/README.md
+++ b/common_apps/email_management/README.md
@@ -1,0 +1,6 @@
+# Possible Common Email Features
+
+> [!CAUTION]
+> Do **not** install. Code not fully tested. Probably should not be in `main`.
+
+See [TACC/Core-CMS#828](https://github.com/TACC/Core-CMS/pull/828) for status.

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -476,7 +476,6 @@ INSTALLED_APPS = [
     # core TACC CMS
     # HELP: If this were top of list, would TACC/Core-CMS/pull/169 fix break?
     'taccsite_cms',
-    'common_apps.email_management',
 
     # django CMS Bootstrap
     # IDEA: Extend Bootstrap apps instead of overwrite


### PR DESCRIPTION
## Status

> [!IMPORTANT]
> [Issue resolved.](https://tacc-team.slack.com/archives/C02GF2X2AS3/p1755028690671249?thread_ts=1755025558.623269&cid=C02GF2X2AS3) This change is unnecessary.

## Overview

Possibly fix `django.contrib.sites.models.Site.DoesNotExist: Site matching query does not exist.` error from https://github.com/TACC/tup-ui/tree/v1.1.17.

> [!NOTE]
> **This could also be done on `main`.** I pointed it to `release/v4.28.X` instead of `main` **only** to limit Core-CMS update necessary to (possibly) solve the error and (definitely) solve another error ([migration](https://github.com/TACC/Core-CMS/blob/v4.24.2/taccsite_cms/migrations/0001_add_groups.py) that [has become noop](https://github.com/TACC/Core-CMS/pull/932)).

## Related

- [internal conversation](https://tacc-team.slack.com/archives/C02GF2X2AS3/p1755025738199119?thread_ts=1755025558.623269&cid=C02GF2X2AS3)

## Changes

- **removes** install of unused app
- **documents** unused app

## Testing

1. Rebuild `tup-cms` using a CMS image with this change.
2. Verify **no** `Site matching query does not exist.` error.

## UI

…