### PR TITLE
Quick: enable httponly csrftoken

### DIFF
--- a/taccsite_cms/settings/settings.py
+++ b/taccsite_cms/settings/settings.py
@@ -51,6 +51,7 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
 # whether the session and csrf cookies should be secure (https:// only)
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_HTTPONLY = True
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 


### PR DESCRIPTION
## Overview

Set `CSRF_COOKIE_HTTPONLY = True` to satisfy security scans

## Testing

1. Ensure regular activity works, esp put/posts for forms, etc.
