### PR TITLE
refactor(ckeditor): move paste handler code

### DIFF
--- a/taccsite_cms/_settings/djangocms_plugins.py
+++ b/taccsite_cms/_settings/djangocms_plugins.py
@@ -17,6 +17,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 
 CKEDITOR_SETTINGS = {
     'autoParagraph': False,
+    'customConfig': '/static/js/addons/ckeditor.config.js',
     'stylesSet': 'default:/static/js/addons/ckeditor.wysiwyg.js',
     'contentsCss': ['/static/djangocms_text_ckeditor/ckeditor/contents.css'],
     'extraPlugins': 'pastefromgdocs',

--- a/taccsite_cms/static/js/addons/ckeditor.config.js
+++ b/taccsite_cms/static/js/addons/ckeditor.config.js
@@ -6,3 +6,34 @@ CKEDITOR.plugins.addExternal(
   'https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@4.21.0/plugins/pastefromgdocs/',
   'plugin.js'
 );
+
+/* Convert inline bold/italic styles to semantic tags on paste,
+   because the site strips inline styles from saved content,
+   yet `pastefromgdocs` bold/italic are as inline styles. */
+CKEDITOR.on('instanceReady', function(ev) {
+  ev.editor.on('paste', function(e) {
+    var parser = new DOMParser();
+    var doc = parser.parseFromString(e.data.dataValue, 'text/html');
+
+    doc.querySelectorAll('span').forEach(function(span) {
+      var fw = span.style.fontWeight;
+      var fs = span.style.fontStyle;
+      var replacement;
+
+      if (fw === 'bold' || fw === '700') {
+        replacement = doc.createElement('strong');
+      } else if (fs === 'italic') {
+        replacement = doc.createElement('em');
+      }
+
+      if (replacement) {
+        while (span.firstChild) replacement.appendChild(span.firstChild);
+        span.parentNode.replaceChild(replacement, span);
+      }
+    });
+
+    e.data.dataValue = doc.body.innerHTML;
+  /* Priority 4 runs after `pastetools` (priority 3); we must run after it
+     because it re-reads original clipboard data and overwrites dataValue. */
+  }, null, null, 4);
+});

--- a/taccsite_cms/static/js/addons/ckeditor.config.js
+++ b/taccsite_cms/static/js/addons/ckeditor.config.js
@@ -1,0 +1,8 @@
+/* Register external plugins before CKEditor resolves extraPlugins */
+/* https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-customConfig */
+
+CKEDITOR.plugins.addExternal(
+  'pastefromgdocs',
+  'https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@4.21.0/plugins/pastefromgdocs/',
+  'plugin.js'
+);

--- a/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
+++ b/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
@@ -1,12 +1,6 @@
 /* Alter ckeditor/styles.js to match our own wants */
 /* https://github.com/django-cms/djangocms-text-ckeditor/blob/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor/styles.js */
 
-CKEDITOR.plugins.addExternal(
-  'pastefromgdocs',
-  'https://cdn.jsdelivr.net/gh/ckeditor/ckeditor4@4.21.0/plugins/pastefromgdocs/',
-  'plugin.js'
-);
-
 /* Convert inline bold/italic styles to semantic tags on paste,
    because the site strips inline styles from saved content,
    yet `pastefromgdocs` bold/italic are as inline styles. */

--- a/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
+++ b/taccsite_cms/static/js/addons/ckeditor.wysiwyg.js
@@ -1,37 +1,6 @@
 /* Alter ckeditor/styles.js to match our own wants */
 /* https://github.com/django-cms/djangocms-text-ckeditor/blob/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/ckeditor/styles.js */
 
-/* Convert inline bold/italic styles to semantic tags on paste,
-   because the site strips inline styles from saved content,
-   yet `pastefromgdocs` bold/italic are as inline styles. */
-CKEDITOR.on('instanceReady', function(ev) {
-  ev.editor.on('paste', function(e) {
-    var parser = new DOMParser();
-    var doc = parser.parseFromString(e.data.dataValue, 'text/html');
-
-    doc.querySelectorAll('span').forEach(function(span) {
-      var fw = span.style.fontWeight;
-      var fs = span.style.fontStyle;
-      var replacement;
-
-      if (fw === 'bold' || fw === '700') {
-        replacement = doc.createElement('strong');
-      } else if (fs === 'italic') {
-        replacement = doc.createElement('em');
-      }
-
-      if (replacement) {
-        while (span.firstChild) replacement.appendChild(span.firstChild);
-        span.parentNode.replaceChild(replacement, span);
-      }
-    });
-
-    e.data.dataValue = doc.body.innerHTML;
-  /* Priority 4 runs after `pastetools` (priority 3); we must run after it
-     because it re-reads original clipboard data and overwrites dataValue. */
-  }, null, null, 4);
-});
-
 CKEDITOR.stylesSet.add( 'default', [
 
 	/* Block styles */


### PR DESCRIPTION
## Overview

Moves the Google Docs paste handler (bold/italic span → `<strong>`/`<em>`) from `ckeditor.wysiwyg.js` into `ckeditor.config.js`. The wysiwyg file is for style definitions only; JS behavior belongs in the config file.

## Related

- follow-up to #1164

## Changes

- **moved** paste handler from `ckeditor.wysiwyg.js` to `ckeditor.config.js`

## Testing

1. Deploy with #1164 merged.
2. Open a text plugin (WYSIWYG) in edit mode.
3. Paste content from Google Docs with bold and italic text.
4. Verify bold renders as `<strong>` and italic as `<em>`.

## UI

https://github.com/user-attachments/assets/73825a6e-6a48-4ddf-b951-c6f96cd168e5

---

Made with [Cursor](https://cursor.com)