### PR TITLE
Dockerfile warnings and ES image patch version bump for WSL2 development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # PYTHON BASE IMAGE
-FROM python:3.11-bullseye as python-base
+FROM python:3.11-bullseye AS python-base
 LABEL maintainer="TACC-ACI-WMA <wma_prtl@tacc.utexas.edu>"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
@@ -29,7 +29,7 @@ RUN poetry install --only main --no-root
 
 
 # POETRY DEPENDENCIES
-FROM python-base as development
+FROM python-base AS development
 COPY . /code/
 # quicker install because poetry runtime deps are already installed
 RUN poetry install --no-root
@@ -37,7 +37,7 @@ RUN poetry install --no-root
 
 
 # NODE DEPENDENCIES & BUILD & OUTPUT
-FROM node:20 as node_build
+FROM node:20 AS node_build
 
 # Install dependencies
 COPY package.json package-lock.json /code/
@@ -52,7 +52,7 @@ RUN npm run build --build-id="$BUILD_ID"
 
 
 # FINAL LAYER
-FROM python-base as production
+FROM python-base AS production
 
 # Support CMS logs
 RUN mkdir -p /var/log/cms

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,11 +30,12 @@ services:
       - core_cms_net
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
-    ulimits:
-      memlock: -1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
+    memlock:
+        soft: -1
+        hard: -1
     environment:
-      - ES_HEAP_SIZE:1g
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
       - discovery.type=single-node
     volumes:
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,9 +31,10 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
-    memlock:
-        soft: -1
-        hard: -1
+    ulimits:
+      memlock:
+          soft: -1
+          hard: -1
     environment:
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
       - discovery.type=single-node


### PR DESCRIPTION
## Overview

Resolves a few warnings logged during image build from the Dockerfile. Also updates the ES image patch version and configs used during dev to support local dev in the WSL2 ecosystem.

## Related

- https://github.com/TACC/Core-Portal/pull/1329

## Changes

- **updated** ES patch version and configuration syntax.
- **fixed** syntax error in Dockerfile throwing warnings.

## Testing

1. Build and run as usual.

## UI

- No UI changes.

## Notes

- No notes.
