### PR TITLE
feat(picture): fall back to image default caption

### DIFF
--- a/taccsite_cms/templates/djangocms_picture/default/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/default/picture.html
@@ -28,7 +28,10 @@
 {# start render figure/figcaption #}
 {# TACC (support children as caption content): #}
 {# {% if instance.caption_text %} #}
-{% if instance.caption_text or instance.child_plugin_instances %}
+{# TACC (fall back to image default caption): #}
+{# {% if instance.caption_text or instance.child_plugin_instances %} #}
+{% if instance.caption_text or instance.child_plugin_instances or instance.picture.default_caption %}
+{# /TACC #}
     {# TACC (assign attributes to parent): #}
     {# <figure> #}
     <figure {{ instance.attributes_str }}>
@@ -60,7 +63,10 @@
     {# TACC (allow link to be conditional): #}
     {% block picture_attributes %}
     {# TACC (assign attributes to parent): #}
-    {% if not instance.caption_text and not picture_link and not instance.child_plugin_instances %}
+    {# TACC (fall back to image default caption): #}
+    {# {% if not instance.caption_text and not picture_link and not instance.child_plugin_instances %} #}
+    {% if not instance.caption_text and not instance.picture.default_caption and not picture_link and not instance.child_plugin_instances %}
+    {# /TACC #}
     {{ instance.attributes_str }}
     {% endif %}
     {# /TACC #}
@@ -71,11 +77,17 @@
 
 {# start render figure/figcaption #}
 {# {% if instance.caption_text %} #}
-{% if instance.caption_text or instance.child_plugin_instances %}
+{# TACC (fall back to image default caption): #}
+{# {% if instance.caption_text or instance.child_plugin_instances %} #}
+{% if instance.caption_text or instance.child_plugin_instances or instance.picture.default_caption %}
+{# /TACC #}
         {# TACC (support children as caption content): #}
         {# <figcaption>{{ instance.caption_text }}</figcaption> #}
         <figcaption>
-        {{ instance.caption_text }}
+        {# TACC (fall back to image default caption): #}
+        {# {{ instance.caption_text }} #}
+        {% if instance.caption_text %}{{ instance.caption_text }}{% elif instance.picture.default_caption and not instance.child_plugin_instances %}{{ instance.picture.default_caption }}{% endif %}
+        {# /TACC #}
         {% for plugin in instance.child_plugin_instances %}
             {% render_plugin plugin %}
         {% endfor %}

--- a/taccsite_cms/tests/djangocms_picture_default_caption.py
+++ b/taccsite_cms/tests/djangocms_picture_default_caption.py
@@ -1,0 +1,94 @@
+"""Tests for the TACC `default_caption` fallback in the Picture template.
+
+The override at
+``taccsite_cms/templates/djangocms_picture/default/picture.html`` falls back to
+the filer Image's ``default_caption`` for the ``<figcaption>`` when the editor
+provides no instance-specific caption content (neither ``caption_text`` nor
+child plugins), mirroring the existing ``default_alt_text`` fallback for ``alt``.
+"""
+
+from django.template.loader import get_template
+from django.test import SimpleTestCase
+
+
+class _FakeImage:
+    """Stand-in for a django-filer Image (``instance.picture``)."""
+
+    def __init__(self, default_alt_text='', default_caption=''):
+        self.default_alt_text = default_alt_text
+        self.default_caption = default_caption
+
+
+class _TruthyEmpty:
+    """Truthy container that iterates to nothing.
+
+    Lets the "child plugins are present" branches be exercised without invoking
+    the ``{% render_plugin %}`` machinery (which needs full CMS request context).
+    The template only checks truthiness of ``child_plugin_instances`` and then
+    iterates it; this is truthy yet yields no items, so the loop renders nothing.
+    """
+
+    def __bool__(self):
+        return True
+
+    def __len__(self):
+        return 1
+
+    def __iter__(self):
+        return iter(())
+
+
+class _FakePicture:
+    """Stand-in for a djangocms_picture Picture plugin instance."""
+
+    def __init__(self, caption_text='', children=None, default_caption='',
+                 default_alt_text='', attributes=None):
+        self.caption_text = caption_text
+        self.child_plugin_instances = children if children is not None else []
+        self.picture = _FakeImage(default_alt_text=default_alt_text,
+                                  default_caption=default_caption)
+        self.attributes = attributes or {}
+        self.attributes_str = ''
+        self.link_attributes_str = ''
+        self.link_target = ''
+        self.img_src = '/media/test.jpg'
+        self.width = None
+        self.height = None
+
+
+def _render(instance):
+    template = get_template('djangocms_picture/default/picture.html')
+    return template.render({
+        'instance': instance,
+        'picture_link': '',
+        'img_srcset_data': [],
+    })
+
+
+class DefaultCaptionFallbackTests(SimpleTestCase):
+    def test_default_caption_used_when_no_instance_caption(self):
+        """No caption_text and no children -> default_caption renders."""
+        html = _render(_FakePicture(default_caption='From the library'))
+        self.assertIn('<figure', html)
+        self.assertIn('<figcaption>', html)
+        self.assertIn('From the library', html)
+
+    def test_caption_text_overrides_default_caption(self):
+        """caption_text wins; default_caption is not shown."""
+        html = _render(_FakePicture(caption_text='Specific caption',
+                                    default_caption='Default caption'))
+        self.assertIn('Specific caption', html)
+        self.assertNotIn('Default caption', html)
+
+    def test_child_plugins_suppress_default_caption(self):
+        """Child plugins are instance-specific content; default is suppressed."""
+        html = _render(_FakePicture(default_caption='Default caption',
+                                    children=_TruthyEmpty()))
+        self.assertIn('<figure', html)
+        self.assertNotIn('Default caption', html)
+
+    def test_no_caption_no_default_no_figure(self):
+        """Nothing to caption -> no <figure>/<figcaption> (unchanged behavior)."""
+        html = _render(_FakePicture())
+        self.assertNotIn('<figure', html)
+        self.assertNotIn('<figcaption', html)


### PR DESCRIPTION
## Overview

A Picture plugin only showed a caption when the editor typed one into the plugin. This falls back to the filer Image's own default caption when no instance-specific caption is set, so a shared image carries its caption everywhere without re-entering it — matching how `alt` already falls back to the image's default alt text.

## Changes

- **added** a `default_caption` fallback in `picture.html`: the `<figure>`/`<figcaption>` now render the image's default caption when there is no `caption_text` and no child plugins
- **added** tests for the caption fallback (`taccsite_cms/tests/djangocms_picture_default_caption.py`)

## Testing

1. `make start`
2. In a filer Image, set a **Default caption**.
3. Add a Picture plugin using that image, leave its caption empty, and publish.
4. Verify the rendered `<figcaption>` shows the default caption.
5. Set the plugin's own caption text and verify it overrides the default.
6. Add a child plugin (no caption text) and verify the default caption is not shown.
7. `docker exec core_cms python manage.py test taccsite_cms.tests.djangocms_picture_default_caption --no-input`

## UI

https://github.com/user-attachments/assets/b29c9b77-efe7-4002-9f78-72ad0182fa19

## Notes

> [!TIP]
> I also tested instance caption (with a default) and instance caption (with no default); both resulted in the instance caption being added under image.