### PR TITLE
fix: deleted assets_core_project is used by TUP

### DIFF
--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -41,7 +41,9 @@
   {% include 'assets_site.html' %}
 {% elif settings.TACC_CORE_STYLES_VERSION >= 1 %}
   {% include 'assets_core.html' %}
+  {% block assets_project %}
   {% include 'assets_core_cms.html' %}
+  {% endblock assets_project %}
 {% endif %}
   {% endblock assets %}
 


### PR DESCRIPTION
## Overview

Restore `assets_core_project` as `assets_project`.

(Because [TACC/tup-ui] needs such a block.)

[TACC/tup-ui]: https://github.com/TACC/tup-ui/

## Related

- deleted in #490

## Changes

- **adds** `assets_project` template block

## Testing

Tested locally with [TACC/tup-ui] during https://github.com/TACC/tup-ui/pull/537 and manual live edits to Core-CMS template.

## UI

Skipped.

## Notes

Not having such a block caused login form to **not** have `s-form-page` because `core-styles.portal.css` was not loaded, because it relied on such a block.