### PR TITLE
feat(nav): set a CMS menu link to open in new tab - via setting

### DIFF
--- a/taccsite_cms/cms_menus.py
+++ b/taccsite_cms/cms_menus.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from menus.base import Modifier
+from menus.menu_pool import menu_pool
+
+
+class NewTabModifier(Modifier):
+    """
+    Annotate CMS nav nodes whose reverse_id is in PORTAL_CMS_MENU_NEW_TAB_PAGE_IDS
+    with attr['new_tab'] = True, so the menu template can render target="_blank".
+
+    SEE: https://docs.django-cms.org/en/release-3.11.x/how_to/menus.html#navigation-modifiers
+    """
+
+    # To run this modification AFTER built-in CMS modifiers
+    # https://docs.django-cms.org/en/release-3.11.x/how_to/menus.html#performance-issues-in-menu-modifiers
+    rating = 20
+
+    # https://docs.django-cms.org/en/release-3.11.x/how_to/menus.html#how-it-works
+    def modify(self, request, nodes, namespace, root_id, post_cut, breadcrumb):
+        if post_cut:
+            page_ids = getattr(settings, 'PORTAL_CMS_MENU_NEW_TAB_PAGE_IDS', [])
+            if page_ids:
+                for node in nodes:
+                    if node.attr.get('reverse_id') in page_ids:
+                        node.attr['new_tab'] = True
+        return nodes
+
+
+menu_pool.register_modifier(NewTabModifier)

--- a/taccsite_cms/settings/settings.py
+++ b/taccsite_cms/settings/settings.py
@@ -281,6 +281,10 @@ PORTAL_LOGIN_PATH = '/login'
 # FAQ: A falsy value will trigger default logic for nav width
 PORTAL_NAV_WIDTH = False
 
+# CMS pages (by `reverse_id`) whose menu link should open in a new tab
+# https://docs.django-cms.org/en/release-3.10.x/reference/templatetags.html#page-lookup:~:text=reverse_id
+PORTAL_CMS_MENU_NEW_TAB_PAGE_IDS = []
+
 # using container name to avoid cep.dev dns issues locally
 # CEP_AUTH_VERIFICATION_ENDPOINT = https://hostname.tacc.utexas.edu # Dev/Prod/Etc
 CEP_AUTH_VERIFICATION_ENDPOINT = 'http://django:6000'               # Local

--- a/taccsite_cms/settings/settings_custom.example.py
+++ b/taccsite_cms/settings/settings_custom.example.py
@@ -24,6 +24,10 @@ AUTH_LDAP_SERVER_URI = "ldap://cluster.ldap.tacc.utexas.edu"
 # DJANGO_CMS
 ########################
 
+# Pages (by `reverse_id`) whose nav menu link opens in a new tab.
+# Set `reverse_id` in CMS admin: Page > Settings > Advanced > "Id".
+# PORTAL_CMS_MENU_NEW_TAB_PAGE_IDS = ['workbench', 'some-other-page']
+
 CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),

--- a/taccsite_cms/templates/cms_menu.html
+++ b/taccsite_cms/templates/cms_menu.html
@@ -39,7 +39,7 @@
       <a
         class="dropdown-item{% if grandchild.selected %} active{% endif %}"
         href="{{ grandchild|get_menu_uri }}"
-        {% target_blank grandchild|get_menu_uri %}
+        {% target_blank grandchild|get_menu_uri grandchild %}
       >
         {{ grandchild.get_menu_title|safe }}
         {% if grandchild.selected %}<span class="sr-only">(current)</span>{% endif %}
@@ -52,7 +52,7 @@
   <a
     class="nav-link"
     href="{{ child|get_menu_uri }}"
-    {% target_blank child|get_menu_uri %}
+    {% target_blank child|get_menu_uri child %}
   >
     {{ child.get_menu_title|safe }}
     {% if child.selected %}<span class="sr-only">(current)</span>{% endif %}

--- a/taccsite_cms/templatetags/tacc_uri_shortcuts.py
+++ b/taccsite_cms/templatetags/tacc_uri_shortcuts.py
@@ -42,7 +42,7 @@ def site_uri(context):
     }
 
 @register.simple_tag(takes_context=True)
-def target_blank(context, link_uri):
+def target_blank(context, link_uri, menu_node=None):
     """
     Custom Template Tag `target_blank`
 
@@ -82,9 +82,10 @@ def target_blank(context, link_uri):
     # FAQ: I am literally double-checking, because I am unskilled in Django
     is_external = ( link_origin != req_origin and link_origin != '://' )
     is_internal = ( link.hostname == req.hostname or link.hostname == None )
-    should_open_in_new_window = ( is_external and not is_internal )
+    is_forced_new_tab = ( menu_node is not None and menu_node.attr.get('new_tab') )
+    should_open_in_new_tab = ( is_external and not is_internal ) or is_forced_new_tab
 
-    if should_open_in_new_window:
+    if should_open_in_new_tab:
         # FAQ: Use `format_html` to not render `target="&quot;_blank&quot;"`
         return format_html('target="_blank"')
     else:


### PR DESCRIPTION
## Overview

Let us configure specific CMS menu links to open in a new tab.

Usage requires:
- **both** by new setting (set via CMS dev)
- **and** Page "ID" (set via CMS admin)

Previously, only external links got `target="_blank"` (via custom Core-CMS JavaScript).

> [!WARNING]
> Alternatives exist:
> - https://github.com/TACC/Core-CMS/pull/1151
> - add JavaScript to Core-Portal via new `PORTAL_JS_FILENAMES`

## Related

- **fixes [WP-1230](https://tacc-main.atlassian.net/browse/WP-1230)**
- alternative: #1151

## Changes

- **added** `NewTabModifier` in `taccsite_cms/cms_menus.py`
    - reads setting `PORTAL_CMS_MENU_NEW_TAB_PAGE_IDS`
    - adds node attribute `new_tab`
- **added** setting `PORTAL_CMS_MENU_NEW_TAB_PAGE_IDS`
- **updated** template tag `target_blank` to honor `attr['new_tab']`
- **updated** `cms_menu.html`
- **updated** `settings_custom.example.py`

## Testing

1. In CMS admin, set a page's **reverse_id** (Page > Settings > Advanced > "Id").
2. Add that slug to `PORTAL_CMS_MENU_NEW_TAB_PAGE_IDS` in `settings_custom.py` and restart.
3. Verify that nav link opens in a new tab; other internal links do not.
4. Verify external redirect links still open in a new tab (existing behavior).

## UI

> [!WARNING]
> Untested.

---

Made with [Cursor](https://cursor.com/). Directed and scrutinized by @wesleyboar.