### PR TITLE
fix: serve page with no header nor footer

### DIFF
--- a/taccsite_cms/templates/content.html
+++ b/taccsite_cms/templates/content.html
@@ -3,6 +3,12 @@
 
 {% block header %}{% endblock %}
 
-{% include 'plain.html' %}
+{# To remove container and breadcrumbs #}
+{% block content %}
+  {% block cms_content %}
+    {% placeholder "content" %}
+  {% endblock cms_content %}
+  {% block app_content %}{% endblock app_content %}
+{% endblock content %}
 
 {% block footer %}{% endblock %}


### PR DESCRIPTION
## Overview

Fix breadcrumbs and container showing in `content.html` template.

## Related

- fixes #1012

## Changes

- **refactored** `content.html` to manually hide breadcrumbs and container
    <sup>like `fullwidth.html` and `plain.html`</sup>

## Testing

Repeat steps from:
- #1012

## UI

| before | after |
| - | - |
| <img width="960" height="475" alt="bug" src="https://github.com/user-attachments/assets/fbc699c7-ac72-456b-8b6b-157a803e909c" /> | <img width="960" height="475" alt="fix" src="https://github.com/user-attachments/assets/0f368d7c-9640-437e-bc9a-2ad169af6a44" /> |
