### PR TITLE
feat: (minimally) style news layout choice form

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/tacc/layout-choice-form.html
+++ b/taccsite_cms/templates/djangocms_blog/tacc/layout-choice-form.html
@@ -3,7 +3,7 @@
 {# To support user changing layout of news list #}
 {# FAQ: The form is hidden, because styles are not complete #}
 {# FAQ: The script is active, so new styles can be tested on a server #}
-<form id="layout-choice-form" class="s-form">
+<form id="layout-choice-form" class="s-form" hidden>
   <div>
     <menu id="layout-choice">
       <li>


### PR DESCRIPTION
## Overview

Minimally style the news layout options form.

## Related

- helps when testing #1050

## Changes

- **changed** markup

## Testing

0. Open a News feed page.
1. Remove `hidden` attribute from form.
2. Click form options.
3. Verify news layout changes (on wide screen).

## UI

| before | after |
| - | - |
| <img width="310" height="430" alt="news layout form BEFORE" src="https://github.com/user-attachments/assets/7bbfd924-6754-40ac-92c5-440e6fe158fb" /> | <img width="310" height="430" alt="news layout form AFTER" src="https://github.com/user-attachments/assets/dea7ce3a-e350-436f-aba2-faa74798c00d" /> |