### PR TITLE
chore(deps): use Core-Styles footer fix branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,6 @@
 
 This is a **Docker-based Django CMS** project. All application code runs inside Docker containers.
 
-### Local-agent guardrails
-
-- Treat these instructions as valid for both Local and Cloud agents.
-- For non-interactive setup, always run `make setup` with `DJANGO_SUPERUSER_PASSWORD=...`.
-- Before setup/start, check for stale `core_cms*` containers or old Compose projects that can cause name conflicts; remove them if needed.
-- For branch-based npm dependencies, update via npm command (not manual lockfile edits), then verify `package.json` and `package-lock.json` match.
-- Before screenshot requests, confirm target URL is reachable; do not ask for `ready` until page is actually loaded.
-
 ### Services
 
 | Service | Container | Port |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,14 @@
 
 This is a **Docker-based Django CMS** project. All application code runs inside Docker containers.
 
+### Local-agent guardrails
+
+- Treat these instructions as valid for both Local and Cloud agents.
+- For non-interactive setup, always run `make setup` with `DJANGO_SUPERUSER_PASSWORD=...`.
+- Before setup/start, check for stale `core_cms*` containers or old Compose projects that can cause name conflicts; remove them if needed.
+- For branch-based npm dependencies, update via npm command (not manual lockfile edits), then verify `package.json` and `package-lock.json` match.
+- Before screenshot requests, confirm target URL is reachable; do not ask for `ready` until page is actually loaded.
+
 ### Services
 
 | Service | Container | Port |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "github:TACC/Core-Styles#fix/footer-text-color-one-step-darker"
+        "@tacc/core-styles": "github:TACC/Core-Styles#main"
       },
       "engines": {
         "node": ">=20",
@@ -1012,9 +1012,9 @@
       }
     },
     "node_modules/@csstools/postcss-normalize-display-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.0.tgz",
-      "integrity": "sha512-HlEoG0IDRoHXzXnkV4in47dzsxdsjdz6+j7MLjaACABX2NfvjFS6XVAnpaDyGesz9gK2SC7MbNwdCHusObKJ9Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+      "integrity": "sha512-TQUGBuRvxdc7TgNSTevYqrL8oItxiwPDixk20qCB5me/W8uF7BPbhRrAvFuhEoywQp/woRsUZ6SJ+sU5idZAIA==",
       "dev": true,
       "funding": [
         {
@@ -1069,6 +1069,30 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/@csstools/postcss-position-area-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-position-area-property/-/postcss-position-area-property-1.0.0.tgz",
+      "integrity": "sha512-fUP6KR8qV2NuUZV3Cw8itx0Ep90aRjAZxAEzC3vrl6yjFv+pFsQbR18UuQctEKmA72K9O27CoYiKEgXxkqjg8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
     "node_modules/@csstools/postcss-progressive-custom-properties": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.2.1.tgz",
@@ -1088,6 +1112,34 @@
       "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-property-rule-prelude-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-property-rule-prelude-list/-/postcss-property-rule-prelude-list-1.0.0.tgz",
+      "integrity": "sha512-IxuQjUXq19fobgmSSvUDO7fVwijDJaZMvWQugxfEUxmjBeDCVaDuMpsZ31MsTm5xbnhA+ElDi0+rQ7sQQGisFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peer": true,
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -1256,6 +1308,61 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/@csstools/postcss-syntax-descriptor-syntax-production": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-syntax-descriptor-syntax-production/-/postcss-syntax-descriptor-syntax-production-1.0.1.tgz",
+      "integrity": "sha512-GneqQWefjM//f4hJ/Kbox0C6f2T7+pi4/fqTqOFGTL3EjnvOReTqO1qUQ30CaUjkwjYq9qZ41hzarrAxCc4gow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peer": true,
+      "dependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-system-ui-font-family": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-system-ui-font-family/-/postcss-system-ui-font-family-1.0.0.tgz",
+      "integrity": "sha512-s3xdBvfWYfoPSBsikDXbuorcMG1nN1M6GdU0qBsGfcmNR0A/qhloQZpTxjA3Xsyrk1VJvwb2pOfiOT3at/DuIQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peer": true,
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
     "node_modules/@csstools/postcss-text-decoration-shorthand": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.3.tgz",
@@ -1403,8 +1510,8 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "github:TACC/Core-Styles#fix/footer-text-color-one-step-darker",
-      "resolved": "git+https://github.com/TACC/Core-Styles.git#332e7d93f48f98e84fb7784e9abbb65f2f7582d2",
+      "version": "2.56.0",
+      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#c44dd0afdfc5897752ab6058ef8a7b2d305f2054",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1429,17 +1536,6 @@
         "postcss-mixins": "^10.0.1",
         "postcss-preset-env": "^10.0.2",
         "postcss-replace": "^2.0.1"
-      }
-    },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -1494,9 +1590,9 @@
       "peer": true
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.22",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
-      "integrity": "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
         {
@@ -1515,10 +1611,9 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "browserslist": "^4.27.0",
-        "caniuse-lite": "^1.0.30001754",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
-        "normalize-range": "^0.1.2",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -1533,14 +1628,17 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.32.tgz",
-      "integrity": "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -1580,9 +1678,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -1601,11 +1699,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1640,9 +1738,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001757",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
-      "integrity": "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -2005,9 +2103,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "8.4.3",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.4.3.tgz",
-      "integrity": "sha512-8aaDS5nVqMXmYjlmmJpqlDJosiqbl2NJkYuSFOXR6RTY14qNosMrqT4t7O+EUm+OdduQg3GNI2ZwC03No1Y58Q==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.8.0.tgz",
+      "integrity": "sha512-QbLeyz2Bgso1iRlh7IpWk6OKa3lLNGXsujVjDMPl9rOZpxKeiG69icLpbLCFxeURwmcdIfZqQyhlooKJYM4f8Q==",
       "dev": true,
       "funding": [
         {
@@ -2221,9 +2319,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.262",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
-      "integrity": "sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -2245,6 +2343,17 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2288,9 +2397,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -2328,9 +2437,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2743,9 +2852,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2754,17 +2863,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2839,9 +2937,9 @@
       "peer": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2864,9 +2962,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -3682,9 +3780,9 @@
       }
     },
     "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -4217,9 +4315,9 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.4.0.tgz",
-      "integrity": "sha512-2kqpOthQ6JhxqQq1FSAAZGe9COQv75Aw8WbsOvQVNJ2nSevc9Yx/IKZGuZ7XJ+iOTtVon7LfO7ELRzg8AZ+sdw==",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.6.1.tgz",
+      "integrity": "sha512-yrk74d9EvY+W7+lO9Aj1QmjWY9q5NsKjK2V9drkOPZB/X6KZ0B3igKsHUYakb7oYVhnioWypQX3xGuePf89f3g==",
       "dev": true,
       "funding": [
         {
@@ -4259,23 +4357,27 @@
         "@csstools/postcss-media-minmax": "^2.0.9",
         "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
         "@csstools/postcss-nested-calc": "^4.0.0",
-        "@csstools/postcss-normalize-display-values": "^4.0.0",
+        "@csstools/postcss-normalize-display-values": "^4.0.1",
         "@csstools/postcss-oklab-function": "^4.0.12",
+        "@csstools/postcss-position-area-property": "^1.0.0",
         "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+        "@csstools/postcss-property-rule-prelude-list": "^1.0.0",
         "@csstools/postcss-random-function": "^2.0.1",
         "@csstools/postcss-relative-color-syntax": "^3.0.12",
         "@csstools/postcss-scope-pseudo-class": "^4.0.1",
         "@csstools/postcss-sign-functions": "^1.1.4",
         "@csstools/postcss-stepped-value-functions": "^4.0.9",
+        "@csstools/postcss-syntax-descriptor-syntax-production": "^1.0.1",
+        "@csstools/postcss-system-ui-font-family": "^1.0.0",
         "@csstools/postcss-text-decoration-shorthand": "^4.0.3",
         "@csstools/postcss-trigonometric-functions": "^4.0.9",
         "@csstools/postcss-unset-value": "^4.0.0",
-        "autoprefixer": "^10.4.21",
-        "browserslist": "^4.26.0",
+        "autoprefixer": "^10.4.23",
+        "browserslist": "^4.28.1",
         "css-blank-pseudo": "^7.0.1",
         "css-has-pseudo": "^7.0.3",
         "css-prefers-color-scheme": "^10.0.0",
-        "cssdb": "^8.4.2",
+        "cssdb": "^8.6.0",
         "postcss-attribute-case-insensitive": "^7.0.1",
         "postcss-clamp": "^4.1.0",
         "postcss-color-functional-notation": "^7.0.12",
@@ -4631,13 +4733,14 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -4687,6 +4790,17 @@
       "peer": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/slash": {
@@ -4829,19 +4943,19 @@
       }
     },
     "node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
+      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
+        "sax": "^1.5.0",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -4863,9 +4977,9 @@
       }
     },
     "node_modules/thenby": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
-      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.4.0.tgz",
+      "integrity": "sha512-D+BkEl5MpeTbQ1Rz0io/TLZmwmYUAgvUpS1r2eKUvPicYOnpqzjZE6bVa7rSEYv189zkSM+CVc+hG5X7nVe9LQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -4896,9 +5010,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -4966,9 +5080,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -5417,9 +5531,9 @@
       }
     },
     "@csstools/postcss-normalize-display-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.0.tgz",
-      "integrity": "sha512-HlEoG0IDRoHXzXnkV4in47dzsxdsjdz6+j7MLjaACABX2NfvjFS6XVAnpaDyGesz9gK2SC7MbNwdCHusObKJ9Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+      "integrity": "sha512-TQUGBuRvxdc7TgNSTevYqrL8oItxiwPDixk20qCB5me/W8uF7BPbhRrAvFuhEoywQp/woRsUZ6SJ+sU5idZAIA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -5440,6 +5554,14 @@
         "@csstools/utilities": "^2.0.0"
       }
     },
+    "@csstools/postcss-position-area-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-position-area-property/-/postcss-position-area-property-1.0.0.tgz",
+      "integrity": "sha512-fUP6KR8qV2NuUZV3Cw8itx0Ep90aRjAZxAEzC3vrl6yjFv+pFsQbR18UuQctEKmA72K9O27CoYiKEgXxkqjg8Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
+    },
     "@csstools/postcss-progressive-custom-properties": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.2.1.tgz",
@@ -5448,6 +5570,17 @@
       "peer": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "@csstools/postcss-property-rule-prelude-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-property-rule-prelude-list/-/postcss-property-rule-prelude-list-1.0.0.tgz",
+      "integrity": "sha512-IxuQjUXq19fobgmSSvUDO7fVwijDJaZMvWQugxfEUxmjBeDCVaDuMpsZ31MsTm5xbnhA+ElDi0+rQ7sQQGisFA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "@csstools/postcss-random-function": {
@@ -5523,6 +5656,27 @@
         "@csstools/css-tokenizer": "^3.0.4"
       }
     },
+    "@csstools/postcss-syntax-descriptor-syntax-production": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-syntax-descriptor-syntax-production/-/postcss-syntax-descriptor-syntax-production-1.0.1.tgz",
+      "integrity": "sha512-GneqQWefjM//f4hJ/Kbox0C6f2T7+pi4/fqTqOFGTL3EjnvOReTqO1qUQ30CaUjkwjYq9qZ41hzarrAxCc4gow==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "@csstools/postcss-system-ui-font-family": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-system-ui-font-family/-/postcss-system-ui-font-family-1.0.0.tgz",
+      "integrity": "sha512-s3xdBvfWYfoPSBsikDXbuorcMG1nN1M6GdU0qBsGfcmNR0A/qhloQZpTxjA3Xsyrk1VJvwb2pOfiOT3at/DuIQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
     "@csstools/postcss-text-decoration-shorthand": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.3.tgz",
@@ -5592,17 +5746,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "github:TACC/Core-Styles#fix/footer-text-color-one-step-darker",
-      "resolved": "git+https://github.com/TACC/Core-Styles.git#332e7d93f48f98e84fb7784e9abbb65f2f7582d2",
+      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#c44dd0afdfc5897752ab6058ef8a7b2d305f2054",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/Core-Styles#main",
       "requires": {}
-    },
-    "@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "peer": true
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -5640,24 +5787,23 @@
       "peer": true
     },
     "autoprefixer": {
-      "version": "10.4.22",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
-      "integrity": "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "peer": true,
       "requires": {
-        "browserslist": "^4.27.0",
-        "caniuse-lite": "^1.0.30001754",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
-        "normalize-range": "^0.1.2",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "baseline-browser-mapping": {
-      "version": "2.8.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.32.tgz",
-      "integrity": "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "peer": true
     },
@@ -5686,17 +5832,17 @@
       }
     },
     "browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       }
     },
     "camelcase-css": {
@@ -5720,9 +5866,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001757",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
-      "integrity": "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "peer": true
     },
@@ -5938,9 +6084,9 @@
       "peer": true
     },
     "cssdb": {
-      "version": "8.4.3",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.4.3.tgz",
-      "integrity": "sha512-8aaDS5nVqMXmYjlmmJpqlDJosiqbl2NJkYuSFOXR6RTY14qNosMrqT4t7O+EUm+OdduQg3GNI2ZwC03No1Y58Q==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.8.0.tgz",
+      "integrity": "sha512-QbLeyz2Bgso1iRlh7IpWk6OKa3lLNGXsujVjDMPl9rOZpxKeiG69icLpbLCFxeURwmcdIfZqQyhlooKJYM4f8Q==",
       "dev": true,
       "peer": true
     },
@@ -6078,9 +6224,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.262",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
-      "integrity": "sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "peer": true
     },
@@ -6095,6 +6241,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "peer": true
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "peer": true
     },
@@ -6127,9 +6280,9 @@
       }
     },
     "fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -6154,9 +6307,9 @@
       "peer": true
     },
     "fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -6434,9 +6587,9 @@
       "peer": true
     },
     "node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "peer": true
     },
@@ -6444,13 +6597,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "peer": true
-    },
-    "normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
       "peer": true
     },
@@ -6500,9 +6646,9 @@
       "peer": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "peer": true
     },
@@ -6514,9 +6660,9 @@
       "peer": true
     },
     "postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -6940,9 +7086,9 @@
           "peer": true
         },
         "yaml": {
-          "version": "2.8.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-          "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+          "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
           "dev": true,
           "peer": true
         }
@@ -7218,9 +7364,9 @@
       }
     },
     "postcss-preset-env": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.4.0.tgz",
-      "integrity": "sha512-2kqpOthQ6JhxqQq1FSAAZGe9COQv75Aw8WbsOvQVNJ2nSevc9Yx/IKZGuZ7XJ+iOTtVon7LfO7ELRzg8AZ+sdw==",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.6.1.tgz",
+      "integrity": "sha512-yrk74d9EvY+W7+lO9Aj1QmjWY9q5NsKjK2V9drkOPZB/X6KZ0B3igKsHUYakb7oYVhnioWypQX3xGuePf89f3g==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -7249,23 +7395,27 @@
         "@csstools/postcss-media-minmax": "^2.0.9",
         "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
         "@csstools/postcss-nested-calc": "^4.0.0",
-        "@csstools/postcss-normalize-display-values": "^4.0.0",
+        "@csstools/postcss-normalize-display-values": "^4.0.1",
         "@csstools/postcss-oklab-function": "^4.0.12",
+        "@csstools/postcss-position-area-property": "^1.0.0",
         "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+        "@csstools/postcss-property-rule-prelude-list": "^1.0.0",
         "@csstools/postcss-random-function": "^2.0.1",
         "@csstools/postcss-relative-color-syntax": "^3.0.12",
         "@csstools/postcss-scope-pseudo-class": "^4.0.1",
         "@csstools/postcss-sign-functions": "^1.1.4",
         "@csstools/postcss-stepped-value-functions": "^4.0.9",
+        "@csstools/postcss-syntax-descriptor-syntax-production": "^1.0.1",
+        "@csstools/postcss-system-ui-font-family": "^1.0.0",
         "@csstools/postcss-text-decoration-shorthand": "^4.0.3",
         "@csstools/postcss-trigonometric-functions": "^4.0.9",
         "@csstools/postcss-unset-value": "^4.0.0",
-        "autoprefixer": "^10.4.21",
-        "browserslist": "^4.26.0",
+        "autoprefixer": "^10.4.23",
+        "browserslist": "^4.28.1",
         "css-blank-pseudo": "^7.0.1",
         "css-has-pseudo": "^7.0.3",
         "css-prefers-color-scheme": "^10.0.0",
-        "cssdb": "^8.4.2",
+        "cssdb": "^8.6.0",
         "postcss-attribute-case-insensitive": "^7.0.1",
         "postcss-clamp": "^4.1.0",
         "postcss-color-functional-notation": "^7.0.12",
@@ -7479,12 +7629,13 @@
       "peer": true
     },
     "resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "peer": true,
       "requires": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -7506,6 +7657,13 @@
       "requires": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "peer": true
     },
     "slash": {
       "version": "5.1.0",
@@ -7594,18 +7752,18 @@
       "peer": true
     },
     "svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
+      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
+        "sax": "^1.5.0",
         "stable": "^0.1.8"
       },
       "dependencies": {
@@ -7619,9 +7777,9 @@
       }
     },
     "thenby": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
-      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.4.0.tgz",
+      "integrity": "sha512-D+BkEl5MpeTbQ1Rz0io/TLZmwmYUAgvUpS1r2eKUvPicYOnpqzjZE6bVa7rSEYv189zkSM+CVc+hG5X7nVe9LQ==",
       "dev": true,
       "peer": true
     },
@@ -7643,9 +7801,9 @@
       "peer": true
     },
     "update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -7680,9 +7838,9 @@
       "peer": true
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "peer": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.56.0"
+        "@tacc/core-styles": "github:TACC/Core-Styles#fix/footer-text-color-one-step-darker"
       },
       "engines": {
         "node": ">=20",
@@ -1403,9 +1403,8 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.56.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.56.0.tgz",
-      "integrity": "sha512-j4TII9rhrt6fH5dpSKCRS8lbLt8Fuc3Iv+aaoLlU8m4FGcsWDE1ODLpqsiZSERbZMF5fLUbJAZhNwzGG59axnw==",
+      "version": "github:TACC/Core-Styles#fix/footer-text-color-one-step-darker",
+      "resolved": "git+https://github.com/TACC/Core-Styles.git#332e7d93f48f98e84fb7784e9abbb65f2f7582d2",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5593,9 +5592,8 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.56.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.56.0.tgz",
-      "integrity": "sha512-j4TII9rhrt6fH5dpSKCRS8lbLt8Fuc3Iv+aaoLlU8m4FGcsWDE1ODLpqsiZSERbZMF5fLUbJAZhNwzGG59axnw==",
+      "version": "github:TACC/Core-Styles#fix/footer-text-color-one-step-darker",
+      "resolved": "git+https://github.com/TACC/Core-Styles.git#332e7d93f48f98e84fb7784e9abbb65f2f7582d2",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "github:TACC/Core-Styles#main"
+        "@tacc/core-styles": "^2.56.1"
       },
       "engines": {
         "node": ">=20",
@@ -1510,8 +1510,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.56.0",
-      "resolved": "git+ssh://git@github.com/TACC/Core-Styles.git#c44dd0afdfc5897752ab6058ef8a7b2d305f2054",
+      "version": "2.56.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.56.1.tgz",
+      "integrity": "sha512-9l2bIdZWTicDoTEG8BJE6L95LTtMzt3V1eNVxL2VwYX9PxiogR03ElWgvi+w2dybF9Z0bQMD/Q+hYpZkdeZHdg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5746,9 +5747,10 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/Core-Styles.git#c44dd0afdfc5897752ab6058ef8a7b2d305f2054",
+      "version": "2.56.1",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.56.1.tgz",
+      "integrity": "sha512-9l2bIdZWTicDoTEG8BJE6L95LTtMzt3V1eNVxL2VwYX9PxiogR03ElWgvi+w2dybF9Z0bQMD/Q+hYpZkdeZHdg==",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/Core-Styles#main",
       "requires": {}
     },
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "github:TACC/Core-Styles#fix/footer-text-color-one-step-darker"
+    "@tacc/core-styles": "github:TACC/Core-Styles#main"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.56.0"
+    "@tacc/core-styles": "github:TACC/Core-Styles#fix/footer-text-color-one-step-darker"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "github:TACC/Core-Styles#main"
+    "@tacc/core-styles": "^2.56.1"
   }
 }


### PR DESCRIPTION
## Overview
Use a Core-Styles commit-ish with the footer text-color fix.

## Related
- requires https://github.com/TACC/Core-Styles/pull/633

## Changes
- **updated** `@tacc/core-styles` to a branch-based install
- **updated** lockfile entries to the matching Core-Styles commit

## Testing
1. Verify dependency and lockfile both reference `fix/footer-text-color-one-step-darker`.
2. Build CSS locally and confirm footer text/links render one step darker.

## UI

<img width="960" height="874" alt="cms-footer-after" src="https://github.com/user-attachments/assets/48b850ce-7f0e-43f2-be2c-ded2452113fc" />

---

Made with [Cursor](https://cursor.com)