### PR TITLE
refactor: load blog styles as ad-hoc css

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/base.html
+++ b/taccsite_cms/templates/djangocms_blog/base.html
@@ -24,7 +24,7 @@
 {# /TACC #}
 
 {# TACC (to add blog styles): #}
-{% block assets_app %}
+{% block assets_blog %}
 {% addtoblock "css" %}
 {% if settings.TACC_CORE_STYLES_VERSION == 0 %}
 <style>
@@ -36,7 +36,7 @@
 </style>
 {% endif %}
 {% endaddtoblock %}
-{% endblock assets_app %}
+{% endblock assets_blog %}
 {# /TACC #}
 
 <div class="app app-blog

--- a/taccsite_cms/templates/djangocms_blog/post_detail.html
+++ b/taccsite_cms/templates/djangocms_blog/post_detail.html
@@ -93,7 +93,7 @@
 {% endblock content_blog %}
 
 {# TACC (redirect external articles): #}
-{% block assets_app %}
+{% block assets_blog %}
 {{ block.super }}
 {% addtoblock "js" %}
 <script id="redirect-external-article" type="module">
@@ -102,5 +102,5 @@ import { redirectExternalArticle } from '{% static "site_cms/js/modules/manageEx
 redirectExternalArticle('{{ settings.PORTAL_BLOG_SHOW_ABSTRACT_TAG }}');
 </script>
 {% endaddtoblock %}
-{% endblock assets_app %}
+{% endblock assets_blog %}
 {# /TACC #}

--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -84,7 +84,7 @@
 {% endspaceless %}
 
 {# TACC (change how to open external articles): #}
-{% block assets_app %}
+{% block assets_blog %}
 {{ block.super }}
 {% addtoblock "js" %}
 <script type="module" id="change-how-to-open-external-articles">
@@ -93,5 +93,5 @@ import { changeHowExternalArticleOpens } from '{% static "site_cms/js/modules/ma
 changeHowExternalArticleOpens('{{ settings.PORTAL_BLOG_SHOW_ABSTRACT_TAG }}');
 </script>
 {% endaddtoblock %}
-{% endblock assets_app %}
+{% endblock assets_blog %}
 {# /TACC #}


### PR DESCRIPTION
## Overview

Consistently manage blog scripts & styles.

## Related

- #1033

## Changes

- Load blog styles as ad-hoc CSS (like scripts).
- Let blog scripts be overridden by client (like styles).
- Rename `assets_app` to `assets_blog`.

## Testing

1. Follow #1033.
2. Verify blog styles are still loaded.

## UI

1. See #1033.
2. See <img width="960" height="470" alt="blog assets still load" src="https://github.com/user-attachments/assets/7b49268f-7c93-4e4f-a3e7-ffe5d0cff0a6" />


