### PR TITLE
fix: video not loading on LCCF via remote-content plugin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -991,8 +991,8 @@ requests = ">=2.25.1"
 [package.source]
 type = "git"
 url = "https://github.com/TACC/Core-CMS-Plugin-Remote-Content.git"
-reference = "fix/5-relative-url-patterns"
-resolved_reference = "501f8c99ec336ca5a6e7a89e2b65c2277ab0d78b"
+reference = "v0.5.0"
+resolved_reference = "388a066253bf06b98857c006a345f6be8ca16628"
 
 [[package]]
 name = "djangocms-tacc-system-monitor"
@@ -2501,4 +2501,4 @@ testing = ["func-timeout", "jaraco.itertools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "761252e749b85cc9083409f39795a443066bb24e9a755e05ad413bc67c7a3d77"
+content-hash = "e04540887939847ea908781d2cab2fda6dcafa13cd09e4fff6d52cc36fe9214e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ djangocms-picture = "^4.1.1"
 djangocms-snippet = "3.0.0"
 djangocms-style = "3.0.0"
 djangocms-tacc-image-gallery = {git = "https://github.com/TACC/Core-CMS-Plugin-Image-Gallery.git", rev = "v0.1.5"}
-djangocms-tacc-remote-content = {git = "https://github.com/TACC/Core-CMS-Plugin-Remote-Content.git", rev = "fix/5-relative-url-patterns"}
+djangocms-tacc-remote-content = {git = "https://github.com/TACC/Core-CMS-Plugin-Remote-Content.git", rev = "v0.5.0"}
 djangocms-tacc-system-monitor = {git = "https://github.com/TACC/Core-CMS-Plugin-System-Monitor.git", rev = "v0.3.0"}
 djangocms-text-ckeditor = "^5.1"
 djangocms-transfer = "1.0.1"


### PR DESCRIPTION
## Overview

On LCCF, fix `//youtube.com` not being parsed correctly, thus failing to load video via markup from TACC.

## Related

- requires https://github.com/TACC/Core-CMS-Plugin-Remote-Content/pull/6

## Changes

- **updates** dependency

## Testing

1. Build & Deploy on LCCF (Pre-Prod).
2. Open https://pprd.lccf.tacc.utexas.edu/internship-via-tacc/.
3. Verify video loads.

## UI

| before | after |
| - | - |
| <img width="900" height="470" alt="before" src="https://github.com/user-attachments/assets/b52924cb-168a-4fdf-a10c-b79e5b243585" /> | <img width="900" height="470" alt="after" src="https://github.com/user-attachments/assets/148c9d84-35c8-4c12-a0d9-bcf59490f747" /> |