### PR TITLE
feat: max size for logos, no tiny branding

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/logos.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/logos.css
@@ -5,6 +5,7 @@
 }
 [class*="logos--"] a svg {
   display: block;
+  max-block-size: 500px; /* to avoid unexpectedly giant logos*/
 }
 
 

--- a/taccsite_cms/templates/snippets/logos-branding.html
+++ b/taccsite_cms/templates/snippets/logos-branding.html
@@ -1,18 +1,18 @@
 <p class="logos--branding">
     <a href="https://www.tacc.utexas.edu/" class="logos__tacc">
-        <svg width="1em" height="1em" role="img">
+        <svg role="img">
             <title>Texas Advanced Computing Center</title>
             <use href="/static/site_cms/img/org_logos/tacc-formal.svg?2025-11#tacc-formal" />
         </svg>
     </a>
     <a href="https://www.nsf.gov/" target="_blank" class="logos__nsf">
-        <svg width="1em" height="1em" role="img">
+        <svg role="img">
             <title>Bluesky</title>
             <use href="/static/site_cms/img/org_logos/nsf-logo.svg?2025-11#nsf-logo" />
         </svg>
     </a>
     <a href="https://www.utexas.edu/" target="_blank" class="logos__ut">
-        <svg width="1em" height="1em" role="img">
+        <svg role="img">
             <title>University of Texas at Austin</title>
             <use href="/static/site_cms/img/org_logos/ut-primary.svg?2025-11#ut-primary" />
         </svg>


### PR DESCRIPTION
## Overview

Greater default size for branding logos (from snippet).

## Related

- supports https://github.com/TACC/tup-ui/pull/535
- supports https://github.com/TACC/tup-ui/pull/537

## Changes

- **added** bix width and height constraints into SVG CSS
- **deleted** tiny width and height constraints from SVG HTML

## Testing

Dimensions of branding logos (from snippet) are constrained by their parent container or their max block size (500px).

## UI

| before | after | test max size |
| - | - | - |
| <img width="900" height="470" alt="before" src="https://github.com/user-attachments/assets/a4007928-612e-468c-af2f-7bf1f2b7c628" /> | <img width="900" height="470" alt="after" src="https://github.com/user-attachments/assets/5a9400e7-5e43-4fc3-a6f2-8055d3dcbba2" /> | <img width="900" height="470" alt="test max size" src="https://github.com/user-attachments/assets/22394a28-c220-4d77-a1c8-621b4f46c1db" /> |