### PR TITLE
fix: GH-1185 header logo portal-logo on img-only pictures

### DIFF
--- a/taccsite_cms/contrib/taccsite_header_logo/cms_plugins.py
+++ b/taccsite_cms/contrib/taccsite_header_logo/cms_plugins.py
@@ -7,6 +7,34 @@ from djangocms_picture.models import Picture
 from .forms import HeaderLogoForm
 
 HEADER_LOGO_LINK_CLASS = 'navbar-brand'
+PORTAL_LOGO_IMG_CLASS = 'portal-logo'
+
+
+def picture_attributes_hoist_to_parent(instance, picture_link):
+    """Match djangocms_picture/default/picture.html attribute placement."""
+    default_caption = ''
+    if instance.picture:
+        default_caption = getattr(instance.picture, 'default_caption', '') or ''
+    return bool(
+        instance.caption_text
+        or default_caption
+        or picture_link
+        or instance.child_plugin_instances
+    )
+
+
+def apply_header_logo_classes(instance, context, picture_link):
+    if not instance.attributes:
+        instance.attributes = {}
+
+    existing_class = instance.attributes.get('class', '')
+    link_class = f'{HEADER_LOGO_LINK_CLASS} {existing_class}'.strip()
+
+    if picture_attributes_hoist_to_parent(instance, picture_link):
+        instance.attributes['class'] = link_class
+        context['picture_img_class'] = PORTAL_LOGO_IMG_CLASS
+    else:
+        instance.attributes['class'] = f'{link_class} {PORTAL_LOGO_IMG_CLASS}'.strip()
 
 
 @plugin_pool.register_plugin
@@ -20,11 +48,5 @@ class HeaderLogoPlugin(PicturePlugin):
     name = _('Header logo')
 
     def render(self, context, instance, placeholder):
-        if not instance.attributes:
-            instance.attributes = {}
-
-        # To add required attributes
-        existing_class = instance.attributes.get('class', '')
-        instance.attributes['class'] = f'{HEADER_LOGO_LINK_CLASS} {existing_class}'.strip()
-
+        apply_header_logo_classes(instance, context, instance.get_link())
         return super().render(context, instance, placeholder)

--- a/taccsite_cms/templates/djangocms_picture/default/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/default/picture.html
@@ -73,7 +73,7 @@
     {% endblock %}
     {# /TACC #}
     {# TACC (allow attributes to be force-added to <img>): #}
-    {% block picture_attributes_img %}{% endblock %}
+    {% block picture_attributes_img %}{% if picture_img_class %}class="{{ picture_img_class }}"{% endif %}{% endblock %}
     {# /TACC #}
 >
 {% endlocalize %}

--- a/taccsite_cms/templates/djangocms_picture/portal_logo/picture.html
+++ b/taccsite_cms/templates/djangocms_picture/portal_logo/picture.html
@@ -1,2 +1,1 @@
 {% extends "djangocms_picture/default/picture.html" %}
-{% block picture_attributes_img %}class="portal-logo"{% endblock %}

--- a/taccsite_cms/tests/djangocms_picture_default_caption.py
+++ b/taccsite_cms/tests/djangocms_picture_default_caption.py
@@ -42,13 +42,13 @@ class _FakePicture:
     """Stand-in for a djangocms_picture Picture plugin instance."""
 
     def __init__(self, caption_text='', children=None, default_caption='',
-                 default_alt_text='', attributes=None):
+                 default_alt_text='', attributes=None, attributes_str=None):
         self.caption_text = caption_text
         self.child_plugin_instances = children if children is not None else []
         self.picture = _FakeImage(default_alt_text=default_alt_text,
                                   default_caption=default_caption)
         self.attributes = attributes or {}
-        self.attributes_str = ''
+        self.attributes_str = attributes_str if attributes_str is not None else ''
         self.link_attributes_str = ''
         self.link_target = ''
         self.img_src = '/media/test.jpg'

--- a/taccsite_cms/tests/djangocms_picture_portal_logo.py
+++ b/taccsite_cms/tests/djangocms_picture_portal_logo.py
@@ -1,0 +1,48 @@
+"""Tests for header logo picture class handling (portal-logo on <img>)."""
+
+from django.template.loader import get_template
+from django.test import SimpleTestCase
+
+from taccsite_cms.contrib.taccsite_header_logo.cms_plugins import apply_header_logo_classes
+from taccsite_cms.tests.djangocms_picture_default_caption import _FakePicture
+
+
+def _render_default(instance, *, picture_link='', picture_img_class=None):
+    context = {
+        'instance': instance,
+        'picture_link': picture_link,
+        'img_srcset_data': [],
+    }
+    if picture_img_class is not None:
+        context['picture_img_class'] = picture_img_class
+    return get_template('djangocms_picture/default/picture.html').render(context)
+
+
+class PortalLogoPictureTests(SimpleTestCase):
+    def test_portal_logo_on_img_when_no_link(self):
+        instance = _FakePicture(attributes={'alt': 'Project logo'})
+        ctx = {}
+        apply_header_logo_classes(instance, ctx, picture_link='')
+        instance.attributes_str = (
+            f' class="{instance.attributes["class"]}"'
+            f' alt="{instance.attributes["alt"]}"'
+        )
+        html = _render_default(instance, picture_link='')
+        self.assertIn('navbar-brand portal-logo', html)
+        self.assertNotIn('picture_img_class', ctx.keys())
+
+    def test_portal_logo_on_img_when_linked(self):
+        instance = _FakePicture(
+            attributes={'alt': 'Project logo'},
+            attributes_str=' class="navbar-brand"',
+        )
+        ctx = {}
+        apply_header_logo_classes(instance, ctx, picture_link='/')
+        html = _render_default(
+            instance,
+            picture_link='/',
+            picture_img_class=ctx.get('picture_img_class'),
+        )
+        self.assertEqual(ctx.get('picture_img_class'), 'portal-logo')
+        self.assertIn('navbar-brand', html)
+        self.assertIn('class="portal-logo"', html)


### PR DESCRIPTION
## Overview

Fixes missing `portal-logo` on the header logo `<img>` when the picture has no link, by aligning class placement with the TACC picture template’s attribute hoisting rules.

## Related

- [#1185](https://github.com/TACC/Core-CMS/issues/1185)
- requires https://github.com/TACC/Core-CMS/pull/1083

## Changes

- **added** `apply_header_logo_classes()` on `HeaderLogoPlugin` to mirror picture template hoist behavior
- **added** optional `picture_img_class` on the default picture template for img-only classes when attributes hoist to a parent
- **updated** `portal_logo` picture template to extend default only (logic lives in the plugin)
- **added** tests for linked and img-only header logo markup

## Testing

1. `docker exec core_cms python manage.py test taccsite_cms.tests.djangocms_picture_portal_logo taccsite_cms.tests.djangocms_picture_default_caption --no-input`
2. After #1083 is merged and this branch is rebased onto `main`: add a header logo via CMS, confirm linked logo still has `navbar-brand` on `<a>` and `portal-logo` on `<img>`.
3. Remove the logo link in the plugin; confirm `<img>` still has `portal-logo` (and Core-Styles layout holds).

## UI

Screenshots: pending upload

## Notes

Do not merge until #1083 is merged (this PR is stacked on that branch). Rebase onto `main` after #1083 lands.