### PR TITLE
docs(test-releases): v4.40.0-rc6 smoke tests

### DIFF
--- a/docs/test-releases/v4.40.0.md
+++ b/docs/test-releases/v4.40.0.md
@@ -1,4 +1,4 @@
-# [v4.40.0-rc5](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc5)
+# [v4.40.0-rc6](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc6)
 
 ## Standard Features
 
@@ -12,11 +12,76 @@
 1. Log in.
 2. Open a page with `?edit`; open a Text plugin.
 3. Confirm CKEditor loads:
-    - WYSIWYG editor is **not** blank
+  - WYSIWYG editor is **not** blank
     - **no** Console errors about a paste plugin
 4. In Google Docs, have a paragraph of bold and italic and normal text.
 5. Copy/Paste that paragraph from Google Docs to the CMS WYSIWYG editor.
 6. Confirm formatting is selective i.e. **not** all bold.
+
+### Bootstrap Heading Utility Classes
+
+**Tests:** heading utility classes (`.h1`–`.h6`) ([v4.40.0-rc6](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc6)).
+
+1. Log in.
+2. Open a page with `?edit`.
+3. Add or edit a Text plugin.
+4. Switch to source view.
+5. Add e.g. `<p class="h2">Heading utility test</p>` near a real `<h2>` for comparison.
+6. Save and refresh the page.
+7. Confirm the `.h2` paragraph matches CMS `h2` styling (size, weight, accent color).
+
+### Bootstrap 4 Alerts
+
+**Tests:** Bootstrap 4 alert styles ([v4.40.0-rc6](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc6)).
+
+1. Log in.
+2. Open a page with `?edit`.
+3. Add a Bootstrap 4 Alert plugin **or** a Text plugin.
+4. If using Text: switch to source view and add e.g.
+  ```html
+    <div class="alert alert-success" role="alert">Alert test</div>
+  ```
+5. Save and refresh the page.
+6. Confirm alert uses TACC/Core-Styles colors and padding (success/warning/danger variants if you add them).
+
+### ~~"Ask AI" Button~~
+
+> [!NOTE] **Skipped.** Test of [Core-Portal #1310](https://github.com/TACC/Core-Portal/pull/1310) tests this.
+
+**Tests:** "Ask AI" header button ([v4.40.0-rc6](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc6)).
+
+### Sortable Table
+
+> [!NOTE]
+> **Optional.** Skip if you are not smoke-testing sortable tables.
+
+**Tests:** sortable tables ([v4.40.0-rc6](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc6)).
+
+1. Log in.
+2. Open a page with `?edit`.
+3. Add a Text plugin.
+4. Switch to source view.
+5. Add e.g.
+  ```html
+    <table class="js-sortable">
+      <caption class="sr-only">Sortable table smoke test</caption>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th class="not-sortable">Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Beta</td><td>Row B</td></tr>
+        <tr><td>Alpha</td><td>Row A</td></tr>
+      </tbody>
+    </table>
+  ```
+6. Refresh the page after you add or change content (so delayed scripts enhance the updated HTML).
+7. Confirm sortable column headers on `Name` expose sort controls (not plain text).
+8. Confirm `Notes` does not sort.
+9. Click the `Name` header.
+10. Confirm row order updates (Alpha before Beta).
 
 ## Blog/News
 
@@ -27,41 +92,37 @@
 
 **Tests:** new setting ([v4.40.0-rc1](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc1)).
 
-0. Open News on a site that has news.[^2]
-1. Open a published news article that has a main image.
-2. Confirm layout looks normal.\
-    <sup>(i.e. image under heading (large or floated ot the right)</sup>
-3. With `PORTAL_BLOG_SHOW_AUTO_MAIN_IMAGE` **off** —
-
-    requires setting change **and** redeploy
-
+1. Open News on a site that has news.[^2]
+2. Open a published news article that has a main image.
+3. Confirm layout looks normal.\
+  (i.e. image under heading (large or floated ot the right)
+4. With `PORTAL_BLOG_SHOW_AUTO_MAIN_IMAGE` **off** —
+  requires setting change **and** redeploy
     — confirm **no** main image at top (unless added via Content).
-4. With `PORTAL_BLOG_SHOW_AUTO_MAIN_IMAGE` **on** —
-
-    requires setting change **and** redeploy
-
+5. With `PORTAL_BLOG_SHOW_AUTO_MAIN_IMAGE` **on** —
+  requires setting change **and** redeploy
     — confirm **only one** main image appears.
 
 ### Edit an Article That Has No Image
 
 **Tests:** empty article visual in edit mode ([v4.40.0-rc5](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc5)).
 
-0. Open News on a site that has news.[^2]
-1. While logged in, be in `?edit` mode.
-2. Create/Open a news article that has no image.
-3. Confirm the `class="blog-visual"` element is `display: none`.
+1. Open News on a site that has news.[^2]
+2. While logged in, be in `?edit` mode.
+3. Create/Open a news article that has no image.
+4. Confirm the `class="blog-visual"` element is `display: none`.
 
 ### Share Article on Social Media
 
 **Tests:** social media share buttons ([v4.40.0-rc1](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc1)).
 
-0. Open a site that has this feature[^1] e.g.
-  - [`artscivis`](https://pprd.artscivis.tacc.utexas.edu)
-  - [`craftlab`](https://pprd.craftlab.tacc.utexas.edu)
-  - ~~[`texascale`](https://pprd.texascale.tacc.utexas.edu)~~ (not being updated yet)
-  - [`txospo`](https://pprd.txospo.tacc.utexas.edu)
-1. Open a news article.
-2. Confirm share links render ([default platforms](https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/settings/settings.py#L294))
+1. Open a site that has this feature[^1] e.g.
+  - `[artscivis](https://pprd.artscivis.tacc.utexas.edu)`
+  - `[craftlab](https://pprd.craftlab.tacc.utexas.edu)`
+  - ~~`[texascale](https://pprd.texascale.tacc.utexas.edu)`~~ (not being updated yet)
+  - `[txospo](https://pprd.txospo.tacc.utexas.edu)`
+2. Open a news article.
+3. Confirm share links render ([default platforms](https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/settings/settings.py#L294))
 
 [^1]: Sites that, in [Core-Portal-Deployments](https://github.com/TACC/Core-Portal-Deployments), sets `BLOG_` settings but **not** `PORTAL_SOCIAL_SHARE_PLATFORMS`.
 
@@ -70,20 +131,18 @@
 **Tests:** external article snippets ([v4.40.0-rc2](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc2)).
 
 > [!TIP]
-> Pre-tested on https://pprd.txospo.tacc.utexas.edu. Testing removed.
+> Pre-tested on [https://pprd.txospo.tacc.utexas.edu](https://pprd.txospo.tacc.utexas.edu). Testing removed.
 
-0. Open News on a site that has news.[^2]
-1. Save the URL of any of the articles that open in same tab.
-2. Add a temporary snippet to footer with:
-
-    ```html
+1. Open News on a site that has news.[^2]
+2. Save the URL of any of the articles that open in same tab.
+3. Add a temporary snippet to footer with:
+  ```html
     <script type="module" src="/static/site_cms/js/scripts/openAllArticlesAsExternal.js"></script>
     <script type="module" src="/static/site_cms/js/scripts/redirectAllArticlesAsExternal.js"></script>
-    ```
-
-3. Click an article link.
-4. Confirm external URL opens in a new tab.
-5. Visit URL from step 2.
-6. Confirm redirect to external URL.
+  ```
+4. Click an article link.
+5. Confirm external URL opens in a new tab.
+6. Visit URL from step 2.
+7. Confirm redirect to external URL.
 
 [^2]: Sites that have a "News" > "Latest News" menu item (or, for TXOSPO-only, "Newsletter") (these sites, in [Core-Portal-Deployments](https://github.com/TACC/Core-Portal-Deployments), sets `BLOG_` settings.

--- a/docs/test-releases/v4.40.0.md
+++ b/docs/test-releases/v4.40.0.md
@@ -10,13 +10,14 @@
 **Tests:** Google Docs paste ([v4.40.0-rc2](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc2)), WYSIWYG load fix ([v4.40.0-rc4](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc4)).
 
 1. Log in.
-2. Open a page with `?edit`; open a Text plugin.
-3. Confirm CKEditor loads:
+2. Open a page with `?edit`
+3. Add/Edit a Text plugin.
+4. Confirm CKEditor loads:
   - WYSIWYG editor is **not** blank
     - **no** Console errors about a paste plugin
-4. In Google Docs, have a paragraph of bold and italic and normal text.
-5. Copy/Paste that paragraph from Google Docs to the CMS WYSIWYG editor.
-6. Confirm formatting is selective i.e. **not** all bold.
+5. In Google Docs, have a paragraph of bold and italic and normal text.
+6. Copy/Paste that paragraph from Google Docs to the CMS WYSIWYG editor.
+7. Confirm formatting is selective i.e. **not** all bold.
 
 ### Bootstrap Heading Utility Classes
 
@@ -24,11 +25,10 @@
 
 1. Log in.
 2. Open a page with `?edit`.
-3. Add or edit a Text plugin.
-4. Switch to source view.
-5. Add e.g. `<p class="h2">Heading utility test</p>` near a real `<h2>` for comparison.
-6. Save and refresh the page.
-7. Confirm the `.h2` paragraph matches CMS `h2` styling (size, weight, accent color).
+3. Add/Edit a Text plugin.
+4. Switch to "Source" view.
+5. Add `<p class="h2">Heading Utility Test</p>` near a real `<h2>` for comparison.
+6. Confirm `.h2` paragraph matches CMS `h2` styling.
 
 ### Bootstrap 4 Alerts
 
@@ -61,13 +61,12 @@
 2. Open a page with `?edit`.
 3. Add a Text plugin.
 4. Switch to source view.
-5. Add e.g.
+5. Add something like
   ```html
     <table class="js-sortable">
-      <caption class="sr-only">Sortable table smoke test</caption>
       <thead>
         <tr>
-          <th>Name</th>
+          <th><abbr title="Longer Text for Name">Name</abbr></th>
           <th class="not-sortable">Notes</th>
         </tr>
       </thead>
@@ -77,11 +76,13 @@
       </tbody>
     </table>
   ```
-6. Refresh the page after you add or change content (so delayed scripts enhance the updated HTML).
+6. Refresh the page after you add or change content.  
+    <sup>(So delayed scripts enhance the updated HTML.)</sup>
 7. Confirm sortable column headers on `Name` expose sort controls (not plain text).
 8. Confirm `Notes` does not sort.
 9. Click the `Name` header.
-10. Confirm row order updates (Alpha before Beta).
+10. Confirm row order updates ("Alpha" before "Beta").
+11. Confirm `Name` header still has an `<abbr title="…">`.
 
 ## Blog/News
 
@@ -145,4 +146,4 @@
 6. Visit URL from step 2.
 7. Confirm redirect to external URL.
 
-[^2]: Sites that have a "News" > "Latest News" menu item (or, for TXOSPO-only, "Newsletter") (these sites, in [Core-Portal-Deployments](https://github.com/TACC/Core-Portal-Deployments), sets `BLOG_` settings.
+[^2]: Sites that have a "News" > "Latest News" menu item (or, for TXOSPO-only, "Newsletter"). Sites whose [Core-Portal-Deployments](https://github.com/TACC/Core-Portal-Deployments) CMS settings include `BLOG_*`.


### PR DESCRIPTION
## Overview

Updates the v4.40.0 smoke-test checklist for rc6 (Core-Styles v2.57.0 and sortable tables).

## Related

- [v4.40.0-rc6](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc6)
- [Core-Styles v2.57.0](https://github.com/TACC/Core-Styles/releases/tag/v2.57.0)
- [Core-Portal #1310](https://github.com/TACC/Core-Portal/pull/1310) ("Ask AI" button — skipped in CMS-only pass)

## Changes

- **updated** `docs/test-releases/v4.40.0.md` for rc6
- **added** smoke steps for heading utilities, Bootstrap 4 alerts, optional sortable table
- **added** skipped "Ask AI" section with Portal PR pointer
- **updated** blog/news step numbering and formatting from prior edits

## Testing

1. Read `docs/test-releases/v4.40.0.md` on the branch.

## UI

N/A (documentation only).


Made with [Cursor](https://cursor.com)