### PR TITLE
fix(gh-999): align header logo markup with settings path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.57.0"
+        "@tacc/core-styles": "github:TACC/core-styles#fix/s-header-navbar-brand-flex"
       },
       "engines": {
         "node": ">=20",
@@ -1511,8 +1511,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.57.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.0.tgz",
-      "integrity": "sha512-MRYts9CdayXrlJfLPRO1fBiWIicNFFoUs4h0lUbcsl8PAT9/YZU3bjY1TzcCe36OUUxi1ENjciU348LTa7EXcQ==",
+      "resolved": "git+ssh://git@github.com/TACC/core-styles.git#349f09976814315ff753ef7fb5c87acce9cfe862",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5747,10 +5746,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.57.0",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.0.tgz",
-      "integrity": "sha512-MRYts9CdayXrlJfLPRO1fBiWIicNFFoUs4h0lUbcsl8PAT9/YZU3bjY1TzcCe36OUUxi1ENjciU348LTa7EXcQ==",
+      "version": "git+ssh://git@github.com/TACC/core-styles.git#349f09976814315ff753ef7fb5c87acce9cfe862",
       "dev": true,
+      "from": "@tacc/core-styles@github:TACC/core-styles#fix/s-header-navbar-brand-flex",
       "requires": {}
     },
     "ansi-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "github:TACC/core-styles#fix/s-header-navbar-brand-flex"
+        "@tacc/core-styles": "github:TACC/core-styles#850bb31"
       },
       "engines": {
         "node": ">=20",
@@ -1511,7 +1511,7 @@
     },
     "node_modules/@tacc/core-styles": {
       "version": "2.57.0",
-      "resolved": "git+ssh://git@github.com/TACC/core-styles.git#349f09976814315ff753ef7fb5c87acce9cfe862",
+      "resolved": "git+ssh://git@github.com/TACC/core-styles.git#850bb31b2c4fda66c649a7f764bd811c49afab40",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5746,9 +5746,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "git+ssh://git@github.com/TACC/core-styles.git#349f09976814315ff753ef7fb5c87acce9cfe862",
+      "version": "git+ssh://git@github.com/TACC/core-styles.git#850bb31b2c4fda66c649a7f764bd811c49afab40",
       "dev": true,
-      "from": "@tacc/core-styles@github:TACC/core-styles#fix/s-header-navbar-brand-flex",
+      "from": "@tacc/core-styles@github:TACC/core-styles#850bb31",
       "requires": {}
     },
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.57.0"
+    "@tacc/core-styles": "github:TACC/core-styles#fix/s-header-navbar-brand-flex"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "github:TACC/core-styles#fix/s-header-navbar-brand-flex"
+    "@tacc/core-styles": "github:TACC/core-styles#850bb31"
   }
 }

--- a/taccsite_cms/_settings/djangocms_plugins.py
+++ b/taccsite_cms/_settings/djangocms_plugins.py
@@ -41,6 +41,7 @@ DJANGOCMS_PICTURE_ALIGN = [
 ]
 DJANGOCMS_PICTURE_TEMPLATES = [
     ('no_link_to_ext_image', _('Do not link to external image')),
+    ('portal_logo', _('Portal logo')),
 ]
 
 ########################

--- a/taccsite_cms/contrib/taccsite_header_logo/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_header_logo/cms_plugins.py
@@ -6,15 +6,13 @@ from djangocms_picture.models import Picture
 
 from .forms import HeaderLogoForm
 
-HEADER_LOGO_ELEMENT_ID = 'header-logo'
+HEADER_LOGO_LINK_CLASS = 'navbar-brand'
 
 
 @plugin_pool.register_plugin
 class HeaderLogoPlugin(PicturePlugin):
     """
-    Header > "Header logo" plugin
-
-    Full Picture plugin; default id="header-logo" when not set in Attributes.
+    Header > "Header logo" (Picture) plugin
     """
     model = Picture
     form = HeaderLogoForm
@@ -24,6 +22,9 @@ class HeaderLogoPlugin(PicturePlugin):
     def render(self, context, instance, placeholder):
         if not instance.attributes:
             instance.attributes = {}
-        if 'id' not in instance.attributes:
-            instance.attributes['id'] = HEADER_LOGO_ELEMENT_ID
+
+        # To add required attributes
+        existing_class = instance.attributes.get('class', '')
+        instance.attributes['class'] = f'{HEADER_LOGO_LINK_CLASS} {existing_class}'.strip()
+
         return super().render(context, instance, placeholder)

--- a/taccsite_cms/contrib/taccsite_header_logo/forms.py
+++ b/taccsite_cms/contrib/taccsite_header_logo/forms.py
@@ -1,4 +1,5 @@
 from cms.models import Page
+from django.conf import settings
 from django.contrib.sites.models import Site
 from djangocms_picture.forms import PictureForm
 
@@ -14,8 +15,7 @@ class HeaderLogoForm(PictureForm):
     """
     Defaults for new Header logo plugins only (admin add form).
 
-    Uses Portal logo picture template (portal-logo on img). Attributes class
-    applies to the link when a link is set (see default picture.html).
+    On a TACC/Core-Portal instance, defaults to Portal logo picture template.
     """
 
     def __init__(self, *args, **kwargs):
@@ -23,7 +23,8 @@ class HeaderLogoForm(PictureForm):
         if self.instance.pk:
             return
 
-        self.initial.setdefault('template', HEADER_LOGO_PICTURE_TEMPLATE)
+        if settings.PORTAL_IS_TACC_CORE_PORTAL:
+            self.initial.setdefault('template', HEADER_LOGO_PICTURE_TEMPLATE)
 
         home = default_home_page()
         if home is not None:
@@ -31,7 +32,3 @@ class HeaderLogoForm(PictureForm):
 
         self.initial.setdefault('use_no_cropping', True)
         self.initial.setdefault('use_automatic_scaling', False)
-
-        attributes = dict(self.initial.get('attributes') or {})
-        attributes.setdefault('class', 'mr-5')
-        self.initial['attributes'] = attributes

--- a/taccsite_cms/contrib/taccsite_header_logo/forms.py
+++ b/taccsite_cms/contrib/taccsite_header_logo/forms.py
@@ -2,6 +2,8 @@ from cms.models import Page
 from django.contrib.sites.models import Site
 from djangocms_picture.forms import PictureForm
 
+HEADER_LOGO_PICTURE_TEMPLATE = 'portal_logo'
+
 
 def default_home_page():
     site = Site.objects.get_current()
@@ -11,12 +13,17 @@ def default_home_page():
 class HeaderLogoForm(PictureForm):
     """
     Defaults for new Header logo plugins only (admin add form).
+
+    Uses Portal logo picture template (portal-logo on img). Attributes class
+    applies to the link when a link is set (see default picture.html).
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance.pk:
             return
+
+        self.initial.setdefault('template', HEADER_LOGO_PICTURE_TEMPLATE)
 
         home = default_home_page()
         if home is not None:
@@ -25,3 +32,6 @@ class HeaderLogoForm(PictureForm):
         self.initial.setdefault('use_no_cropping', True)
         self.initial.setdefault('use_automatic_scaling', False)
 
+        attributes = dict(self.initial.get('attributes') or {})
+        attributes.setdefault('class', 'mr-5')
+        self.initial['attributes'] = attributes

--- a/taccsite_cms/contrib/taccsite_header_logo/forms.py
+++ b/taccsite_cms/contrib/taccsite_header_logo/forms.py
@@ -11,9 +11,6 @@ def default_home_page():
 class HeaderLogoForm(PictureForm):
     """
     Defaults for new Header logo plugins only (admin add form).
-
-    With a link, TACC default picture.html puts Attributes (e.g. class mr-5) on
-    the <a>, not the <img>.
     """
 
     def __init__(self, *args, **kwargs):
@@ -25,10 +22,6 @@ class HeaderLogoForm(PictureForm):
         if home is not None:
             self.initial.setdefault('link_page', home.pk)
 
-        self.initial.setdefault('height', 50)
         self.initial.setdefault('use_no_cropping', True)
         self.initial.setdefault('use_automatic_scaling', False)
 
-        attributes = dict(self.initial.get('attributes') or {})
-        attributes.setdefault('class', 'mr-5')
-        self.initial['attributes'] = attributes

--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -57,7 +57,7 @@
   {% render_block "css" %}
 </head>
 
-<body class="{% block page_type_class %}{% endblock page_type_class %}">
+<body class="{% block page_type_class %}{% endblock page_type_class %}{% if settings.PORTAL_IS_TACC_CORE_PORTAL %}has-portal{% endif %}">
   {% cms_toolbar %}
 
   {% block header %}

--- a/taccsite_cms/templates/base.html
+++ b/taccsite_cms/templates/base.html
@@ -57,7 +57,7 @@
   {% render_block "css" %}
 </head>
 
-<body class="{% block page_type_class %}{% endblock page_type_class %}{% if settings.PORTAL_IS_TACC_CORE_PORTAL %}has-portal{% endif %}">
+<body class="{% block page_type_class %}{% endblock page_type_class %}">
   {% cms_toolbar %}
 
   {% block header %}

--- a/taccsite_cms/templates/djangocms_picture/default/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/default/picture.html
@@ -66,6 +66,9 @@
     {# /TACC #}
     {% endblock %}
     {# /TACC #}
+    {# TACC (allow attributes to be force-added to <img>): #}
+    {% block picture_attributes_img %}{% endblock %}
+    {# /TACC #}
 >
 {% endlocalize %}
 

--- a/taccsite_cms/templates/djangocms_picture/portal_logo/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/portal_logo/picture.html
@@ -1,0 +1,2 @@
+{% extends "djangocms_picture/default/picture.html" %}
+{% block picture_attributes_img %}class="portal-logo"{% endblock %}

--- a/taccsite_cms/templates/header_logo_via_settings.html
+++ b/taccsite_cms/templates/header_logo_via_settings.html
@@ -1,4 +1,3 @@
-{# @var className #}
 {% load static custom_portal_settings %}
 
 {% if settings.LOGO %}
@@ -7,7 +6,7 @@
 {% with settings.LOGO as logo %}
   {% with filename=logo|index:1 selectors=logo|index:2 targeturl=logo|index:3 targettype=logo|index:4 accessibility=logo|index:5 corstype=logo|index:6 visibility=logo|index:7 %}
     {% if visibility == "True" %}
-    <a id="header-logo" class="navbar-brand {{className}}" href="{{ targeturl }}" target="{{ targettype }}">
+    <a class="navbar-brand" href="{{ targeturl }}" target="{{ targettype }}">
       <img class="portal-logo {{ selectors }}" src="{% static filename %}" crossorigin="{{ corstype }}" alt="{{ accessibility }}" />
     </a>
     {% endif %}
@@ -19,8 +18,7 @@
 {# via CMS setting (e.g. CMS developer sets logo image) #}
 {% with settings.PORTAL_LOGO as logo %}
   <a
-    id="header-logo"
-    class="navbar-brand {{className}}"
+    class="navbar-brand"
     href="{{ logo.link_href }}"
     {% if logo.link_target %}
     target="{{ logo.link_target }}"


### PR DESCRIPTION
## Overview

Header logo plugin and settings fallback match Core-Portal link/img classes. Portal logo picture template puts `portal-logo` on the image (even if a link is set).

## Related

- supports #1083
- supports #999
- requires https://github.com/TACC/Core-Styles/pull/648
- requires https://github.com/TACC/Core-Styles/pull/649

## Changes

- **updated** header logo plugin render and settings fallback markup
- **added** Portal logo picture template and `picture_attributes_img` on default Picture
- **updated** Header logo form defaults (Portal template when Core Portal)
- **updated** `@tacc/core-styles` dev dep (temporary pin)

## Testing

1. Empty `header-content`: settings logo uses `navbar-brand` on `<a>`, `portal-logo` on `<img>`.
2. With `PORTAL_IS_TACC_CORE_PORTAL`: add Header logo defaults to Portal logo; published output has `portal-logo` on `<img>` and `navbar-brand` on the link.
3. Core-Portal `/cms/header/logo/markup/` matches site logo for plugin vs settings paths.

## UI

https://github.com/user-attachments/assets/4a186b0b-3625-4314-9154-2d6de6ffadc8

https://github.com/user-attachments/assets/dc629e0e-b4ec-4955-94a7-7c0b1cf91f84

https://github.com/user-attachments/assets/ec99e5e5-5d68-4db7-8e25-21ced4609bdf

https://github.com/user-attachments/assets/39368ab6-8995-4aec-83c7-ccf8b2d31962

## Notes

Bumped `@tacc/core-styles` to a published version after Core-Styles PRs merge.