### PR TITLE
fix: GH-1072 Safari / `http://` localhost access

### DIFF
--- a/taccsite_cms/settings_default.example.py
+++ b/taccsite_cms/settings_default.example.py
@@ -3,3 +3,6 @@ A `settings_default.py` file can override default values in `settings.py` before
 
 This allows Core-CMS client software to standardize their custom settings while still supporting `settings_custom.py` e.g. https://github.com/TACC/Core-Portal/pull/1034.
 '''
+
+# To allow http:// access (e.g. in Safari)
+# SESSION_COOKIE_SECURE = False


### PR DESCRIPTION
## Overview

Suggests fix for clients unable to access http:// (.e.g when using Safari browser).

## Related

- fixes #1072
- fixes https://github.com/TACC/Core-CMS-Template/issues/20

## Changes

- **adds** _commented_ default settings

## Testing & UI

1. https://github.com/TACC/Core-CMS-Template/pull/22

## Notes

> [!note]
> Consider moving some `settings_local.py` commented settings into `settings_default.py`.