### PR TITLE
feat: serve page with no header nor footer

### DIFF
--- a/taccsite_cms/settings_custom.example.py
+++ b/taccsite_cms/settings_custom.example.py
@@ -28,8 +28,9 @@ CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),
 
-    # WARNING: Unintuitive, so only enable as needed e.g. TACC/Core-CMS#868
-    # ('plain.html', 'Plain'),
+    # WARNING: Unintuitive, so only enable as needed
+    # ('plain.html', 'Plain'),          # TACC/Core-CMS#868
+    # ('content.html', 'Content Only'), # TACC/Core-CMS#___
 )
 
 ########################

--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -51,9 +51,11 @@
 <body class="{% block page_type_class %}{% endblock page_type_class %}">
   {% cms_toolbar %}
 
+  {% block header %}
   <header>
     {% include "header.html" %}
   </header>
+  {% endblock header %}
 
   <main id="cms-content">
   {% block content %}
@@ -79,7 +81,9 @@
   {% endblock content %}
   </main>
 
+  {% block footer %}
   {% include "footer.html" %}
+  {% endblock footer %}
 
   <!-- Assets (Delayed). -->
 {% if settings.TACC_CORE_STYLES_VERSION == 0 %}

--- a/taccsite_cms/templates/content.html
+++ b/taccsite_cms/templates/content.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block header %}{% endblock %}
+
+{% include 'plain.html' %}
+
+{% block footer %}{% endblock %}


### PR DESCRIPTION
## Overview

Allow serving a page with no header and no footer.

> [!important]
> So https://galaxy.cfdeworkspace.org/ can load https://cfdeworkspace.org/welcome/ inside its portal [without header and footer](https://cfdeworkspace.org/welcome/?template=content.html).

## Changes

- **adds** template `content.html`
- **adds** blocks `header` and `footer`
    <sup> so they can be emptied by the new template</sup>

## Testing

0. In `settings_custom.py` or `settingslocal.py`, add:
    ```py
    CMS_TEMPLATES = (
        ...
        ('content.html', 'Content Only'),
    )
    ```
1. Open any page that has content.
2. Append `?template=content.html&toolbar_off` to the URL.
3. Verify page header and page footer are **not** shown.

## UI

| normal URL | `?template=content.html` |
| - | - |
| <img width="960" height="475" alt="baseline" src="https://github.com/user-attachments/assets/f4d1a198-599a-4eeb-95ef-d47130e3e3bf" /> | <img width="960" height="475" alt="test" src="https://github.com/user-attachments/assets/5114b253-fabd-40cf-9929-316f047b5f26" /> |