### PR TITLE
refactor: figure & blockquote, @mixin not @extend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.54.0"
+        "@tacc/core-styles": "github:TACC/Core-Styles#ecad7fa"
       },
       "engines": {
         "node": ">=16",
@@ -1404,8 +1404,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.54.0.tgz",
-      "integrity": "sha512-jBpNKpuENqtHPXNv2MS6r5iwU4aFjDdsQvCknMB68UwZxyJx6+IisPNO/nh2/2p15J8jGqsqKBoNl9Iwc00l4A==",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#ecad7fada9ed56ee4728b5890bff14ce1c545225",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5593,10 +5592,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.54.0.tgz",
-      "integrity": "sha512-jBpNKpuENqtHPXNv2MS6r5iwU4aFjDdsQvCknMB68UwZxyJx6+IisPNO/nh2/2p15J8jGqsqKBoNl9Iwc00l4A==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#ecad7fada9ed56ee4728b5890bff14ce1c545225",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#ecad7fa",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.54.0"
+    "@tacc/core-styles": "github:TACC/Core-Styles#ecad7fa"
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/elements/figure-caption-blockquote.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/elements/figure-caption-blockquote.css
@@ -4,18 +4,18 @@
 /* To style elements that are or have captions */
 figure,
 .embed-responsive {
-  @extend .x-figure;
+  @mixin figure;
 }
 figcaption,
 p.caption {
-  @extend .x-figure-caption;
+  @mixin figure-caption;
 }
 
 blockquote {
-  @extend .x-blockquote;
+  @mixin blockquote;
 }
 blockquote footer {
-  @extend .x-blockquote-caption;
+  @mixin blockquote-caption;
 }
 
 /* To remove extra whitespace beneath embeded content */


### PR DESCRIPTION
## Overview

Use figure and blockquote styles form Core-Styles via `@mixin` not `@extend`.

> [!IMPORTANT]
> Install Core-Styles at version after releasing https://github.com/TACC/Core-Styles/pull/612

## Related

- requires https://github.com/TACC/Core-Styles/pull/612
- required by https://github.com/TACC/tup-ui/pull/537

## Changes

- **updates** Core-Styles
- **changes** `@extend .x-figure` to `@mixin figure`

## Testing

1. Build CSS for `main` and this branch such that you can compare diff:

    ```sh
    git checkout main
    git pull
    npm ci
    npm run build:css
    git add -f taccsite_cms/static/site_cms/css/build
    gco refactor/use-figure-and-blockquote-mixins-bot-extend
    git pull
    npm ci
    npm run build:css
    ```

2. Verify unstaged diff of `taccsite_cms/static/site_cms/css/build/figure-caption-blockquote.css` looks similar to diff of https://github.com/TACC/Core-Styles/pull/612's `dist/elements/html-elements.docs.css`.
3. Stage the diff of new build:

    ```sh
    git add -f taccsite_cms/static/site_cms/css/build
    ```

4. Copy diff of https://github.com/TACC/Core-Styles/pull/612's `dist/elements/html-elements.docs.css` into `taccsite_cms/static/site_cms/css/build/figure-caption-blockquote.css`.
5. Verify diff is just the new selectors in `taccsite_cms/static/site_cms/css/src/_imports/elements/figure-caption-blockquote.css` and the unique rule at the bottom of it.

## UI

**Skipped.**

I will do manual integration test via https://github.com/TACC/tup-ui/pull/537. This is belated housekeeping to allow me to properly fix illegible caption on https://tacc.utexas.edu/use-tacc/visualization-services/.