### PR TITLE
fix: empty article visual is visible when editing

### DIFF
--- a/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/tools/x-news.css
@@ -378,8 +378,11 @@
 /* Media */
 
 @define-mixin news-article-page__media {
-  /* To not show empty block (which might have margin) */
-  &:empty {
+  /* To not show invisible content that might have margin: */
+  /* - empty element */
+  &:empty,
+  /* - element with empty placeholder */
+  &:has(.cms-placeholder:first-child:empty) {
     display: none;
   }
 }


### PR DESCRIPTION
## Overview

Integrate tested bandaid from https://github.com/TACC/Core-CMS-Custom/commit/af34eeeb.

If user is editing a news article that has no content in media placeholder for an article, the margin of the parent element has unwanted margin. (The parent element is visible, because it has CMS-generated markup, thus has content, so is not hidden by existing CSS.)

## Related

- integrates https://github.com/TACC/Core-CMS-Custom/commit/af34eeeb

## Changes

- **added** editor-specific selector to existing `display: none` rule

## Testing

1. Have a CMS with news.
2. News config allows post and media content (default)
3. Article has no image.
4. User is **both** logged in **and** in `?edit` mode.
5. Verify `.blog-visual` is hidden (`display: none`).

## UI

<details open><summary>While Editing</summary>

| Before | After |
| - | - |
| <img width="900" height="470" alt="editing, before" src="https://github.com/user-attachments/assets/aeced60f-90c8-48fe-b432-ac731492e5c6" /> | <img width="900" height="470" alt="editing, after" src="https://github.com/user-attachments/assets/915beb3d-569a-4cee-9335-f9f93e2dc6be" /> |

</details>

<details><summary>Not Editing (Unchanged)</summary>

| Before & After |
| - |
| <img width="900" height="470" alt="not editing" src="https://github.com/user-attachments/assets/02d24464-c4b2-420a-ae75-1e2757117138" /> |

</details>