### PR TITLE
fix: untested #1101 / make bootstrap4_link perm work

### DIFF
--- a/taccsite_cms/management/commands/util.py
+++ b/taccsite_cms/management/commands/util.py
@@ -97,8 +97,8 @@ def let_view_and_change_text(group):
     """
     add_perm(group, 'djangocms_link', 'link', 'Can change link')
     add_perm(group, 'djangocms_link', 'link', 'Can view link')
-    add_perm(group, 'bootstrap4_link', 'link', 'Can change bootstrap4 link')
-    add_perm(group, 'bootstrap4_link', 'link', 'Can view bootstrap4 link')
+    add_perm(group, 'bootstrap4_link', 'bootstrap4 link', 'Can change bootstrap4 link')
+    add_perm(group, 'bootstrap4_link', 'bootstrap4 link', 'Can view bootstrap4 link')
 
     add_perm(group, 'djangocms_text_ckeditor', 'text', 'Can change text')
     add_perm(group, 'djangocms_text_ckeditor', 'text', 'Can view text')
@@ -109,8 +109,8 @@ def let_add_and_delete_text(group):
     """
     add_perm(group, 'djangocms_link', 'link', 'Can add link')
     add_perm(group, 'djangocms_link', 'link', 'Can delete link')
-    add_perm(group, 'bootstrap4_link', 'link', 'Can add bootstrap4 link')
-    add_perm(group, 'bootstrap4_link', 'link', 'Can delete bootstrap4 link')
+    add_perm(group, 'bootstrap4_link', 'bootstrap4 link', 'Can add bootstrap4 link')
+    add_perm(group, 'bootstrap4_link', 'bootstrap4 link', 'Can delete bootstrap4 link')
 
     add_perm(group, 'djangocms_text_ckeditor', 'text', 'Can add text')
     add_perm(group, 'djangocms_text_ckeditor', 'text', 'Can delete text')


### PR DESCRIPTION
## Overview

Make Bootstrap 4 "Link / Button" permission work

<details><summary>Error Being Fixed</summary>

```
17:56:26     add_perm(group, 'bootstrap4_link', 'link', 'Can change link')
17:56:26   File "/code/taccsite_cms/management/commands/util.py", line 20, in add_perm
17:56:26     content_type = ContentType.objects.get(
17:56:26                    ^^^^^^^^^^^^^^^^^^^^^^^^
17:56:26   File "/usr/local/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
17:56:26     return getattr(self.get_queryset(), name)(*args, **kwargs)
17:56:26            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:56:26   File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 637, in get
17:56:26     raise self.model.DoesNotExist(
17:56:26 django.contrib.contenttypes.models.ContentType.DoesNotExist: ContentType matching query does not exist.
```

</details>

> [!tip]
> Successful test on [WTCS (pre-prod)](https://pprd.wtcs.tacc.utexas.edu/admin/auth/group/5/change/).

## Related

- fixes #1101
