### PR TITLE
fix: GH-999 CMS admin can change header logo

### DIFF
--- a/taccsite_cms/settings/settings.py
+++ b/taccsite_cms/settings/settings.py
@@ -563,8 +563,8 @@ CMS_LANGUAGES = {
 CMS_PERMISSION = True
 CMS_PLACEHOLDER_CONF = {
     'header-content': {
-        'plugins': ['PicturePlugin'],
-        # One plugin with template "Header logo" = logo; any other content = bottom of header
+        # One PicturePlugin with template "Header logo" = custom logo
+        # Any other plugins render inline within the header nav
         'limits': {'global': 10},
     },
 }

--- a/taccsite_cms/templates/djangocms_picture/header_logo/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/header_logo/picture.html
@@ -1,3 +1,3 @@
-{% load header_logo_tags %}
+{% load header_content_tags %}
 {% header_logo_from_picture instance picture_link as plugin_logo %}
 {% include "header_logo.html" with plugin_logo=plugin_logo %}

--- a/taccsite_cms/templates/header.html
+++ b/taccsite_cms/templates/header.html
@@ -1,5 +1,5 @@
 {# @var settings #}
-{% load cms_tags header_content_tags %}
+{% load cms_tags %}
 
 {# WARNING: Some markup is duplicated in other repositories #}
 {# SEE: https://confluence.tacc.utexas.edu/x/LoCnCQ #}
@@ -23,13 +23,9 @@
   {% endif %}
 ">
   <!-- Portal Logo -->
-  {% get_header_content_parsed "header-content" as header_content %}
-  {% if header_content.logo_plugin %}
-    {% header_logo_from_picture header_content.logo_plugin header_content.logo_link as plugin_logo %}
-    {% include "header_logo.html" with plugin_logo=plugin_logo %}
-  {% else %}
+  {% static_placeholder "header-content" or %}
     {% include "header_logo.html" %}
-  {% endif %}
+  {% endstatic_placeholder %}
 
   <!-- Navbar Accordian Toggle on Small Screens  -->
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExpandTarget" aria-controls="navbarsExpandTarget" aria-expanded="false" aria-label="Toggle navigation">
@@ -51,14 +47,6 @@
     {% endif %}
   </div>
 </nav>
-{% if header_content.remaining_plugins %}
-<div class="header-content-extra">
-  {% for plugin in header_content.remaining_plugins %}
-  {% render_plugin plugin %}
-  {% endfor %}
-</div>
-{% endif %}
-
 {% endwith %}
 {% endwith %}
 {% endwith %}

--- a/taccsite_cms/templatetags/header_content_tags.py
+++ b/taccsite_cms/templatetags/header_content_tags.py
@@ -20,10 +20,9 @@ def _get_header_content_parsed(request, placeholder_name):
     logo_link = None
     remaining_plugins = []
 
-    site = getattr(request, 'site', None)
     placeholder = StaticPlaceholder.objects.filter(
         code=placeholder_name,
-        site=site
+        site_id__isnull=True
     ).first()
 
     # Return NO content (if placeholder does not exist)

--- a/taccsite_cms/templatetags/header_content_tags.py
+++ b/taccsite_cms/templatetags/header_content_tags.py
@@ -41,7 +41,7 @@ def _get_header_content_parsed(request, placeholder_name):
     if len(plugin_list) == 1:
         first_plugin = plugin_list[0]
         instance, plugin_type = first_plugin.get_plugin_instance()
-        is_picture_plugin = getattr(plugin_type, '__name__', '') == 'PicturePlugin'
+        is_picture_plugin = type(plugin_type).__name__ == 'PicturePlugin'
         uses_logo_template = getattr(instance, 'template', None) == 'header_logo'
 
         if instance and is_picture_plugin:
@@ -111,9 +111,10 @@ def header_logo_from_picture(instance, picture_link):
     alt = attrs.get('alt') or default_alt_text or ''
     img_src = getattr(instance, 'img_src', None) or ''
     link_target = getattr(instance, 'link_target', None)
+    is_remote = img_src.startswith('http://') or img_src.startswith('https://')
 
     return {
-        'is_remote': False,
+        'is_remote': is_remote,
         'img_file_src': img_src,
         'img_class': '',
         'link_href': picture_link or '/',


### PR DESCRIPTION
Fix misc. bugs in https://github.com/TACC/Core-CMS/pull/1083/.

| default logo | custom logo |
| - | - |
| <img width="1280" height="400" alt="edit header - default image" src="https://github.com/user-attachments/assets/ef119dcc-e49a-460e-9853-06ef9a1521ee" /> | <img width="1280" height="400" alt="edit header - custom logo" src="https://github.com/user-attachments/assets/1759ecf7-458d-4ca2-bc26-1f3957973a54" /> |