### PR TITLE
fix: djangocms-icon picker not showing Cortal icons

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -847,18 +847,18 @@ django-filer = ">=1.7"
 
 [[package]]
 name = "djangocms-icon"
-version = "2.0.0"
+version = "2.1.0"
 description = "Adds icon plugin to django CMS."
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "djangocms-icon-2.0.0.tar.gz", hash = "sha256:47cb98354b1b4ff5115757b3e37c573148c017ec29fcf78721426589cefdfb6d"},
-    {file = "djangocms_icon-2.0.0-py3-none-any.whl", hash = "sha256:c0074762e70d39e0bb4586d54f654c9345ec4387de9f73517e56fd937a5751ae"},
+    {file = "djangocms-icon-2.1.0.tar.gz", hash = "sha256:1a356c07e4fd89c31919f440300f9f3d80a951491a41545285fe5cf22e59d62d"},
+    {file = "djangocms_icon-2.1.0-py3-none-any.whl", hash = "sha256:be145e28c1f458fed5d96120a3147ff9373ea12540621e2ecf61a261b3b2af64"},
 ]
 
 [package.dependencies]
-django-cms = ">=3.7"
+django-cms = ">=3.10"
 djangocms-attributes-field = ">=1"
 
 [[package]]
@@ -2498,4 +2498,4 @@ testing = ["func-timeout", "jaraco.itertools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "79b1550820b1e2ee49c161333d3490ea79dda9a58d048c66511e4470304dd3c5"
+content-hash = "2ac17635289fc7cf2692591557221b048c40769a3ea1a108915ed19fc43cd098"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ djangocms-column = "^2.0"
 djangocms-file = "3.0.0"
 djangocms-forms-maintained = { git = "https://github.com/TACC/djangocms-forms", rev = "6b59ff366495915f06f4d6fac01a2f0aa9efecaf" }
 djangocms-googlemap = "2.0.0"
-djangocms-icon = "2.0.0"
+djangocms-icon = "^2.1.0"
 djangocms-link = "^3.1"
 djangocms-page-meta = "1.3.0"
 djangocms-picture = "3.0.0"

--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -750,8 +750,8 @@ with open(CORTAL_ICONFILE, 'r') as f:
     CORTAL_ICONS = f.read()
 
 DJANGOCMS_ICON_SETS = [
-    # The SVG icon set must be first or icon selection is not remembered on edit
-    # HELP: Icon previews are blank if editor switches from SVG set to icon set
+    # IMPORTANT: Each set must have same props, even if value is empty
+    # WARNING: Values in icon sets are not cleared when user changes set
     # https://github.com/django-cms/djangocms-icon/issues/9
     (LOGO_ICONS, '', _('Logo SVGs')),
     (CORTAL_ICONS, 'icon', _('TACC "Cortal" Icons')),

--- a/taccsite_cms/static/site_cms/img/icons/cortal.json
+++ b/taccsite_cms/static/site_cms/img/icons/cortal.json
@@ -1,4 +1,6 @@
 {
+    "svg": false,
+    "spritePath": "",
     "iconClass": "icon",
     "// icons": "https://github.com/TACC/Core-Styles/blob/main/src/lib/_imports/components/cortal.icon.font.css",
     "icons": [

--- a/taccsite_cms/static/site_cms/img/icons/cortal.json
+++ b/taccsite_cms/static/site_cms/img/icons/cortal.json
@@ -2,7 +2,6 @@
     "svg": false,
     "spritePath": "",
     "iconClass": "icon",
-    "// icons": "https://github.com/TACC/Core-Styles/blob/main/src/lib/_imports/components/cortal.icon.font.css",
     "icons": [
         "icon-add-file",
         "icon-alert",
@@ -99,7 +98,7 @@
         "icon-add-folder",
         "icon-add-project",
         "icon-extract",
-        "icon-compress",
-        "icon-pytorch"
-    ]
+        "icon-compress"
+    ],
+    "// icons": "https://github.com/TACC/Core-Styles/blob/v2.47.0/src/lib/_imports/components/cortal-icon-font.css#L77-L463"
 }

--- a/taccsite_cms/static/site_cms/img/icons/logos.json
+++ b/taccsite_cms/static/site_cms/img/icons/logos.json
@@ -1,7 +1,6 @@
 {
     "svg": true,
     "spritePath": "site_cms/img/icons/logos.svg",
-    "// iconClass": "Must be blank or svg template <use> hash includes a space",
     "iconClass": "",
     "icons": [
         "tacc-formal-logo",

--- a/taccsite_cms/templates/admin/djangocms_icon/includes/assets.html
+++ b/taccsite_cms/templates/admin/djangocms_icon/includes/assets.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.5.0/dist/components/cortal.icon.css" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/TACC/Core-Styles@v2.47.0/dist/components/cortal-icon.css" crossorigin="anonymous" />
 <style>
 /* To undo Core-Styles .icon class side effect on djangocms_icon markup */
 .djangocms-icon > .icon {


### PR DESCRIPTION
## Overview

Fix icon set icons not appearing if icon set is changed.

## Related

- still has known issue https://github.com/django-cms/djangocms-icon/issues/9

## Changes

- update djangocms-icon to latest
- document requirement for custom icons
- **SET SAME PROPERTIES FOR EVERY ICON SET**
- update cortal icon set

## Testing & UI

1. Add icon.
2. Select icon for Cortal icon set.
3. Change to Logo SVG set.
4. Change back to Cortal icon set.
5. Verify Cortal icons all visible in icon picker.

https://github.com/user-attachments/assets/267c0f7e-24f2-4583-b6bb-c78b9952a309

## Notes

<details><summary>

### Details about Current Solution

</summary>

Latest version of `djangocms-icon` (years later) did **not** fix problem for me. My solution was to ensure any value set in one custom icon set is also set in every other custom icon set.

Why? The values in different icon sets are not cleared upon switching icon set via the admin form; this means the value from one icon set can bleed into the value of the next one selected, causing different issues depending on customization:

| property | possible effect if not cleared/overwritten |
| - | - |
| `svg` | use wrong custom template |
| `spritePath` | asset load |
| `iconClass` | value in icon template |

I discovered this by logging [`options` within `iconPickerButton.on('change', …` in `icon-widget.js`](https://github.com/django-cms/djangocms-icon/blob/2.1.0/djangocms_icon/static/djangocms_icon/js/icon-widget.js#L61-L64).

</details>

### Known Issue

Must put Cortal icon set last. Something about it using `icon icon-name` as class name seems to cause https://github.com/django-cms/djangocms-icon/issues/9. Problem might go away when if retire Cortal icons.