### PR TITLE
docs(test-releases): add v4.40.0 TOC sub-headings

### DIFF
--- a/docs/test-releases/v4.40.0.md
+++ b/docs/test-releases/v4.40.0.md
@@ -1,7 +1,16 @@
 # [v4.40.0-rc6](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc6)
 
 * [Standard Features](#standard-features)
+  * [Edit Text](#edit-text)
+  * [Bootstrap Heading Utility Classes](#bootstrap-heading-utility-classes)
+  * [Bootstrap 4 Alerts](#bootstrap-4-alerts)
+  * [~~"Ask AI" Button~~](#ask-ai-button)
+  * [Sortable Table](#sortable-table)
 * [Blog/News Features](#blognews-features)
+  * [Automatic Main Article Image](#automatic-main-article-image)
+  * [Edit an Article That Has No Image](#edit-an-article-that-has-no-image)
+  * [Share Article on Social Media](#share-article-on-social-media)
+  * [Force All Articles to Open in New Tab](#force-all-articles-to-open-in-new-tab)
 
 ## Standard Features
 


### PR DESCRIPTION
## Overview

The v4.40.0 test release checklist listed only top-level sections in its table of contents. Nested links now point to each `###` test section so reviewers can jump straight to a scenario.

## Changes

- **updated** `docs/test-releases/v4.40.0.md` table of contents with Standard Features and Blog/News sub-headings

## Testing

1. Open `docs/test-releases/v4.40.0.md` on GitHub (or in preview).
2. Click each new TOC link and confirm it scrolls to the matching `###` heading.

## UI

[/docs/test-releases/v4.40.0.md](https://github.com/TACC/Core-CMS/blob/d4b213109cdad4c904cab351b12f9b8426182f26/docs/test-releases/v4.40.0.md)

---

Made with [Cursor](https://cursor.com)