### PR TITLE
fix: giant logos in header by updating Core-Styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.47.2"
+        "@tacc/core-styles": "^2.47.3"
       },
       "engines": {
         "node": ">=16",
@@ -1132,9 +1132,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.47.2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.47.2.tgz",
-      "integrity": "sha512-fzJyc7sNQhdk5Rpfe54rbW5tUknBDV4RtTmVxon2+xJkDE0Vzz38zLkoN/w8411njrlMZX0h9uFLjnKlV8a2Lg==",
+      "version": "2.47.3",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.47.3.tgz",
+      "integrity": "sha512-W+ol2BtrhEeWkimvMcjDg2sTsKW4Ri6ggYa4kPbJN9Okw/DyHmtCx+JTwUBAp+iDxUWCC+FaMOmi8ZqSnAeljA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4733,9 +4733,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.47.2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.47.2.tgz",
-      "integrity": "sha512-fzJyc7sNQhdk5Rpfe54rbW5tUknBDV4RtTmVxon2+xJkDE0Vzz38zLkoN/w8411njrlMZX0h9uFLjnKlV8a2Lg==",
+      "version": "2.47.3",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.47.3.tgz",
+      "integrity": "sha512-W+ol2BtrhEeWkimvMcjDg2sTsKW4Ri6ggYa4kPbJN9Okw/DyHmtCx+JTwUBAp+iDxUWCC+FaMOmi8ZqSnAeljA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.47.2"
+    "@tacc/core-styles": "^2.47.3"
   }
 }


### PR DESCRIPTION
## Overview

Fix giant logos by updating Core-Styles.

## Related

- requires https://github.com/TACC/Core-Styles/pull/551
- fixes #1004

## Changes

- **updates** Core-Styles to [v2.47.3](https://github.com/TACC/Core-Styles/releases/tag/v2.47.3)

## Testing & UI

See https://github.com/TACC/Core-Styles/pull/551.