### PR TITLE
fix(bin): setup-cms use `main`, handle download errors

### DIFF
--- a/bin/setup-cms.sh
+++ b/bin/setup-cms.sh
@@ -14,7 +14,7 @@ IMP='\033[1m'    # important
 # Define paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${SCRIPT_DIR}/../"
-SRC_ROOT="${SCRIPT_DIR}/../"
+SRC_ROOT="${SCRIPT_DIR}/.."
 
 # Configure fallback for settings
 VERSION="main"


### PR DESCRIPTION
## Overview

Update `setup-cms.sh` to use `main` branch (because of [rename](https://github.com/TACC/Core-CMS/wiki/v4.37-Branch-Rename)).

## Related

- https://github.com/TACC/Core-CMS-Template/issues/17

## Changes

- **renamed** `stable` to `main`
- **added** error handling for file downloads

## Testing

### Download Errors

1. Change `main` to `whatever`.
2. Delete all `settings/` files **except** `settings.py` and `__init__.py`.
3. `make setup`
4. See errors and instructions.
5. Follow instructions.
6. `make setup`
7. Follow steps.
8. Open site.
9. No errors.

### Regression

1. `make clean`
2. `make setup`
3. Follow steps.
4. Open site.
5. No errors.

### Blog Install

I also tested no blog install, and delayed blog install, by not having `custom_app_settings.py` nor `urls.py`, then adding them, then running Django migrations.

## UI

Skipped.