### PR TITLE
feat: align article tags (not shown on any client)

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.css
@@ -87,10 +87,14 @@ Styleguide Components.DjangoCMS.Blog.App
 .app-blog .categories {
   @mixin news-metadata;
   a { @mixin news-category; }
+
+  justify-self: start;
 }
 .app-blog .tags {
   @mixin news-metadata;
   a { @mixin news-tag; }
+
+  justify-self: end;
 }
 
 


### PR DESCRIPTION
## Overview

- Align article tags (not shown on feed for any client).
- Align article categories implicitly (no visual change).