### PR TITLE
fix: svg could display content

### DIFF
--- a/taccsite_cms/templates/djangocms_icon/includes/svg.html
+++ b/taccsite_cms/templates/djangocms_icon/includes/svg.html
@@ -5,7 +5,7 @@
 {# FAQ: The <span> allows Django CMS editor to edit via double-click #}
 <span
   class="has-svg {{ instance.icon }}{% if instance.attributes.class %} {{ instance.attributes.class }}{% endif %}"
-  {% if not instance.attributes.role or instance.attributes.role and instance.attributes.role != 'none' and instance.attributes.role != 'presentation' %}
+  {% if not instance.attributes.role %}
   aria-hidden="true"
   {% endif %}
   {% for key, value in instance.attributes.items %}

--- a/taccsite_cms/templates/djangocms_icon/includes/svg.html
+++ b/taccsite_cms/templates/djangocms_icon/includes/svg.html
@@ -4,7 +4,7 @@
 
 {# FAQ: The <span> allows Django CMS editor to edit via double-click #}
 <span class="has-svg {{ instance.icon }}{% if instance.attributes.class %} {{ instance.attributes.class }}{% endif %}" aria-hidden="true"{% for key, value in instance.attributes.items %}{% if key != 'class' %}{{ key }}="{{ value }}" {% endif %}{% endfor %}>
-  <svg role="presentation">
+  <svg>
     <use href="{% static path %}#{{ instance.icon }}"></use>
   </svg>
 </span>

--- a/taccsite_cms/templates/djangocms_icon/includes/svg.html
+++ b/taccsite_cms/templates/djangocms_icon/includes/svg.html
@@ -5,14 +5,11 @@
 {# FAQ: The <span> allows Django CMS editor to edit via double-click #}
 <span
   class="has-svg {{ instance.icon }}{% if instance.attributes.class %} {{ instance.attributes.class }}{% endif %}"
-  {% if instance.attributes.role %}
-  role="{{ instance.attributes.role }}"
-  {% endif %}
   {% if not instance.attributes.role or instance.attributes.role and instance.attributes.role != 'none' and instance.attributes.role != 'presentation' %}
   aria-hidden="true"
   {% endif %}
   {% for key, value in instance.attributes.items %}
-    {% if key != 'class' and key != 'role' %}
+    {% if key != 'class' %}
     {{ key }}="{{ value }}"
     {% endif %}
   {% endfor %}

--- a/taccsite_cms/templates/djangocms_icon/includes/svg.html
+++ b/taccsite_cms/templates/djangocms_icon/includes/svg.html
@@ -3,7 +3,20 @@
 {% load cms_tags static %}
 
 {# FAQ: The <span> allows Django CMS editor to edit via double-click #}
-<span class="has-svg {{ instance.icon }}{% if instance.attributes.class %} {{ instance.attributes.class }}{% endif %}" aria-hidden="true"{% for key, value in instance.attributes.items %}{% if key != 'class' %}{{ key }}="{{ value }}" {% endif %}{% endfor %}>
+<span
+  class="has-svg {{ instance.icon }}{% if instance.attributes.class %} {{ instance.attributes.class }}{% endif %}"
+  {% if instance.attributes.role %}
+  role="{{ instance.attributes.role }}"
+  {% endif %}
+  {% if not instance.attributes.role or instance.attributes.role and instance.attributes.role != 'none' and instance.attributes.role != 'presentation' %}
+  aria-hidden="true"
+  {% endif %}
+  {% for key, value in instance.attributes.items %}
+    {% if key != 'class' and key != 'role' %}
+    {{ key }}="{{ value }}"
+    {% endif %}
+  {% endfor %}
+  >
   <svg>
     <use href="{% static path %}#{{ instance.icon }}"></use>
   </svg>


### PR DESCRIPTION
## Overview

- Only set `aria-hidden` if role is absent or not `none`/`presentation`.
- Indent attributes for Icon container (`<span>`).

Let user decide via attribute on Icon.

## Related

None.

## Changes

- edit template

## Testing

1. Add an `.svg` Icon with **no** `role` attribute`.
2. Verify HTML has `aria-hidden="true"`.
3. Add an `.svg` Icon with `role` attribute with **any _non-empty_ value**.
4. Verify HTML has `role="that value"` and **no** `aria-hidden="true"`.

## UI

Skipped.

## Notes

User can add `role` via Attributes (via "Advanced settings"). If user manually adds `aria-hidden`, no problem (it's just a duplicate).