### PR TITLE
fix: second breadcrumb link always disabled

### DIFF
--- a/taccsite_cms/templates/nav_cms_breadcrumbs.html
+++ b/taccsite_cms/templates/nav_cms_breadcrumbs.html
@@ -37,7 +37,7 @@
     const href = secondLink.getAttribute('href');
     {# FAQ: Nav item with `href` (no `dropdown-toggle`) is to navigable page #}
     {# FAQ: Nav item sans `href` (e.g. `button`, `href=""`) is dropdown-only #}
-    const isDirectNavLink = href && cmsNav.querySelector(
+    const isDirectNavLink = href && cmsNav && cmsNav.querySelector(
       'a.nav-link:not(.dropdown-toggle)[href="' + href + '"]'
     );
     if (!isDirectNavLink) secondLink.removeAttribute('href');


### PR DESCRIPTION
## Overview

Do **not** force-disable second breadcrumb link. **Only** disable **if** there are children shown in menu.

## Related

- fixes https://github.com/TACC/Core-CMS/issues/1118
- supplants https://github.com/wesleyboar/Core-CMS/pull/5

## Changes

- **adds** condition around `.removeAttribute('href')`

## Testing

1. Create two sets of nested pages.
2. Make one set's children **not** show in menu.
3. Verify that if children are in menu, parent link is disabled in breadcrumb.
3. Verify that if children are **not** in menu, parent link is **not** disabled in breadcrumb.

## UI

https://github.com/user-attachments/assets/8a6bea76-8dcb-4719-9273-d29c56149cd5