### PR TITLE
fix: drop cap not hidden when blog tag applied

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -142,6 +142,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 }
 
 /* Remove Drop Cap when tag is added */
+/* https://github.com/TACC/Core-Styles/blob/v2.50.2/src/lib/_imports/trumps/s-drop-cap.css#L3-L6 */
 .has-blog-tag-no-drop-cap .s-drop-cap::first-letter,
 .has-blog-tag-no-drop-cap .s-drop-cap > p:not(.s-drop-cap)::first-letter {
   padding-right: unset;


### PR DESCRIPTION
## Overview

If first element is not a `<p>`, then drop-cap still happens, even if with `no-drop-cap` tag.

## Changes

- **added** selector to ruleset that disables drop-cap

## Testing

0. Open an article with the bug.
    <sup> article has tag `no-drop-cap` **and** first text element is `<h2>`</sup>
1. Verify drop cap is present.
2. In Developer Tools "Inspector", select the first `<p>` tag of the article.
3. In "Styles" tab, find the `.has-blog-tag-no-drop-cap` class.
4. Prepend selector with

    ```css
    .has-blog-tag-no-drop-cap .s-drop-cap::first-letter, 
    ```

5. Verify drop cap is gone.

## UI

https://github.com/user-attachments/assets/632d4f4b-b17d-47fa-8788-fc8a16383761

