### PR TITLE
refactor!: video_player; delete content, add title

### DIFF
--- a/taccsite_cms/templates/djangocms_video/default/video_player.html
+++ b/taccsite_cms/templates/djangocms_video/default/video_player.html
@@ -1,13 +1,22 @@
 {# https://github.com/django-cms/djangocms-video/blob/3.0.0/djangocms_video/templates/djangocms_video/default/video_player.html #}
 {% load i18n cms_tags %}
 
-{# TACC: #}
-{% block content_video %}
-{# /TACC #}
+{# TACC: optional responsive wrapper when template is not default/default-tacc; ratio from folder name #}
+{% if instance.template != 'default' %}
+{% with embed_ratio=instance.template|slice:'10:' %}
+<div class="embed-responsive{% if embed_ratio != 'auto' %} embed-responsive-{{ embed_ratio }}{% endif %}">
+{% endwith %}
+{% endif %}
 
 {% if instance.embed_link %}
     {# show iframe if embed_link is provided #}
-    <iframe src="{{ instance.embed_link_with_parameters }}" {{ instance.attributes_str }} frameborder="0" allowfullscreen="true"></iframe>
+    <iframe src="{{ instance.embed_link_with_parameters }}" {{ instance.attributes_str }} frameborder="0" allowfullscreen="true"
+      {# TACC: default title if none provided #}
+      {% if "title" not in instance.attributes_str %}
+      title="{% block video_iframe_title %}media related to this content{% endblock video_iframe_title %}"
+      {% endif %}
+      {# /TACC #}
+    ></iframe>
     {% with disabled=instance.embed_link %}
         {% for plugin in instance.child_plugin_instances %}
             {% render_plugin plugin %}
@@ -24,6 +33,10 @@
     </video>
 {% endif %}
 
+{% if instance.template != 'default' and instance.template != 'default-tacc' %}
+</div>
+{% endif %}
+
 {% comment %}
     # Available variables:
     {{ instance.template }}
@@ -32,7 +45,3 @@
     {{ instance.poster }}
     {{ instance.attributes_str }}
 {% endcomment %}
-
-{# TACC: #}
-{% endblock content_video %}
-{# /TACC #}

--- a/taccsite_cms/templates/djangocms_video/responsive-16by9/video_player.html
+++ b/taccsite_cms/templates/djangocms_video/responsive-16by9/video_player.html
@@ -1,7 +1,1 @@
 {% extends "djangocms_video/default/video_player.html" %}
-
-{% block content_video %}
-<div class="embed-responsive embed-responsive-16by9">
-  {{ block.super }}
-</div>
-{% endblock content_video %}

--- a/taccsite_cms/templates/djangocms_video/responsive-1by1/video_player.html
+++ b/taccsite_cms/templates/djangocms_video/responsive-1by1/video_player.html
@@ -1,7 +1,1 @@
 {% extends "djangocms_video/default/video_player.html" %}
-
-{% block content_video %}
-<div class="embed-responsive embed-responsive-1by1">
-  {{ block.super }}
-</div>
-{% endblock content_video %}

--- a/taccsite_cms/templates/djangocms_video/responsive-21by9/video_player.html
+++ b/taccsite_cms/templates/djangocms_video/responsive-21by9/video_player.html
@@ -1,7 +1,1 @@
 {% extends "djangocms_video/default/video_player.html" %}
-
-{% block content_video %}
-<div class="embed-responsive embed-responsive-21by9">
-  {{ block.super }}
-</div>
-{% endblock content_video %}

--- a/taccsite_cms/templates/djangocms_video/responsive-4by3/video_player.html
+++ b/taccsite_cms/templates/djangocms_video/responsive-4by3/video_player.html
@@ -1,7 +1,1 @@
 {% extends "djangocms_video/default/video_player.html" %}
-
-{% block content_video %}
-<div class="embed-responsive embed-responsive-4by3">
-  {{ block.super }}
-</div>
-{% endblock content_video %}

--- a/taccsite_cms/templates/djangocms_video/responsive-auto/video_player.html
+++ b/taccsite_cms/templates/djangocms_video/responsive-auto/video_player.html
@@ -1,7 +1,1 @@
 {% extends "djangocms_video/default/video_player.html" %}
-
-{% block content_video %}
-<div class="embed-responsive">
-  {{ block.super }}
-</div>
-{% endblock content_video %}


### PR DESCRIPTION
## Overview

> [!warning]
> Not backward-compatible, but not a problem.[^1]

[^1]: Because I know no client is using `video_content`, because I maintain or oversee all current clients.


## Related

- expects #1091
- changed by #1093

## Changes

- **delete** `content_video` block
- **add** `video_player_title` block

## Testing

1. Verify Video plugin templates still add wrapper they had added.

## UI

Tested in #1091.