### PR TITLE
feat: let client have fullwidth breadcrumbs

### DIFF
--- a/taccsite_cms/templates/fullwidth.html
+++ b/taccsite_cms/templates/fullwidth.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load cms_tags %}
 
-{# To remove container and breadcrumbs #}
+{# To remove container and not render breadcrumbs #}
 {% block content %}
+  {% block breadcrumbs %}{% endblock breadcrumbs %}
   {% block cms_content %}
     {% placeholder "content" %}
   {% endblock cms_content %}


### PR DESCRIPTION
## Overview

Let client add breadcrumbs to fullwidth template as the would customize breadcrumbs on other templates.

## Related

- inspired by https://github.com/TACC/Texascale-CMS/pull/51

## Changes

- **adds** empty block

## Testing

- https://github.com/TACC/Texascale-CMS/pull/51

## UI

Skipped.