### PR TITLE
fix(css): remove dead figcaption offset style

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
@@ -383,13 +383,6 @@
     display: none;
   }
 }
-@define-mixin news-article-page__media--offset__figcaption {
-  /* ???: Is this really desired for Core… */
-  /* https://github.com/TACC/Core-Styles/blob/v2.53.0/src/lib/_imports/objects/o-offset-content.css#L34-L36 */
-  &.figure .figure-caption {
-    padding-right: 125px;
-  }
-}
 @define-mixin news-article-page__media--offset-right {
   @mixin offset-content;
   @mixin offset-content--float-right;
@@ -398,8 +391,6 @@
   @media (--medium-and-above) {
     @mixin offset-content--offset-right;
   }
-
-  @mixin news-article-page__media--offset__figcaption;
 }
 @define-mixin news-article-page__media--offset-left {
   @mixin offset-content;
@@ -409,8 +400,6 @@
   @media (--medium-and-above) {
     @mixin offset-content--offset-left;
   }
-
-  @mixin news-article-page__media--offset__figcaption;
 }
 @define-mixin news-article-page__media--layout-center {
   margin-inline: auto;
@@ -422,6 +411,5 @@
     @mixin offset-content--float-right;
     @mixin offset-content--terminate-offset-right;
     @mixin offset-content--offset-right;
-    @mixin news-article-page__media--offset__figcaption;
   }
 }


### PR DESCRIPTION
## Overview

`news-article-page__media--offset__figcaption` applied `padding-right: 125px` to `.figure .figure-caption` but:
- its selector can never match in practice
- if matched, causes unwanted style[^1]

[^1]: Seems to be cruft from older version of Texascale. I reproduced the style in Core-CMS, where it looks like a bug. New and old Texascale don't have markup that will be affected by this change.

## Related

- noticed during #1157

## Changes

- **deleted** `news-article-page__media--offset__figcaption` mixin

## Testing

No visible change expected — the selector never matched reachable markup.

## UI

N/A

## Notes

The selector `&.figure .figure-caption` requires an element to simultaneously carry a CMS align class (`.align-right` / `.align-left`) and Bootstrap's `.figure` class, with a `.figure-caption` descendant. This combination cannot be produced through the Text plugin, which is how article body content is authored. Older Texascale editions that did use Bootstrap figures predated this code. Newer websites work exclusively inside the Text plugin, which cannot produce Bootstrap figure markup. The original `???:` comment in the mixin already signaled uncertainty about whether it ever applied. And if the code appeared, it would have unwanted padding because of this code (I tested manually).

Made with [Cursor](https://cursor.com).