### PR TITLE
fix: hidden a11y text should not require asset

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
+++ b/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js
@@ -22,8 +22,8 @@ function ensureOpenNewWindowSpan() {
   }
   const span = document.createElement( 'span' );
   span.id = ID_OPEN_NEW_WINDOW;
-  span.className = CLASS_VISUALLY_HIDDEN;
   span.textContent = TEXT_OPEN_NEW_WINDOW;
+  span.hidden = true;
   document.body.appendChild( span );
 }
 


### PR DESCRIPTION
## Overview

Hide a11y text via `hidden` not a class, because class requires stylesheet to have loaded.

_When testing https://github.com/TACC/Core-Portal/pull/1303, a11y text showed on screen before Bootstrap stylesheet had loaded._

## Related

- fixes UI bug with https://github.com/TACC/Core-Portal/pull/1303

## Changes

- **changed** className to `hidden` attribute

## Testing

0. Have external link without accessible descritpion.
    <sub>(e.g. a CMS Nav link that opens site in new tab.)</sub>
1. Deploy with (or on-the-fly change to use) new code.
2. Verify link a11y description is still "Opens in a new window".
3. Verify element with text "Opens in a new window":
    - is `hidden`
    - not `class="sr-only"`

## UI

https://github.com/user-attachments/assets/316dbed1-769e-4d12-a655-f147801fd036

https://github.com/user-attachments/assets/e131f8f5-447b-4372-8aa0-c35b1e492923
