### PR TITLE
fix: big error if core portal expected but absent (#993)

### DIFF
--- a/taccsite_cms/templates/nav_portal.html
+++ b/taccsite_cms/templates/nav_portal.html
@@ -5,9 +5,7 @@
 <ul class="s-portal-nav  {{ className }}" id="portal-nav">
 
   {# This content can be replaced by JavaScript below #}
-  {% if settings.PORTAL_HAS_LOGIN and not settings.PORTAL_IS_TACC_CORE_PORTAL %}
   {% include "./nav_portal.raw.html" %}
-  {% endif %}
 
 </ul>
 

--- a/taccsite_cms/templates/nav_portal.raw.html
+++ b/taccsite_cms/templates/nav_portal.raw.html
@@ -3,8 +3,12 @@
 <!-- FAQ: This template mimics Portal's `nav_portal.raw.html`
           so CMS can render similar "Login" button for different portal -->
 
+{% if settings.PORTAL_IS_TACC_CORE_PORTAL %}
+<!-- TACC/Core-Portal should overwrite this content -->
+{% else %}
 <li class="nav-item">
   <a class="nav-link" href="{{ settings.PORTAL_LOGIN_PATH }}">
     <i class="icon icon-user"></i> Log in
   </a>
 </li>
+{% endif %}

--- a/taccsite_cms/urls.py
+++ b/taccsite_cms/urls.py
@@ -49,6 +49,12 @@ try:
 except ModuleNotFoundError:
     pass
 
+if getattr(settings, 'PORTAL_IS_TACC_CORE_PORTAL', True):
+    urlpatterns += [
+        # To provide markup if TACC/Core-Portal is missing
+        url(r'^core/markup/nav/$', TemplateView.as_view(template_name='nav_portal.raw.html'), name='portal_nav_markup'),
+    ]
+
 urlpatterns += [
     # The Django CMS urls
     url(r'^', include('cms.urls')),


### PR DESCRIPTION
## Overview

Fix big error if TACC/Core-Portal expected but absent.

## Related

- fixes #991

## Changes

- load template with comment **if*:
    - `PORTAL_IS_TACC_CORE_PORTAL  = True`
    - TACC/Core-Portal is **not** running

## Testing & UI

0. Do **not** have TACC/Core-Portal attached or running.
1. Have CMS with settings:
    ```py
    PORTAL_IS_TACC_CORE_PORTAL = True
    PORTAL_HAS_LOGIN = True
    ```
2. Verify "Login" button does **not** render.
3. Verify portal menu has HTML comment.

	<img width="1024" height="506" alt="Screenshot 2025-10-01 at 14 26 13" src="https://github.com/user-attachments/assets/6535883c-c9fc-4c15-8f7d-5e3d9f04e2d9" />

## Notes

Use Cases:
- TACC/Core-CMS default set up (assumes TACC/Core-Portal).
- TACC/Core-Portal local dev environment incomplete.
