### PR TITLE
fix: casing of tags should be "as is"

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -33,7 +33,9 @@
         {% elif tagged_entries %}
           <strong>{% page_attribute "page_title" %}</strong>
           <span>{% trans "Tag" %}</span>
-          <em>{{ tagged_entries|capfirst }}</em>
+          {# TACC (use tag as is): #}
+          <em>{{ tagged_entries }}</em>
+          {# /TACC #}
         {% elif category %}
           <strong>{% page_attribute "page_title" %}</strong>
           <span>{% trans "Category" %}</span>


### PR DESCRIPTION
## Overview

Do not change casing of News tags.

## Testing

> [!CAUTION]
> Skipped.

## UI

> [!NOTE]
> **Illustration of Problem (That this Fixes)**:
> Should be `lccf`[^1] in HTML, not `Lccf`.

[^1]: Or should be `LCCF` in HTML, after rename in early 2026.

<img width="899" height="470" alt="wrong casing" src="https://github.com/user-attachments/assets/64bc8000-1c55-4980-b346-e00a244f5525" />