### PR TITLE
fix: irrelevant warning in non-external article

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/manageExternalArticles.js
+++ b/taccsite_cms/static/site_cms/js/modules/manageExternalArticles.js
@@ -59,6 +59,9 @@ export function redirectExternalArticle(extTagName = 'external') {
   const article = document.querySelector(`
     .has-blog-tag-${extTagName}
   `);
+
+  if ( ! article ) return;
+
   const URL = getArticleExternalURL( article );
 
   if ( ! URL ) {


### PR DESCRIPTION
## Overview

Exit script early if article is not external.

Prevents irrelevant warning.
