### PR TITLE
fix: footer links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.55.1"
+        "@tacc/core-styles": "github:TACC/Core-Styles#1b8e32e"
       },
       "engines": {
         "node": ">=20",
@@ -1404,8 +1404,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.55.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.55.1.tgz",
-      "integrity": "sha512-5bwIyJ7iQlDSmczoJPixIFvf+F+vTKIQEa68Nn2Cr+zs5Pn+Jdv+GXU2sIsVVGQmBq7V6e9YvCvqh8saNzi3sw==",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#1b8e32e6307d398bcf83e931002711208979d39f",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5593,10 +5592,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.55.1",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.55.1.tgz",
-      "integrity": "sha512-5bwIyJ7iQlDSmczoJPixIFvf+F+vTKIQEa68Nn2Cr+zs5Pn+Jdv+GXU2sIsVVGQmBq7V6e9YvCvqh8saNzi3sw==",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#1b8e32e6307d398bcf83e931002711208979d39f",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#1b8e32e",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "github:TACC/Core-Styles#1b8e32e"
+        "@tacc/core-styles": "^2.56.0"
       },
       "engines": {
         "node": ">=20",
@@ -1403,8 +1403,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.55.1",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#1b8e32e6307d398bcf83e931002711208979d39f",
+      "version": "2.56.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.56.0.tgz",
+      "integrity": "sha512-j4TII9rhrt6fH5dpSKCRS8lbLt8Fuc3Iv+aaoLlU8m4FGcsWDE1ODLpqsiZSERbZMF5fLUbJAZhNwzGG59axnw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5592,9 +5593,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#1b8e32e6307d398bcf83e931002711208979d39f",
+      "version": "2.56.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.56.0.tgz",
+      "integrity": "sha512-j4TII9rhrt6fH5dpSKCRS8lbLt8Fuc3Iv+aaoLlU8m4FGcsWDE1ODLpqsiZSERbZMF5fLUbJAZhNwzGG59axnw==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#1b8e32e",
       "requires": {}
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.55.1"
+    "@tacc/core-styles": "github:TACC/Core-Styles#1b8e32e"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "github:TACC/Core-Styles#1b8e32e"
+    "@tacc/core-styles": "^2.56.0"
   }
 }

--- a/taccsite_cms/templates/footer.html
+++ b/taccsite_cms/templates/footer.html
@@ -2,6 +2,6 @@
 
 <footer class="c-footer  s-footer">
   {% static_placeholder "footer-content" or %}
-  <p>©{% now "Y" %} Texas Advanced Computing Center, The University of Texas at Austin, Office of the Vice President for Research.</p>
+  <p>©{% now "Y" %} <a href="https://tacc.utexas.edu/" target="_blank" aria-label="Opens in new window.">Texas Advanced Computing Center</a>, <a href="https://www.utexas.edu/" target="_blank" aria-label="Opens in new window.">The University of Texas at Austin</a>, <a href="https://research.utexas.edu/" target="_blank" aria-label="Opens in new window.">Office of the Vice President for Research</a></p>
   {% endstatic_placeholder %}
 </footer>

--- a/taccsite_cms/templates/footer.html
+++ b/taccsite_cms/templates/footer.html
@@ -2,6 +2,6 @@
 
 <footer class="c-footer  s-footer">
   {% static_placeholder "footer-content" or %}
-  <p>©{% now "Y" %} <a href="https://tacc.utexas.edu/" target="_blank" aria-label="Opens in new window.">Texas Advanced Computing Center</a>, <a href="https://www.utexas.edu/" target="_blank" aria-label="Opens in new window.">The University of Texas at Austin</a>, <a href="https://research.utexas.edu/" target="_blank" aria-label="Opens in new window.">Office of the Vice President for Research</a></p>
+  <p>©{% now "Y" %} <a href="https://tacc.utexas.edu/" target="_blank">Texas Advanced Computing Center</a>, <a href="https://www.utexas.edu/" target="_blank">The University of Texas at Austin</a>, <a href="https://research.utexas.edu/" target="_blank">Office of the Vice President for Research</a></p>
   {% endstatic_placeholder %}
 </footer>


### PR DESCRIPTION
## Overview

**Before:**
* no footer links by default
* added footer link style did not match design

**After:**
* footer links by default
* footer link style matches design
* footer links are accessible

## Related

- requires [TACC/Core-Styles@v2.56.0](https://github.com/TACC/Core-Styles/releases/tag/v2.56.0)

## Changes

- **added** default footer links
- **updated** Core-Styles

## Testing

1. `make setup`
2. Open http://localhost:8000/.
3. See footer has links.
4. See footer links match text color but have faint underline.
5. See footer link hover and press change footer link style.

## UI

| Before Links<br>Before Styles | After Links<br>Before Styles | After Links<br>After Styles |
| - | - | - |
| <img width="405" height="465" alt="before footer links, before footer styles" src="https://github.com/user-attachments/assets/429eccc5-2106-42bf-81a3-a1b849ffb2df" /> | <img width="405" height="465" alt="after footer links, before footer styles" src="https://github.com/user-attachments/assets/16fe8fa6-3046-49c3-8186-f7539f1766a0" /> | <img width="405" height="465" alt="after footer links, after footer styles" src="https://github.com/user-attachments/assets/9a23bf01-dd20-4d96-a6d7-f8cb24264ae2" />

https://github.com/user-attachments/assets/18fc6809-4854-4e04-a57d-60f38a2e23e1

https://github.com/user-attachments/assets/ce4a87df-5f66-4638-93b8-3a27506c8d4e

https://github.com/user-attachments/assets/71fe0d5c-c4ca-4908-b1a2-74be5aba0e21



