### PR TITLE
fix: hide overlay link underline for media grid area

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
@@ -283,6 +283,12 @@
 
   /* To hide link text */
   font-size: 0;
+
+  /* To hide underline (still shows up even if `font-size: 0`) */
+  & a,
+  &:is(a) {
+    text-decoration: none;
+  }
 }
 
 


### PR DESCRIPTION
## Overview

Add styles to hide [possible] underline from overlay link in media grid area.

> [!important]
> **Actual** fix was https://github.com/TACC/Core-CMS-Custom/commit/852b4c2, **not** this.

## Testing

I tested _in situ_ on ECEP.

## UI

Skipped.