### PR TITLE
fix(css): eliminate double @media in blog visual float layout

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.page.css
@@ -82,18 +82,18 @@ Styleguide Components.DjangoCMS.Blog.App.Page
 :--news-article-page .blog-visual {
   @mixin news-article-page__media;
 
-  @media (--medium-and-below) {
-    & {
+  & {
+    @media (--medium-and-below) {
       @mixin news-article-page__media--layout-center;
     }
   }
-  @media (--medium-and-above) {
-    &:has([data-width="0"]) {
+  &:has([data-width="0"]) {
+    @media (--medium-and-above) {
       @mixin news-article-page__media--layout-center;
     }
-    &:not(:has([data-width="0"])) {
-      @mixin news-article-page__media--layout-float;
-    }
+  }
+  &:not(:has([data-width="0"])) {
+    @mixin news-article-page__media--layout-float;
   }
 }
 

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
@@ -422,6 +422,6 @@
     @mixin offset-content--float-right;
     @mixin offset-content--terminate-offset-right;
     @mixin offset-content--offset-right;
+    @mixin news-article-page__media--offset__figcaption;
   }
-  @mixin news-article-page__media--offset__figcaption;
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
@@ -417,5 +417,11 @@
   width: fit-content;
 }
 @define-mixin news-article-page__media--layout-float {
-  @mixin news-article-page__media--offset-right;
+  @media (--medium-and-above) {
+    @mixin offset-content;
+    @mixin offset-content--float-right;
+    @mixin offset-content--terminate-offset-right;
+    @mixin offset-content--offset-right;
+  }
+  @mixin news-article-page__media--offset__figcaption;
 }


### PR DESCRIPTION
## Overview

A mixin calling another mixin that already contained `@media (--medium-and-above)` produced duplicate nested at-rules in compiled CSS.

## Related

- noticed during #1154

## Changes

- **fixed** double `@media` in compiled output for `.blog-visual` float layout
- **restructured** `.blog-visual` rule block for consistent nesting convention

## Testing

1. `make start`
2. Open a blog post with a banner image and one with a portrait image.
3. At ≥992 px, banner centers, portrait floats right.
4. At <992 px, both center.
5. Confirm no duplicate `@media (min-width: 992px)` nesting in compiled CSS.

## UI

…