### PR TITLE
fix(perm): do not let normal CMS editors edit static placeholders

### DIFF
--- a/taccsite_cms/management/commands/util.py
+++ b/taccsite_cms/management/commands/util.py
@@ -30,6 +30,25 @@ def add_perm(group, app_label, model_name, perm_name):
     else:
         group.permissions.add( Permission.objects.get( name=perm_name ))
 
+def del_perm(group, app_label, model_name, perm_name):
+    """
+    Delete specific permission from a given group
+    """
+    logger.debug(f'Removing permission ({app_label}.{model_name}) "{perm_name}"')
+    if app_label and model_name:
+        model = model_name.lower().replace(' ', '')
+        content_type = ContentType.objects.get(
+            app_label=app_label,
+            model=model
+        )
+        group.permissions.remove(
+            Permission.objects.get(
+                name=perm_name,
+                content_type=content_type
+            )
+        )
+    else:
+        group.permissions.remove(Permission.objects.get(name=perm_name))
 
 
 # Page
@@ -44,9 +63,15 @@ def let_view_page_and_structure(group):
     add_perm(group, 'cms', 'page', 'Can change page')
 
     add_perm(group, 'cms', 'placeholder', 'Can use Structure mode')
-    # HELP: Not necessary on TACC (as of Core-CMS v4.17.1)
-    #       Is necessary on WTCS (as of Core-CMS v4.20.2)
-    add_perm(group, 'cms', 'static placeholder', 'Can change static placeholder')
+    # To delete undesired permission from sites that still have it:
+    # ```py
+    # add_perm(group, 'cms', 'static placeholder', 'Can change static placeholder')
+    # ```
+    # HELP: Should "Sitewide Content Manager" keep this perm?
+    # SEE: https://weteachcs.org/admin/auth/group/9/change/
+    # FAQ: Only superuser may edit static placeholders (e.g. footer-content)
+    # TODO: After this is deployed on all sites once, delete this code
+    del_perm(group, 'cms', 'static placeholder', 'Can change static placeholder')
 
 
 


### PR DESCRIPTION
## Overview

Content editor groups should not be able to change sitewide static placeholders (footer, future header slots). This removes that permission when group setup runs, so existing sites drop it on the next deploy that runs the helper.

## Related

- Relates-to #1171
- Split from #1083

## Changes

- **added** `del_perm` helper (mirror of `add_perm`)
- **updated** `let_view_page_and_structure` to revoke `Can change static placeholder` instead of granting it

## Testing

1. On a dev DB, grant a content group `Can change static placeholder` (or use a site that still has it).
2. Run the management command path that calls `let_view_page_and_structure` for that group (same as existing group setup).
3. Confirm the group no longer has `Can change static placeholder` in Django admin.
4. Confirm superusers can still edit static placeholders.

## UI

No UI change.

## Notes

Includes a TODO to delete the revoke block after all sites have deployed once. Open question in code: whether “Sitewide Content Manager” should retain this permission.