### PR TITLE
feat: PORTAL_LOGIN_PATH

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -280,6 +280,7 @@ PORTAL_FAVICON_HTML = f'''
 PORTAL_IS_TACC_CORE_PORTAL = True
 PORTAL_HAS_LOGIN = True
 PORTAL_HAS_SEARCH = True
+PORTAL_LOGIN_PATH = '/login'
 
 # Only use one of these values: 'sm', 'md', 'lg', 'xl'
 # SEE: https://getbootstrap.com/docs/4.0/components/navbar/#responsive-behaviors
@@ -876,6 +877,7 @@ SETTINGS_EXPORT = deprecated_SETTINGS_EXPORT + [
     'PORTAL_FAVICON_HTML',
     'PORTAL_IS_TACC_CORE_PORTAL',
     'PORTAL_HAS_LOGIN',
+    'PORTAL_LOGIN_PATH',
     'PORTAL_HAS_SEARCH',
     'PORTAL_NAV_WIDTH',
     'PORTAL_STYLES',

--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -1,13 +1,17 @@
-{# @var className #}
+{# @var className, settings #}
 
 {# WARNING: Some markup is duplicated in other repositories #}
 {# SEE: https://confluence.tacc.utexas.edu/x/LoCnCQ #}
 <ul class="s-portal-nav  {{ className }}" id="portal-nav">
 
-  <!-- All Portal-controlled nav elements handled here. -->
-  {# FAQ: Content populated via JavaScript, below #}
+  {# This content can be replaced by JavaScript below #}
+  {% if settings.PORTAL_HAS_LOGIN and not settings.PORTAL_IS_TACC_CORE_PORTAL %}
+  {% include "./nav_portal.raw.html" %}
+  {% endif %}
 
 </ul>
+
+{% if settings.PORTAL_IS_TACC_CORE_PORTAL %}
 <script type="module">
   import * as importHTML from '/static/site_cms/js/modules/importHTML.js';
 
@@ -42,3 +46,4 @@
     )
   });
 </script>
+{% endif %}

--- a/taccsite_cms/templates/nav_portal.raw.html
+++ b/taccsite_cms/templates/nav_portal.raw.html
@@ -1,3 +1,10 @@
-{# intentionally empty #}
-<!-- FAQ: This template loads independently at a unique url (see `urls.py`)
-          so CMS can render markup from this URL even if Portal is absent. -->
+{# @var settings #}
+
+<!-- FAQ: This template mimics Portal's `nav_portal.raw.html`
+          so CMS can render similar "Login" button for different portal -->
+
+<li class="nav-item">
+  <a class="nav-link" href="{{ settings.PORTAL_LOGIN_PATH }}">
+    <i class="icon icon-user"></i> Log in
+  </a>
+</li>

--- a/taccsite_cms/urls.py
+++ b/taccsite_cms/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
 
 if getattr(settings, 'PORTAL_IS_TACC_CORE_PORTAL', True):
     urlpatterns += [
-        # To allow direct access to markup for Portal and User Guide to render
+        # To allow direct access to markup for Portal to render
         url(r'^cms/nav/search/markup/$', TemplateView.as_view(template_name='nav_search.raw.html'), name='search_bar_markup'),
         url(r'^cms/nav/pages/markup/$', TemplateView.as_view(template_name='nav_cms.raw.html'), name='menu_pages_markup'),
         url(r'^cms/header/branding/markup/$', TemplateView.as_view(template_name='header_branding.html'), name='header_branding_markup'),
@@ -48,12 +48,6 @@ try:
     urlpatterns += custom_urls
 except ModuleNotFoundError:
     pass
-
-if getattr(settings, 'PORTAL_HAS_LOGIN', True):
-    urlpatterns += [
-        # To provide markup when Portal is missing
-        url(r'^core/markup/nav/$', TemplateView.as_view(template_name='nav_portal.raw.html'), name='portal_nav_markup'),
-    ]
 
 urlpatterns += [
     # The Django CMS urls


### PR DESCRIPTION
## Overview

Allow "Login" button for a non-TACC portal.

## Related

- mirrors #990
- fixed by #994

## Changes

- Add setting `PORTAL_LOGIN_PATH`.
- Render "Login" button for non-TACC portal.
- Delete `core/markup/nav/` fallback.

## Testing & UI

See #990.