### PR TITLE
chore(cms): label footer-content in Structure sidebar

### DIFF
--- a/taccsite_cms/settings/settings.py
+++ b/taccsite_cms/settings/settings.py
@@ -564,7 +564,11 @@ CMS_LANGUAGES = {
 }
 
 CMS_PERMISSION = True
-CMS_PLACEHOLDER_CONF = {}
+CMS_PLACEHOLDER_CONF = {
+    'footer-content': {
+        'name': _('Footer content'),
+    },
+}
 
 THUMBNAIL_HIGH_RESOLUTION = True
 THUMBNAIL_PROCESSORS = (


### PR DESCRIPTION
## Overview

The footer already uses the `footer-content` static placeholder; this adds a display name so Structure mode shows “Footer content” instead of the raw code.

## Related

- Split from #1083

## Changes

- **updated** `CMS_PLACEHOLDER_CONF` with a `footer-content` entry and translated name only

## Testing

1. `make start`, log in as a user who can use Structure mode.
2. Open any page, enter Structure mode.
3. Confirm the footer static placeholder is labeled “Footer content”.

## UI

Structure sidebar label only; no front-end markup change.