### PR TITLE
fix: remove excess social media styles

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -144,27 +144,20 @@ Styleguide Components.DjangoCMS.Blog.App
   display: flex;
   flex-wrap: wrap;
   justify-self: end;
-}
-
-.app-blog .logos--social > a {
-  display: flex; /* to vertically center the svg (as needed) */
 
   @media (pointer: coarse) {
-    padding-inline: 0.5em;
+    gap: 1.0em;
   }
   @media not (pointer: coarse) {
-    padding-inline: 0.25em;
+    gap: 0.5em;
   }
 }
 
 .app-blog .logos__text-before {
   white-space: nowrap;
-  margin-right: 0.25em;
 }
 
 .app-blog .logos--social svg {
-  fill: var(--global-color-primary--x-dark);
-
   @media (pointer: coarse) {
     height: var(--global-font-size--xx-large);
     width: var(--global-font-size--xx-large);
@@ -174,11 +167,6 @@ Styleguide Components.DjangoCMS.Blog.App
     width: var(--global-font-size--large);
   }
 }
-.app-blog a.logos__facebook:hover svg { fill: #0866ff; }
-.app-blog a.logos__linkedin:hover svg { fill: #0a66c2; }
-.app-blog a.logos__email:hover svg { fill: #0000ff; }
-.app-blog a.logos__bluesky:hover svg { fill: #0085ff; }
-.app-blog a.logos__instagram:hover svg { fill: #bc1888; }
 
 
 


### PR DESCRIPTION
## Overview / Changes

Delete redundant Social Media Share icon styles in News/Blog.

## Related

- mirrored by #1031

## Testing

1. Open blog article.
2. Compare icon layout and UX.
3. Verify minimal change:
    - email icon is TACC blue (via v4.35.12)
    - icons align to right of article (no extra space)

## UI

| before | after |
| - | - |
| <img width="360" height="475" alt="after" src="https://github.com/user-attachments/assets/bce07114-8a30-41bb-b3b1-ddc2038ca5d7" /> | <img width="360" height="475" alt="before" src="https://github.com/user-attachments/assets/9d6098f9-7c34-4c82-a3b6-c7a6bd89a5c3" /> |