### PR TITLE
fix: giant social media icons by default - off stable

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/logos.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/logos.css
@@ -1,0 +1,3 @@
+.logos--social a {
+  display: inline-block;
+}

--- a/taccsite_cms/static/site_cms/css/src/core-cms.css
+++ b/taccsite_cms/static/site_cms/css/src/core-cms.css
@@ -15,3 +15,4 @@
 @import url("./_imports/components/django.cms.picture.css");
 @import url("./_imports/components/django-cms-video.css");
 @import url("./_imports/components/lightgallery.css");
+@import url("./_imports/components/logos.css");

--- a/taccsite_cms/templates/share_on_social.html
+++ b/taccsite_cms/templates/share_on_social.html
@@ -12,28 +12,28 @@
   {% for platform in platforms %}
     {% if platform == 'facebook' %}
     <a href="https://www.facebook.com/sharer/sharer.php?u={{ url }}" target="_blank" class="logos__facebook">
-      <svg viewbox="0 0 25 25">
+      <svg width="1em" height="1em">
         <use href="/static/site_cms/img/org_logos/facebook.svg#facebook-icon"></use>
       </svg>
     </a>
     {% endif %}
     {% if platform == 'linkedin' %}
     <a href="https://www.linkedin.com/cws/share?url={{ url }}" target="_blank" class="logos__linkedin">
-      <svg viewbox="0 0 25 25">
+      <svg width="1em" height="1em">
         <use href="/static/site_cms/img/org_logos/linkedin.svg#linkedin-icon"></use>
       </svg>
     </a>
     {% endif %}
     {% if platform == 'bluesky' %}
     <a href="https://bsky.app/intent/compose?text={{ url }}" target="_blank" class="logos__bluesky">
-      <svg viewbox="0 0 25 25">
+      <svg width="1em" height="1em">
         <use href="/static/site_cms/img/org_logos/bluesky.svg#bluesky-icon"></use>
       </svg>
     </a>
     {% endif %}
     {% if platform == 'email' %}
     <a href="mailto:?body={{ url }}" target="_blank" class="logos__email">
-      <svg viewbox="0 0 25 25">
+      <svg width="1em" height="1em">
         <use href="/static/site_cms/img/org_logos/email.svg#email-icon"></use>
       </svg>
     </a>


### PR DESCRIPTION
## Overview

Social media icons need not be giant by default.

<sup>I had misconception any size meant a standard I commit to, but I found a simple solution.</sup>

## Related

- mimics #1026

## Changes

- **added** default size for icons (match font-size)
- **fixed** extra space within link around svg

## Testing & UI

See #1026.