### PR TITLE
refactor(css): rename blog custom selectors

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css
@@ -16,10 +16,10 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 /* Root */
 
-:--article-list {
+:--news-feed-page {
   @mixin news-feed;
 }
-:--article-list--as-grid {
+:--news-feed-page--as-grid {
   @media (--narrow-and-below) {
     @mixin news-feed--as-list;
   }
@@ -37,14 +37,14 @@ Styleguide Components.DjangoCMS.Blog.App.Item
     grid-template-columns: repeat( 4, 1fr );
   }
 }
-:--article-list--as-list {
+:--news-feed-page--as-list {
   @mixin news-feed--as-list;
 }
 
 
 /* Header */
 
-:--article-list--as-grid > header {
+:--news-feed-page--as-grid > header {
   @media (--narrow-and-above) {
     @mixin news-feed--as-grid__header;
   }
@@ -53,13 +53,13 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 /* Title */
 
-:--article-list h1 > strong::after {
+:--news-feed-page h1 > strong::after {
   @mixin news-feed-title__separator;
 }
-:--article-list h1 > span {
+:--news-feed-page h1 > span {
   @mixin news-feed-title__type-key;
 }
-:--article-list h1 > em {
+:--news-feed-page h1 > em {
   @mixin news-feed-title__type-value;
 }
 
@@ -67,7 +67,7 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 /* Article */
 
 /* For all layouts */
-:--article-item {
+:--news-article-item {
   @mixin news-feed__article;
 
   & header       { grid-area: head; }
@@ -77,78 +77,78 @@ Styleguide Components.DjangoCMS.Blog.App.Item
 
 /* For layout variants — grid vs list */
 @media (--narrow-and-below) {
-  :--article-item {
+  :--news-article-item {
     @mixin news-feed--grid-layout__article;
     @mixin news-feed__article--has-border;
   }
 }
 @media (--narrow-and-above) {
-  :--article-item--in-list {
+  :--news-article-item--in-list {
     @mixin news-feed--list-layout__article;
     @mixin news-feed__article--has-border;
   }
-  :--article-item--in-grid {
+  :--news-article-item--in-grid {
     @mixin news-feed--grid-layout__article;
   }
 }
 /* For layout variants — see grid-template-columns */
-:--article-item--in-grid {
+:--news-article-item--in-grid {
   @media (--narrow-and-below) {
     @mixin news-feed__article--has-border;
   }
 }
 /* For layout variants — no media */
-:--article-item:not(:has(.blog-visual > *)) {
+:--news-article-item:not(:has(.blog-visual > *)) {
   @mixin news-feed__article--no-media;
 }
 
 /* Article - Titles */
 
-:--article-item h3 {
+:--news-article-item h3 {
   margin-bottom: unset; /* overrides Core-Styles headings--cms.css */
 }
-:--article-item h4 {
+:--news-article-item h4 {
   display: none;
 }
 
 /* Article - Details */
 
-:--article-item li {
+:--news-article-item li {
   @mixin news-feed-article__details__item;
 }
 
-:--article-item .attrs {
+:--news-article-item .attrs {
   @mixin news-feed-article__details--attr;
 }
-:--article-item .attrs a {
+:--news-article-item .attrs a {
   @mixin news-feed-article__details--attr__link;
 }
 
 /* Article - Visual */
 
-:--article-item .blog-visual {
+:--news-article-item .blog-visual {
   @mixin news-feed-article__media;
   @mixin news-feed-article__media--constrain-content;
 }
 @media (--medium-and-below) {
-  :--article-item .blog-visual {
+  :--news-article-item .blog-visual {
     @mixin news-feed-article__media--above-text;
   }
 }
 @media (--medium-and-above) {
-  :--article-item--in-grid .blog-visual {
+  :--news-article-item--in-grid .blog-visual {
     @mixin news-feed-article__media--above-text;
   }
 }
 
 /* Article - Lead */
 
-:--article-item .blog-lead {
+:--news-article-item .blog-lead {
   @mixin news-feed-article__lead;
 }
 
 /* Article - Footer */
 
-:--article-item .read-more {
+:--news-article-item .read-more {
   @mixin news-feed-article__link-overlay;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -19,7 +19,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* Root */
 
-:--article-page {
+:--news-article-page {
   @mixin news-article-page;
 }
 
@@ -28,7 +28,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* Header */
 
-:--article-page header {
+:--news-article-page header {
   @mixin news-article-page__header;
 
   & h1          { grid-area: title; }
@@ -49,10 +49,10 @@ Styleguide Components.DjangoCMS.Blog.App.Page
     @mixin news-article-page__header--hide-cats-show-tags;
   }
 }
-:--article-page header h1 {
+:--news-article-page header h1 {
   @mixin news-article-page__title;
 }
-:--article-page header h2 {
+:--news-article-page header h2 {
   @mixin news-article-page__subtitle;
 }
 
@@ -61,9 +61,9 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* Body */
 
-:--article-page .blog-lead,
-:--article-page .blog-visual,
-:--article-page .blog-content {
+:--news-article-page .blog-lead,
+:--news-article-page .blog-visual,
+:--news-article-page .blog-content {
   @mixin news-article-page__body;
 }
 
@@ -73,19 +73,19 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 /* Media */
 
 /* To mimic Bootstrap `.img-fluid` */
-:--article-page .blog-visual img {
+:--news-article-page .blog-visual img {
   max-width: 100%;
   height: auto;
 }
 
 /* To support vertical layouts at narrow viewports */
-:--article-page .blog-visual {
+:--news-article-page .blog-visual {
   @mixin news-article-page__media;
 }
 
 /* To prevent footer on left side of page */
-/* FAQ: Because of `:--article-page .blog-visual`'s `float: right` */
-:--article-page .blog-visual ~ .blog-content::after {
+/* FAQ: Because of `:--news-article-page .blog-visual`'s `float: right` */
+:--news-article-page .blog-visual ~ .blog-content::after {
   /* from Bootstrap `clearfix` */
   display: block;
   content: "";
@@ -112,7 +112,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* To undo inline content styles */
 /* FAQ: In case author pasted such markup from another source */
-:--article-page .blog-content [style]:not(
+:--news-article-page .blog-content [style]:not(
     [data-style="admin"], /* HACK: so CMS admin can override this */
     [id^="flickrembed_"] * /* HACK: so Flickr slideshow works */
 ) {
@@ -121,8 +121,8 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* Add space between all list items */
 /* FAQ: Use case is list items with as much text as a paragraph */
-:--article-page .blog-lead li + li,
-:--article-page .blog-content li + li {
+:--news-article-page .blog-lead li + li,
+:--news-article-page .blog-content li + li {
   margin-top: 0.5em;
 }
 
@@ -143,18 +143,18 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 
 /* TODO: When extending Core-Styles c-news, .blockquote... is only for CMS */
 /* FAQ: .blockquote... is only for CMS, cuz `.align-…` is from Core-Styles */
-:--article-page .blog-content .align-left,
-:--article-page .blog-content .blockquote.text-left {
+:--news-article-page .blog-content .align-left,
+:--news-article-page .blog-content .blockquote.text-left {
   @extend .o-offset-content--left;
 }
-:--article-page .blog-content .align-right,
-:--article-page .blog-content .blockquote.text-right {
+:--news-article-page .blog-content .align-right,
+:--news-article-page .blog-content .blockquote.text-right {
   @extend .o-offset-content--right;
 }
-:--article-page .blog-content .align-center {
+:--news-article-page .blog-content .align-center {
   max-width: 100%;
 }
-:--article-page .blog-content .blockquote.text-center {
+:--news-article-page .blog-content .blockquote.text-center {
   margin-inline: auto;
 }
 
@@ -163,7 +163,7 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 /* TODO: When extending Core-Styles c-news, .blockquote... is only for CMS */
 /* FAQ: .blockquote... is only for CMS, cuz `.align-…` is from Core-Styles */
 @layer foundation {
-  :--article-page .blog-content .blockquote[class*="text-"] {
+  :--news-article-page .blog-content .blockquote[class*="text-"] {
     text-align: left !important; /* overwrite Bootstrap .text-... !important */
   }
 }
@@ -171,28 +171,28 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 /* To remove margin on narrow screens */
 /* To overwrite @tacc/core-styles/…/components/align.css */
 @media (--medium-and-below) {
-  :--article-page .blog-content .align-center,
-  :--article-page .blog-content .align-right,
-  :--article-page .blog-content .align-left {
+  :--news-article-page .blog-content .align-center,
+  :--news-article-page .blog-content .align-right,
+  :--news-article-page .blog-content .align-left {
     max-width: 100%;
   }
-  :--article-page .blog-content .align-right,
-  :--article-page .blog-content .align-left {
+  :--news-article-page .blog-content .align-right,
+  :--news-article-page .blog-content .align-left {
     float: unset;
   }
-  :--article-page .blog-content .align-right {
+  :--news-article-page .blog-content .align-right {
     margin-left: unset;
   }
-  :--article-page .blog-content .align-left {
+  :--news-article-page .blog-content .align-left {
     margin-right: unset;
   }
 }
 
 /* To reduce image width on medium screens */
 @media (--medium-and-above) and (--medium-and-below) {
-  :--article-page .blog-content .align-center,
-  :--article-page .blog-content .align-right,
-  :--article-page .blog-content .align-left {
+  :--news-article-page .blog-content .align-center,
+  :--news-article-page .blog-content .align-right,
+  :--news-article-page .blog-content .align-left {
     max-width: 50%;
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.selectors.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.selectors.css
@@ -2,13 +2,15 @@
 
 /* To make these selectors easier to remember (rather than add classnames) */
 /* FAQ: Avoiding changing blog templates to limit app upgrade maintenance */
-@custom-selector :--article-page article.post-detail;
-@custom-selector :--article-list .blog-list;
-@custom-selector :--article-list--as-list :--article-list:not(.as-grid);
-@custom-selector :--article-list--as-grid :--article-list.as-grid;
-@custom-selector :--article-item :--article-list article;
-@custom-selector :--article-item--in-list :--article-list--as-list article;
-@custom-selector :--article-item--in-grid :--article-list--as-grid article;
+@custom-selector :--news-article-page article.post-detail;
+
+@custom-selector :--news-feed-page .blog-list;
+@custom-selector :--news-feed-page--as-list :--news-feed-page:not(.as-grid);
+@custom-selector :--news-feed-page--as-grid :--news-feed-page.as-grid;
+
+@custom-selector :--news-article-item :--news-feed-page article;
+@custom-selector :--news-article-item--in-list :--news-feed-page--as-list article;
+@custom-selector :--news-article-item--in-grid :--news-feed-page--as-grid article;
 
 @custom-selector :--news-feed-embed
   .blog-latest-entries,


### PR DESCRIPTION
## Overview

Rename custom selectors in CSS for blog/news.

## Testing

Verify all blog/news styles still work.

## UI

| article | feed |
| - | - |
| <img width="900" height="435" alt="article" src="https://github.com/user-attachments/assets/8dde6728-06c0-4fef-abdd-e114d50b2047" /> | <img width="900" height="435" alt="feed" src="https://github.com/user-attachments/assets/f597c453-fbc8-4c4c-8e31-be2d505f30f4" /> |

https://github.com/user-attachments/assets/2a10a2b3-a104-4778-9fba-cec799e47947
