### PR TITLE
fix: "Invalid srcset 'w' descriptor"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -969,8 +969,8 @@ djangocms-picture = ">=3.0,<5.0"
 [package.source]
 type = "git"
 url = "https://github.com/TACC/Core-CMS-Plugin-Image-Gallery.git"
-reference = "fix/GH-2-update-djangocms-picture"
-resolved_reference = "8b64b3327995ceebe1cf39868292640ecdab5676"
+reference = "v0.1.5"
+resolved_reference = "7a8366ce9b1de7baf0a07cff7731343069e14520"
 
 [[package]]
 name = "djangocms-tacc-remote-content"
@@ -2501,4 +2501,4 @@ testing = ["func-timeout", "jaraco.itertools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "b4cf34a33cfa6f9e409d997fc0759e38dac9f374eb35b7acc8799cb3bf8b2a67"
+content-hash = "4a0fb3c77fcb186decbd5a3f77263ac8b92bde977bfd38182c83aa2fecafcecf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ djangocms-page-meta = "1.3.0"
 djangocms-picture = "^4.1.1"
 djangocms-snippet = "3.0.0"
 djangocms-style = "3.0.0"
-djangocms-tacc-image-gallery = {git = "https://github.com/TACC/Core-CMS-Plugin-Image-Gallery.git", rev = "fix/GH-2-update-djangocms-picture"}
+djangocms-tacc-image-gallery = {git = "https://github.com/TACC/Core-CMS-Plugin-Image-Gallery.git", rev = "v0.1.5"}
 djangocms-tacc-remote-content = {git = "https://github.com/TACC/Core-CMS-Plugin-Remote-Content.git", rev = "v0.4.0"}
 djangocms-tacc-system-monitor = {git = "https://github.com/TACC/Core-CMS-Plugin-System-Monitor.git", rev = "v0.3.0"}
 djangocms-text-ckeditor = "^5.1"


### PR DESCRIPTION
## Overview

Dependency bump:
- `djangocms-tacc-image-gallery`
- `djangocms-picture`

## Related

- fixes #1067
- requires https://github.com/TACC/Core-CMS-Plugin-Image-Gallery/issues/2
- belated cleanup in 7d367930 and 8d325ac0

## Changes

0. In `pyproject.toml`, edit version of `djangocms-tacc-image-gallery`.
1. `poetry update djangocms-tacc-image-gallery`
2. `poetry add djangocms-picture@latest`

## Testing

0. Upload big image on page with responsive default) template.
1. See `.0w` in image `srcset` attribute value.
2. Perform temporary edits from [`TESTING.md` "Local Poetry Dependencies in Docker"](https://github.com/TACC/Core-CMS/blob/v4.35.22/TESTING.md#local-poetry-dependencies-in-docker).
3. `git stash`
4. `make stop && docker-compose -f docker-compose.dev.yml build cms && git stash pop && make start ARGS=--detach`
5. Refresh page with big image.
6. See **no** `.0w` in image `srcset` attribute value.

## UI

| before | after |
| - | - |
| <img width="900" height="470" alt="before" src="https://github.com/user-attachments/assets/5dc4eb64-1016-47a9-abe8-f7202504b460" /> | <img width="900" height="470" alt="after" src="https://github.com/user-attachments/assets/0a51a089-fa86-48c5-a77d-df7319bad978" /> |