### PR TITLE
deps: djangocms-tacc-system-monitor v0.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1011,8 +1011,8 @@ django-cms = ">=3.7.4"
 [package.source]
 type = "git"
 url = "https://github.com/TACC/Core-CMS-Plugin-System-Monitor.git"
-reference = "refactor/4-use-python-not-javascript"
-resolved_reference = "abb813124a86e21fd31762364eb8637df6a2800c"
+reference = "v0.4.0"
+resolved_reference = "68b8753f1c04b6c7eea3d76c31a4cded2e471d95"
 
 [[package]]
 name = "djangocms-text-ckeditor"
@@ -2501,4 +2501,4 @@ testing = ["func-timeout", "jaraco.itertools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "4b6770c0c8551a832d661a00f28d8d370139e159a7e472a29467e90bea315570"
+content-hash = "dd5a49ee6ede6af40578aac34151e0c0a645448ccd4eec9b0ee04c042c4f0bbf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ djangocms-snippet = "3.0.0"
 djangocms-style = "3.0.0"
 djangocms-tacc-image-gallery = {git = "https://github.com/TACC/Core-CMS-Plugin-Image-Gallery.git", rev = "v0.1.5"}
 djangocms-tacc-remote-content = {git = "https://github.com/TACC/Core-CMS-Plugin-Remote-Content.git", rev = "v0.5.0"}
-djangocms-tacc-system-monitor = {git = "https://github.com/TACC/Core-CMS-Plugin-System-Monitor.git", branch = "refactor/4-use-python-not-javascript"}
+djangocms-tacc-system-monitor = {git = "https://github.com/TACC/Core-CMS-Plugin-System-Monitor.git", rev = "v0.4.0"}
 djangocms-text-ckeditor = "^5.1"
 djangocms-transfer = "1.0.1"
 djangocms-video = "3.0.0"


### PR DESCRIPTION
## Overview

Update [`djangocms-tacc-system-monitor`](https://github.com/TACC/Core-CMS-Plugin-System-Monitor).

## Related

- tests https://github.com/TACC/Core-CMS-Plugin-System-Monitor/pull/9

## Changes

- **updated** Poetry deps

## Testing

### Old Env

1. ✓ Find **existing** "System Monitor" plugin instance onto page.

### New Env

1. ✓ Add "System Monitor" plugin instance onto page of **new** env.

## UI

<img width="900" height="475" alt="Screenshot 2026-03-06 at 15 07 03" src="https://github.com/user-attachments/assets/8e96c317-045d-4098-ab3d-265af3f2e1fb" />

(no change)