### PR TITLE
docs(agents): commit/PR conventions + CLAUDE.md auto-load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
 - [Architecture](#architecture)
+- [Commits](#commits)
 - [Pull Requests](#pull-requests)
 
 ## Architecture
@@ -66,6 +67,13 @@ As necessary for given task:
 
 See `README.md` for full setup instructions.
 
+## Commits
+
+- **Format:** `.gitmessage` (fallback: `~/.gitmessage`)
+
 ## Pull Requests
 
-Write skimmable, template-aligned PRs; reviewers can see the code diff for details.
+- **Title:** `.gitmessage` (fallback: `~/.gitmessage`)
+- **Description:** `.github/PULL_REQUEST_TEMPLATE.md`
+  - Be concise: plain language, simple sentences; reviewers find detail in the diff. Say what changed, then why (if it matters) — never how.
+  - When updating, first re-read the current description, because it may have been edited.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Overview

Agents writing commits and PRs here weren't reliably following conventions, because the guidance wasn't loaded automatically. This documents the conventions in `AGENTS.md` and adds a `CLAUDE.md` that auto-loads it.

## Changes

- **added** `CLAUDE.md` that imports `AGENTS.md` (`@AGENTS.md`)
    <sup>(because [Claude Code does not read `AGENTS.md` by default](https://github.com/anthropics/claude-code/issues/6235))
- **added** a `## Commits` section pointing at `.gitmessage`
- **updated** the `## Pull Requests` section with title/description sources and concise-writing rules
- **updated** the table of contents

## Testing

1. Open the repo in Claude Code in a new session.
2. Confirm the `AGENTS.md` commit/PR conventions are in context (loaded via the `CLAUDE.md` `@AGENTS.md` import).

## UI

<img width="900" height="509" alt="top" src="https://github.com/user-attachments/assets/5a014c90-57ca-4052-ae9b-22bb9431dc41" />
<img width="900" height="509" alt="end" src="https://github.com/user-attachments/assets/15062b70-75e1-4733-a629-938f9159f753" />