### PR TITLE
fix: news read-more link can't click

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
@@ -279,6 +279,7 @@
 /* To make media clickable via a "read more" link */
 @define-mixin news-feed-article__link-overlay {
   /* To cover the image exactly */
+  display: grid;
   grid-area: media;
 
   /* To hide link text */


### PR DESCRIPTION
## Overview

Allow clicking an article's "read more" link (positioned over the article thumbnail).

## Related

- bug found during testing of #1089

## Changes

- **adds** missing style

## Testing & UI

https://github.com/user-attachments/assets/3460dbb3-3e69-4133-afae-c231b6edcf5e
