### PR TITLE
Quick: specify unique csrftoken name for cms

### DIFF
--- a/taccsite_cms/settings/settings.py
+++ b/taccsite_cms/settings/settings.py
@@ -51,6 +51,7 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
 # whether the session and csrf cookies should be secure (https:// only)
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_NAME = 'cmscsrftoken'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 


### PR DESCRIPTION
## Overview

CMS and Portal containers were using identical csrftoken cookie names, causing weird issues. This changes the name of the cms cookie, which is the simplest change to make them distinct.

## Testing

1. Confirm csrftoken is now named "cmscsrftoken" in browser
