### PR TITLE
feat: always allow CMS_TEMPLATE content.html

### DIFF
--- a/taccsite_cms/settings.py
+++ b/taccsite_cms/settings.py
@@ -157,8 +157,9 @@ SITE_ID = 1
 CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),
+    ('content.html', 'Content Only'),
 
-    ('guide.html', 'Guide'),
+    ('guide.html', 'Guide'), # backwards compatibility, users unknown
 )
 
 CMS_PERMISSION = True

--- a/taccsite_cms/settings_custom.example.py
+++ b/taccsite_cms/settings_custom.example.py
@@ -27,10 +27,10 @@ AUTH_LDAP_SERVER_URI = "ldap://cluster.ldap.tacc.utexas.edu"
 CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),
+    ('content.html', 'Content Only'),
 
     # WARNING: Unintuitive, so only enable as needed
     # ('plain.html', 'Plain'),          # TACC/Core-CMS#868
-    # ('content.html', 'Content Only'), # TACC/Core-CMS#___
 )
 
 ########################


### PR DESCRIPTION
## Overview

Always allow `content.html` "Content Only" template (to hide header and footer).

## Related

- mimicked by #1017

## Notes

When using this to serve pages in `<iframe>`:
1. Edit page.
2. Show "Advanced options".
3. Set "**X Frame Options:**" to "Allow"