### PR TITLE
chore: safely unregister picture plugin

### DIFF
--- a/taccsite_cms/djangocms_picture/extend.py
+++ b/taccsite_cms/djangocms_picture/extend.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(f"portal.{__name__}")
+
 def extendPicturePlugin():
     from django.utils.translation import gettext_lazy as _
 
@@ -125,7 +129,10 @@ def extendPicturePlugin():
     #      but is since not regularly used, but is used, thus maintained
     # FAQ: No need to unregister cuz Bootstrap4PicturePlugin does that
     # https://github.com/django-cms/djangocms-bootstrap4/blob/3.0.0/djangocms_bootstrap4/contrib/bootstrap4_picture/cms_plugins.py#L54
-    # plugin_pool.unregister_plugin(OriginalPicturePlugin)
+    # try:
+    #     plugin_pool.unregister_plugin(OriginalPicturePlugin)
+    # except Exception as e:
+    #     logger.warning(f"Could not unregister original plugin: {e}")
     plugin_pool.register_plugin(PicturePlugin)
 
 
@@ -158,6 +165,8 @@ def extendPicturePlugin():
             context.update(more_context)
 
             return context
-
-    plugin_pool.unregister_plugin(OriginalBootstrap4PicturePlugin)
+    try:
+        plugin_pool.unregister_plugin(OriginalBootstrap4PicturePlugin)
+    except Exception as e:
+        logger.warning(f"Could not unregister original plugin: {e}")
     plugin_pool.register_plugin(Bootstrap4PicturePlugin)


### PR DESCRIPTION
## Overview

Do not assume unregistering the original picture plugin will succeed. 

## Related

- improves https://github.com/TACC/Core-CMS/releases/tag/v4.36.0

## Changes

- **adds** `try`/`catch` around plugin unregister

## Testing / UI

Skipped.

## Notes

A.I. wanted to do this originally. I took it out. Maybe it is safer to not assume. Unsure, in this case. Core-CMS does indeed use original picture plugin, and will continue to do so.
