### PR TITLE
feat(gh-999): default Header logo form values on add

### DIFF
--- a/docs/gh-999-editable-header-plan.md
+++ b/docs/gh-999-editable-header-plan.md
@@ -21,6 +21,7 @@ Plan for [#999 Let CMS Admin Edit Header](https://github.com/TACC/Core-CMS/issue
 - **Render:** Standard Picture template at `{% static_placeholder "header-content" %}`.
 - **Empty placeholder:** `or` fallback [`header_logo_via_settings.html`](taccsite_cms/templates/header_logo_via_settings.html) (`LOGO` / `PORTAL_LOGO`).
 - **Branding images (PR 3):** nested Pictures under TACC Header Branding — not top-level.
+- **Follow-up:** Match `PORTAL_LOGO` / `header_logo_via_settings.html` defaults to Header logo form defaults (margin, height, link) and Core-Styles — deferred until willing to test Core-Styles.
 
 ## PR stack
 

--- a/taccsite_cms/contrib/taccsite_header_logo/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_header_logo/cms_plugins.py
@@ -4,6 +4,8 @@ from django.utils.translation import gettext_lazy as _
 from djangocms_picture.cms_plugins import PicturePlugin
 from djangocms_picture.models import Picture
 
+from .forms import HeaderLogoForm
+
 HEADER_LOGO_ELEMENT_ID = 'header-logo'
 
 
@@ -15,6 +17,7 @@ class HeaderLogoPlugin(PicturePlugin):
     Full Picture plugin; default id="header-logo" when not set in Attributes.
     """
     model = Picture
+    form = HeaderLogoForm
     module = _('TACC Header')
     name = _('Header logo')
 

--- a/taccsite_cms/contrib/taccsite_header_logo/forms.py
+++ b/taccsite_cms/contrib/taccsite_header_logo/forms.py
@@ -1,0 +1,34 @@
+from cms.models import Page
+from django.contrib.sites.models import Site
+from djangocms_picture.forms import PictureForm
+
+
+def default_home_page():
+    site = Site.objects.get_current()
+    return Page.objects.filter(is_home=True, node__site=site).first()
+
+
+class HeaderLogoForm(PictureForm):
+    """
+    Defaults for new Header logo plugins only (admin add form).
+
+    With a link, TACC default picture.html puts Attributes (e.g. class mr-5) on
+    the <a>, not the <img>.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            return
+
+        home = default_home_page()
+        if home is not None:
+            self.initial.setdefault('link_page', home.pk)
+
+        self.initial.setdefault('height', 50)
+        self.initial.setdefault('use_no_cropping', True)
+        self.initial.setdefault('use_automatic_scaling', False)
+
+        attributes = dict(self.initial.get('attributes') or {})
+        attributes.setdefault('class', 'mr-5')
+        self.initial['attributes'] = attributes


### PR DESCRIPTION
## Overview

Pre-fills the Header logo plugin admin form when adding a new instance so editors see home link, height, original-size cropping, and margin defaults (PR #1083 to-do).

## Related

- supports #1083
- supports #999

## Changes

- **added** `HeaderLogoForm` with add-only defaults
- **updated** `HeaderLogoPlugin` to use the form
- **updated** GH-999 plan follow-up note (settings / Core-Styles parity deferred)

## Testing

1. Delete Header logo from `header-content` if present.
2. Add **TACC Header → Header logo**; confirm form shows home page link, height 50, use original image, Attributes class `mr-5`.
3. Save, publish; confirm logo renders with link and expected markup.
4. Edit existing plugin; confirm defaults are not re-applied.

## UI

https://github.com/user-attachments/assets/1679b110-7d9c-4dc4-88f6-aca81a74d52c

https://github.com/user-attachments/assets/37265f24-6808-44cb-b8f0-ff1f4762a67d