### PR TITLE
fix: do not extend nor patch blog if not installed

### DIFF
--- a/taccsite_cms/djangocms_blog/extend.py
+++ b/taccsite_cms/djangocms_blog/extend.py
@@ -1,4 +1,14 @@
+import logging
+
+logger = logging.getLogger(f"portal.{__name__}")
+
+from .utils import is_app_installed
+
 def extendBlogFeaturedPostsPlugin():
+    if not is_app_installed():
+        logger.debug('Not extending djangocms_blog, because it is not installed')
+        return
+
     from django import forms
     from django.utils.html import format_html
     from django.utils.translation import gettext_lazy as _
@@ -43,6 +53,10 @@ def extendBlogFeaturedPostsPlugin():
     plugin_pool.register_plugin(BlogFeaturedPostsPlugin)
 
 def extendBlogFeaturedPostsPluginCached():
+    if not is_app_installed():
+        logger.debug('Not extending djangocms_blog, because it is not installed')
+        return
+
     from django import forms
     from cms.plugin_pool import plugin_pool
     from djangocms_blog.cms_plugins import BlogFeaturedPostsPluginCached as OriginalBlogFeaturedPostsPluginCached

--- a/taccsite_cms/djangocms_blog/patch.py
+++ b/taccsite_cms/djangocms_blog/patch.py
@@ -2,12 +2,13 @@ import logging
 
 logger = logging.getLogger(f"portal.{__name__}")
 
+from .utils import is_app_installed
+
 # To monkey-patch nephila/djangocms-blog until v2.0.6+
 # TODO: After upgrading to v2.0.6+, delete this file and its imports
 def patchBlog():
-        from django.apps import apps
-        if not apps.is_installed('djangocms_blog'):
-            logger.debug('Skipping patch of djangocms_blog because it is not installed')
+        if not is_app_installed():
+            logger.debug('Not patching djangocms_blog, because it is not installed')
             return
 
         from djangocms_blog.models import BasePostPlugin, FeaturedPostsPlugin

--- a/taccsite_cms/djangocms_blog/utils.py
+++ b/taccsite_cms/djangocms_blog/utils.py
@@ -1,0 +1,4 @@
+def is_app_installed():
+    """Whether djangocms_blog is installed"""
+    from django.apps import apps
+    return apps.is_installed('djangocms_blog')


### PR DESCRIPTION
## Overview

Fixes error building instance that has no blog.

## Related

- fixes [v4.35.20](https://github.com/TACC/Core-CMS/releases/tag/v4.35.20)
- fixes bug introduced by #1057
- similar to #1052

## Changes

- **added** logging to check if `djangocms_blog` is installed before extending or patching.
- **refactored** installation check to use `is_app_installed()` utility function for consistency.

## Testing

1. Deploy on website with no blog.
2. See log that patch is skipped.
3. Verify [deploy succeeds](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/3680/console).

## UI

<img width="900" height="470" alt="Screenshot 2026-01-09 at 15 21 51" src="https://github.com/user-attachments/assets/786fcd09-a662-4fa9-8980-2f5a0c06063e" />