### PR TITLE
fix: media adv editor (add & delete folders)

### DIFF
--- a/taccsite_cms/management/commands/group_perms/media_editor_advanced.py
+++ b/taccsite_cms/management/commands/group_perms/media_editor_advanced.py
@@ -30,4 +30,5 @@ def set_group_perms():
     let_add_and_delete_adv_media_plugins(group)
     let_view_thumbnail_option(group)
     let_view_and_change_folder(group)
+    let_add_and_delete_folder(group),
     let_view_and_change_image_file(group)


### PR DESCRIPTION
## Overview

Ensure "Media Editor (Adv…)" group can add/delete folders.

_Without this, unless editor is in "Text Editor (Adv…)" group, they probably can not add/delete folders.[^1]_

[^1]: Why would "Text Editor (Adv…)" group be able to add/delete folders? So they can manage where they add files, if they want to link to files within the textual content they edit.