### PR TITLE
fix: a11y issues, round 2

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
@@ -267,7 +267,6 @@
   --lines: 4;
 
   line-height: 1.5;
-  color: var(--global-color-primary--dark);
 
   & p:last-child {
     margin-bottom: unset; /* overrides core-styles.cms */


### PR DESCRIPTION
## Overview

Fix more accessibility bugs.

## Related

- continues #1089
- referenced by https://github.com/TACC/tup-ui/pull/546

## Changes

- [fix: links [not distinguishable enough] on news article leads](https://github.com/TACC/Core-CMS/commit/67860148a8d4682ddab3b16b87cee6fee70a3508)
    Links in lead are usually only hidden external article links, but we technically can have visible links in article leads.

## Testing

Verify colors of link, unlinked text, and body, pass [color contrast test].

[color contrast test]: https://webaim.org/resources/linkcontrastchecker/?fcolor=222222&bcolor=FFFFFF&lcolor=3D6ACC

## UI

https://github.com/user-attachments/assets/1fece9fa-c565-437f-b02f-f741ac929fe3

| screenshot of[color contrast test] passing |
| - |
| <img width="560" height="349" alt="screenshot of color contrast test passing" src="https://github.com/user-attachments/assets/44d94254-7c61-4476-8eaa-8aba400d459a" /> |