### PR TITLE
fix: traditional email links being updated

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/updateEmailLinkHrefs.js
+++ b/taccsite_cms/static/site_cms/js/modules/updateEmailLinkHrefs.js
@@ -10,7 +10,7 @@
   attributes = ATTRIBUTE_NAMES
 ) {
   const attrs = Object.assign(attributes, ATTRIBUTE_NAMES);
-  const selector = 'a[href*="' + fakeText + '"]';
+  const selector = 'a[href*="' + fakeText + '"]:not[href*="subject"]';
 
   scopeElement.querySelectorAll(selector).forEach(linkEl => {
     _addData(linkEl, fakeText, attrs);


### PR DESCRIPTION
## Overview

No need to update a traditional e-mail link.

- Traditional email links set subject using `?subject` in `href` attribute.
- Custom email links set subject using `data-subject` attribute.

## Related

- fixes https://github.com/TACC/Core-CMS-Custom/issues/524
- fixed by #1068
- alt. solution to https://github.com/TACC/Core-Styles/pull/580
- noticed bug on [ecepalliance.org/alliance-members](https://ecepalliance.org/alliance-members/)

## Changes

- **added** selector specificity

## Testing & UI

### Problem

https://github.com/user-attachments/assets/0c98c7d3-0098-430c-91c6-d445ece08737

### Solution

https://github.com/user-attachments/assets/8eaf0e5b-212d-4692-8d7a-82a2f455698d

> [!CAUTION]
> Syntax error. Fixed in #1068.