### PR TITLE
fix: 1 malformed external article breaks link change for others

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/manageExternalArticles.js
+++ b/taccsite_cms/static/site_cms/js/modules/manageExternalArticles.js
@@ -5,14 +5,18 @@
  */
 export function getArticleExternalURL(article) {
   if (!article) {
-    console.warn('No article found', article);
+    console.warn('No article given');
     return;
   }
 
   // The admin of news promises leads/abstracts will only have 1 external link
-  const contentLink = article.querySelector('.blog-lead a[href^="http"]');
-  const isExternalLink = contentLink.hostname !== window.location.hostname;
-  const URL = isExternalLink ? contentLink.href : null;
+  const externalLink = article.querySelector('.blog-lead a[href^="http"]');
+  if (!externalLink) {
+    console.warn('No external link found for article', article);
+    return;
+  }
+  const isExternalLink = externalLink.hostname !== window.location.hostname;
+  const URL = isExternalLink ? externalLink.href : null;
 
   return URL;
 }


### PR DESCRIPTION
## Overview

One malformed external article breaks the link change for other external articles.

## Related

- fixes #1033

## Changes

- **adds** conditional early return

## Testing

0. Have News feed.
1. Earlier in list, have one malformed external article.
     does **not** have tag `external`
    - in abstract, has a (hidden) link
2. Later in news list, have multiple well-formed external articles:
    - has tag `external`
    - in abstract, has a (hidden) link

## UI

Skipped.
