### PR TITLE
fix: core-styles icon class ineffectual (on main)

### DIFF
--- a/docs/develop-project.md
+++ b/docs/develop-project.md
@@ -93,9 +93,9 @@ See https://tacc.github.io/Core-Styles.
     ```
 1. Checkout [Core Styles] at that version, e.g.:
     ```shell
-    git checkout v2.43.1
+    git checkout v2.47.2
     ```
-2. Follow [Core Styles "Quick Start"](https://github.com/TACC/Core-Styles/blob/v2.43.2/README.md#quick-start) up to `npm start`.
+2. Follow [Core Styles "Quick Start"](https://github.com/TACC/Core-Styles/blob/v2.47.2/README.md#quick-start) up to `npm start`.
 
 ## Develop with [Core Styles] Simultaneously
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.47.1"
+        "@tacc/core-styles": "^2.47.2"
       },
       "engines": {
         "node": ">=16",
@@ -1132,9 +1132,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.47.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.47.1.tgz",
-      "integrity": "sha512-XnfJaR/akvIu2iTHXxLvFSenSUwv9snnkq1zfTqNhqm5UoXqBpBGGfnH9ts7+geSsgdpk7gQ4rUzwHgPQNyO1Q==",
+      "version": "2.47.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.47.2.tgz",
+      "integrity": "sha512-fzJyc7sNQhdk5Rpfe54rbW5tUknBDV4RtTmVxon2+xJkDE0Vzz38zLkoN/w8411njrlMZX0h9uFLjnKlV8a2Lg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4733,9 +4733,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.47.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.47.1.tgz",
-      "integrity": "sha512-XnfJaR/akvIu2iTHXxLvFSenSUwv9snnkq1zfTqNhqm5UoXqBpBGGfnH9ts7+geSsgdpk7gQ4rUzwHgPQNyO1Q==",
+      "version": "2.47.2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.47.2.tgz",
+      "integrity": "sha512-fzJyc7sNQhdk5Rpfe54rbW5tUknBDV4RtTmVxon2+xJkDE0Vzz38zLkoN/w8411njrlMZX0h9uFLjnKlV8a2Lg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.47.1"
+    "@tacc/core-styles": "^2.47.2"
   }
 }

--- a/taccsite_cms/static/site_cms/img/icons/cortal.json
+++ b/taccsite_cms/static/site_cms/img/icons/cortal.json
@@ -100,5 +100,5 @@
         "icon-extract",
         "icon-compress"
     ],
-    "// icons": "https://github.com/TACC/Core-Styles/blob/v2.47.0/src/lib/_imports/components/cortal-icon-font.css#L77-L463"
+    "// icons": "https://github.com/TACC/Core-Styles/blob/v2.47.2/src/lib/_imports/components/cortal-icon-font.css#L77-L463"
 }


### PR DESCRIPTION
Mimics #1002.

_Includes some `main` commits... already in `main`. Dunno what happened. Diff is as expected though._