### PR TITLE
feat(ckeditor): google docs paste, use strong/em not css

### DIFF
--- a/taccsite_cms/_settings/djangocms_plugins.py
+++ b/taccsite_cms/_settings/djangocms_plugins.py
@@ -21,10 +21,6 @@ CKEDITOR_SETTINGS = {
     'contentsCss': ['/static/djangocms_text_ckeditor/ckeditor/contents.css'],
     'extraPlugins': 'pastefromgdocs',
 }
-CKEDITOR_EXTERNAL_PLUGIN_RESOURCES = [
-    ('pastefromgdocs',
-     'https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@4.21.0/plugins/pastefromgdocs/plugin.js'),
-]
 
 ########################
 # DJANGOCMS_PICTURE

--- a/taccsite_cms/_settings/djangocms_plugins.py
+++ b/taccsite_cms/_settings/djangocms_plugins.py
@@ -21,6 +21,10 @@ CKEDITOR_SETTINGS = {
     'contentsCss': ['/static/djangocms_text_ckeditor/ckeditor/contents.css'],
     'extraPlugins': 'pastefromgdocs',
 }
+CKEDITOR_EXTERNAL_PLUGIN_RESOURCES = [
+    ('pastefromgdocs',
+     'https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@4.21.0/plugins/pastefromgdocs/plugin.js'),
+]
 
 ########################
 # DJANGOCMS_PICTURE

--- a/taccsite_cms/_settings/djangocms_plugins.py
+++ b/taccsite_cms/_settings/djangocms_plugins.py
@@ -19,6 +19,7 @@ CKEDITOR_SETTINGS = {
     'autoParagraph': False,
     'stylesSet': 'default:/static/js/addons/ckeditor.wysiwyg.js',
     'contentsCss': ['/static/djangocms_text_ckeditor/ckeditor/contents.css'],
+    'extraPlugins': 'pastefromgdocs',
 }
 
 ########################

--- a/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
+++ b/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
@@ -1,6 +1,12 @@
 /* Alter ckeditor/styles.js to match our own wants */
 /* https://github.com/django-cms/djangocms-text-ckeditor/blob/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor/styles.js */
 
+CKEDITOR.plugins.addExternal(
+  'pastefromgdocs',
+  'https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@4.21.0/plugins/pastefromgdocs/',
+  'plugin.js'
+);
+
 CKEDITOR.stylesSet.add( 'default', [
 
 	/* Block styles */

--- a/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
+++ b/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
@@ -7,6 +7,35 @@ CKEDITOR.plugins.addExternal(
   'plugin.js'
 );
 
+/* Convert inline bold/italic styles to semantic tags on paste,
+   because the site strips inline styles from saved content,
+   yet `pastefromgdocs` bold/italic are as inline styles. */
+CKEDITOR.on('instanceReady', function(ev) {
+  ev.editor.on('paste', function(e) {
+    var parser = new DOMParser();
+    var doc = parser.parseFromString(e.data.dataValue, 'text/html');
+
+    doc.querySelectorAll('span').forEach(function(span) {
+      var fw = span.style.fontWeight;
+      var fs = span.style.fontStyle;
+      var replacement;
+
+      if (fw === 'bold' || fw === '700') {
+        replacement = doc.createElement('strong');
+      } else if (fs === 'italic') {
+        replacement = doc.createElement('em');
+      }
+
+      if (replacement) {
+        while (span.firstChild) replacement.appendChild(span.firstChild);
+        span.parentNode.replaceChild(replacement, span);
+      }
+    });
+
+    e.data.dataValue = doc.body.innerHTML;
+  }, null, null, 1);
+});
+
 CKEDITOR.stylesSet.add( 'default', [
 
 	/* Block styles */

--- a/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
+++ b/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
@@ -33,7 +33,9 @@ CKEDITOR.on('instanceReady', function(ev) {
     });
 
     e.data.dataValue = doc.body.innerHTML;
-  }, null, null, 1);
+  /* Priority 4 runs after `pastetools` (priority 3); we must run after it
+     because it re-reads original clipboard data and overwrites dataValue. */
+  }, null, null, 4);
 });
 
 CKEDITOR.stylesSet.add( 'default', [


### PR DESCRIPTION
## Overview

**Allow pasting from Google docs:**
- Fixes paste from Google docs making entire content bold.
- Replaces `<span style="font-weight: 700">` with `<strong>`.
- Replaces `<span style="font-style: italic">` with `<em>`.

> [!CAUTION]
> Only worked locally. Broke WYSIWYGs on pre-prod and prod (not live) servers. Fixed by #1164.

## Related

- testing via https://github.com/TACC/Core-Portal-Deployments/pull/193/
- fixed by #1164

## Changes

- **added** `pastefromgdocs` plugin

## Testing & UI

### Before

1. In Google docs, have some formatted text.
2. Copy from Google docs into Django CMS WYSIWYG editor.
3. ❌ See all text becomes bold.

https://github.com/user-attachments/assets/60113876-7848-455b-9fb7-0e1dbd95a2d8

### Working… Almost

<details><summary>Archived content.</summary>

1. In Google docs, have some formatted text.
2. Copy from Google docs into Django CMS WYSIWYG editor.
3. ✅ See only bold text from Google pastes as bold.
4. ❌ Bold comes from inline style, not `<b>` nor `<strong>`.

https://github.com/user-attachments/assets/592ddfde-ff05-4d30-b4bc-19a8511bfe97

</details>

### After

1. In Google docs, have some formatted text.
2. Copy from Google docs into Django CMS WYSIWYG editor.
3. ✅ See only bold text from Google pastes as bold.
4. ✅ Verify bold comes from `<strong>`.

https://github.com/user-attachments/assets/2a165ab7-e7d4-42dc-8296-bfdcf41ebe10