### PR TITLE
refactor: no need `__REMOVE_THIS__` for data-subject

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/updateEmailLinkHrefs.js
+++ b/taccsite_cms/static/site_cms/js/modules/updateEmailLinkHrefs.js
@@ -10,7 +10,8 @@
   attributes = ATTRIBUTE_NAMES
 ) {
   const attrs = Object.assign(attributes, ATTRIBUTE_NAMES);
-  const selector = 'a[href*="' + fakeText + '"]:not([href*="subject"])';
+  const attrSelectors = Object.values(attrs).map((name) => 'a[' + name + ']');
+  const selector = attrSelectors.join(', ');
 
   scopeElement.querySelectorAll(selector).forEach(linkEl => {
     _addData(linkEl, fakeText, attrs);
@@ -120,6 +121,9 @@ function _editHref(element, fakeText, attributes) {
 
   const email = _getEmail({href: element.href, fakeText});
   const query = _createQuery({body, subject});
+  const href = 'mailto:' + email + query;
+
+  if (SHOULD_DEBUG) console.info({href});
 
   // So link opens mail program with correct address
   element.href = 'mailto:' + email + query;


### PR DESCRIPTION
## Overview

Do not require `__REMOVE_THIS__` before e-mail address to enable `[data-subject]` to become `?subject="…"`.

## Changes

- **changes** CSS selector in JavaScript

## Testing

1. Open https://ecepalliance.org/alliance-members/alabama.
2. Click the "Contact Alabama" link.
3. Choose a Mail program (if not configured).
    <sup>Chrome has UX bug on macOS where it might just open new tab if mailto app is not configured.</sup>
4. Check e-mail Subject and Body are populated.
    <sup>Or check markup to verify `?subject=` and `&body=` are integrated into `[href="…"]`.</sup>

## UI

> [!tip]
> **Works** (see below), **but** (see further below)…
> | before | after  |
> | - | - |
> | <img width="899" height="470" alt="before" src="https://github.com/user-attachments/assets/a42c9305-578f-4a92-bfde-5b05642c0932" /> | <img width="899" height="470" alt="after" src="https://github.com/user-attachments/assets/7aeedb1a-e69c-4ec9-b632-050426c0fa13" /> |