### PR TITLE
fix: should not patch blog if no blog

### DIFF
--- a/taccsite_cms/djangocms_blog/patch.py
+++ b/taccsite_cms/djangocms_blog/patch.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(f"portal.{__name__}")
 def patchDjangoCMSBlog():
         from django.apps import apps
         if not apps.is_installed('djangocms_blog'):
-            logger.debug('djangocms_blog not installed, skipping patches')
+            logger.debug('Skipping patch of djangocms_blog because it is not installed')
             return
 
         from djangocms_blog.models import BasePostPlugin, FeaturedPostsPlugin


### PR DESCRIPTION
## Overview

Do not patch the blog if no blog is installed.

## Related

- on non-blog site, allows test of #1051

## Changes

- **adds** check for blog before patching

## Testing

1. Deploy on website with no blog.
2. See log that patch is skipped.
3. Verify [deploy succeeds](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/3669/console).

## UI

<img width="900" height="470" alt="Screenshot 2026-01-06 at 17 54 58" src="https://github.com/user-attachments/assets/7795c3c8-f97c-4c8a-9034-463adf73828f" />