### PR TITLE
fix(ckeditor): preserve summary and aria-* in Text plugin HTML

### DIFF
--- a/taccsite_cms/_settings/djangocms_plugins.py
+++ b/taccsite_cms/_settings/djangocms_plugins.py
@@ -23,6 +23,12 @@ CKEDITOR_SETTINGS = {
     'extraPlugins': 'pastefromgdocs',
 }
 
+# To support what html5lib does not
+TEXT_ADDITIONAL_TAGS = ('summary',)
+ALLOW_TOKEN_PARSERS = (
+    'taccsite_cms.djangocms_text_ckeditor_attribute_parsers.AriaAttributeParser',
+)
+
 ########################
 # DJANGOCMS_PICTURE
 # https://github.com/django-cms/djangocms-picture

--- a/taccsite_cms/djangocms_text_ckeditor_attribute_parsers.py
+++ b/taccsite_cms/djangocms_text_ckeditor_attribute_parsers.py
@@ -1,0 +1,10 @@
+"""Allowlists for djangocms-text-ckeditor HTML sanitization."""
+
+from djangocms_text_ckeditor.sanitizer import AllowTokenParser
+
+
+class AriaAttributeParser(AllowTokenParser):
+    """Allow WAI-ARIA attributes (html5lib allowlist omits aria-* by default)."""
+
+    def parse(self, attribute, val):
+        return attribute.startswith('aria-')

--- a/taccsite_cms/static/js/addons/ckeditor.config.js
+++ b/taccsite_cms/static/js/addons/ckeditor.config.js
@@ -7,10 +7,18 @@ CKEDITOR.plugins.addExternal(
   'plugin.js'
 );
 
-/* Convert inline bold/italic styles to semantic tags on paste,
-   because the site strips inline styles from saved content,
-   yet `pastefromgdocs` bold/italic are as inline styles. */
 CKEDITOR.on('instanceReady', function(ev) {
+  var dtd = CKEDITOR.dtd;
+
+  // To support what html5lib does not
+  dtd.details = CKEDITOR.tools.extend({}, dtd.div, { summary: 1 });
+  dtd.summary = CKEDITOR.tools.extend({}, dtd.div, { summary: 0 });
+  dtd.$block['summary'] = 1;
+  dtd.$intermediate['summary'] = 1;
+
+  // To convert inline bold/italic styles to semantic tags on paste
+  // FAQ: `pastefromgdocs` bold/italic are as inline styles,
+  //      but the WYSIWYG strips inline styles from saved content
   ev.editor.on('paste', function(e) {
     var parser = new DOMParser();
     var doc = parser.parseFromString(e.data.dataValue, 'text/html');


### PR DESCRIPTION
## Overview

Text plugin saves were turning `<summary>` into escaped text and stripping `aria-*` because html5lib’s default allowlist includes `<details>` but not `<summary>` or WAI-ARIA attributes. This adds the minimum server and editor hooks so disclosure markup survives save and reload.

## Changes

- **added** configuration to allow `<summary>` for some aspect
- **added** configuration to allow `<summary>` for another aspect
- **added** configuration to support `aria-` attributes

## Testing

1. `make start` (or use running `core_cms`).
2. Log in, open a page with `?edit`, add or edit a Text plugin.
3. In Source, paste:
   ```html
   <details>
   <summary>Abstract</summary>
   <p aria-label="anything">Body text.</p>
   </details>
   ```
4. Save, reopen the plugin, open Source again.
5. Confirm `<summary>` is still a tag (not `&lt;summary&gt;`).
6. Confirm `aria-*` attributes remain.

## UI

https://github.com/user-attachments/assets/3f7c6deb-9c63-4931-a56a-0579feb2a306

https://github.com/user-attachments/assets/9d67287a-8417-447e-8446-2fca9edd4558

> [!TIP]
> I tested `aria-` too (and `class` and `id`), just didn't video that.