### PR TITLE
fix(ckeditor): WYSWIYGs broken (because race condition)

### DIFF
--- a/taccsite_cms/_settings/djangocms_plugins.py
+++ b/taccsite_cms/_settings/djangocms_plugins.py
@@ -17,6 +17,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 
 CKEDITOR_SETTINGS = {
     'autoParagraph': False,
+    'customConfig': '/static/js/addons/ckeditor.config.js',
     'stylesSet': 'default:/static/js/addons/ckeditor.wysiwyg.js',
     'contentsCss': ['/static/djangocms_text_ckeditor/ckeditor/contents.css'],
     'extraPlugins': 'pastefromgdocs',

--- a/taccsite_cms/static/js/addons/ckeditor.config.js
+++ b/taccsite_cms/static/js/addons/ckeditor.config.js
@@ -1,0 +1,8 @@
+/* Register external plugins before CKEditor resolves extraPlugins */
+/* https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-customConfig */
+
+CKEDITOR.plugins.addExternal(
+  'pastefromgdocs',
+  'https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@4.21.0/plugins/pastefromgdocs/',
+  'plugin.js'
+);

--- a/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
+++ b/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
@@ -1,12 +1,6 @@
 /* Alter ckeditor/styles.js to match our own wants */
 /* https://github.com/django-cms/djangocms-text-ckeditor/blob/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor/styles.js */
 
-CKEDITOR.plugins.addExternal(
-  'pastefromgdocs',
-  'https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@4.21.0/plugins/pastefromgdocs/',
-  'plugin.js'
-);
-
 /* Convert inline bold/italic styles to semantic tags on paste,
    because the site strips inline styles from saved content,
    yet `pastefromgdocs` bold/italic are as inline styles. */


### PR DESCRIPTION
## Overview

Fixes CKEditor failing to open on remote servers after #1161.

The `pastefromgdocs` plugin registered via `extraPlugins` was returning 404 because `addExternal` (which redirects CKEditor to the CDN) was placed in the `stylesSet` file. That file loads during editor initialization, after `extraPlugins` are already resolved — so the redirect never took effect on prod/pre-prod.

Moving `addExternal` to a dedicated `customConfig` file fixes this: CKEditor loads `customConfig` first, before plugin resolution.

## Related

- fixes #1161 regression

## Changes

- **added** `ckeditor.config.js` — new CKEditor `customConfig` file; holds `addExternal` for CDN plugin
- **updated** `djangocms_plugins.py` — register `customConfig`
- **deleted** `addExternal` from `ckeditor.wysiwyg.js` (wrong timing; now in config file)

## Testing

1. Deploy to pre-prod.
2. Open any page in edit mode and open a text plugin (WYSIWYG).
3. Verify CKEditor opens without console errors about `pastefromgdocs`.
4. Paste content from Google Docs and verify bold/italic paste behavior still works.

## UI

https://github.com/user-attachments/assets/6359151f-b7d4-419d-a48e-36a076499e8e

---

Made with [Cursor](https://cursor.com)