### PR TITLE
Quick: Use non-slim jQuery dep to fix djangocms-forms incompatibility

### DIFF
--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -4,7 +4,7 @@
 
 {# Bootstrap #}
 {# SEE: https://getbootstrap.com/docs/4.6/getting-started/introduction/#starter-template #}
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
 
 {# TACC/Core-CMS #}


### PR DESCRIPTION
## Overview
The jQuery form plugin used by djangocms-forms is not compatible with jQuery slim (see: https://github.com/jquery-form/form). This diff replaces jquery-slim with the full-fat version, which includes the required ajax config.
…

## Related
Re-enables fix from previous PR: https://github.com/TACC/Core-CMS/pull/912

## UI

| before | after |
| - | - |
| <img width="780" height="455" alt="dev-cep BEFORE" src="https://github.com/user-attachments/assets/a1477840-2d6d-4aff-aa61-b4ac12540986" /> | <img width="900" height="470" alt="dev-cep AFTER" src="https://github.com/user-attachments/assets/ad851253-ab7a-464a-8a28-b8983740092a" /> |
