### PR TITLE
Reduce diff of #1051

### DIFF
--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -4,7 +4,7 @@
 
 {# Bootstrap #}
 {# SEE: https://getbootstrap.com/docs/4.6/getting-started/introduction/#starter-template #}
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
 
 {# TACC/Core-CMS #}


### PR DESCRIPTION
## Overview / Related

Simplifies #1051.

> [!NOTE]
> The CDN suggested in #1051 is jQuery's `code.jquery.com` (powered by Fastly). Better to use it? Dunno. Feedback welcome. I'm just a sucker for consistency (JSDelivr).

## Changes

- use same CDN as other assets
  _if down, find/replace fix (maybe with some regex)_
- minimize diff
  _same integrity sha works for any CDN_

## Testing

0. [Build.](https://jenkins.portals.tacc.utexas.edu/job/Core_CMS_Build/423/parameters/)
1. [Deploy.](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/3674/changes)
2. Test like #151.

## UI

<img width="900" height="470" alt="Screenshot 2026-01-06 at 18 12 05" src="https://github.com/user-attachments/assets/599cbdd5-8c76-4f8d-805d-d610d5324edd" />
