### PR TITLE
test: Button styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.57.3-rc3"
+        "@tacc/core-styles": "^2.57.3-rc4"
       },
       "engines": {
         "node": ">=20",
@@ -1510,9 +1510,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.57.3-rc3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.3-rc3.tgz",
-      "integrity": "sha512-UoTWB7l4j1QJmw0fyddWGUl9X8epnWF56SoRiPbS1Y4O8/3OExZY+mxlIvluMfCtChGRd4nJfnCdjXvR+hTzDA==",
+      "version": "2.57.3-rc4",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.3-rc4.tgz",
+      "integrity": "sha512-74R74vP4tMdMzL+acfrRryKBVX+H4pHuMa8vN7iCz9ajv0zNe4fDgKeLFFSEFXpUgGViYcjJ5Kv9wyztAB/PmA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5747,9 +5747,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.57.3-rc3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.3-rc3.tgz",
-      "integrity": "sha512-UoTWB7l4j1QJmw0fyddWGUl9X8epnWF56SoRiPbS1Y4O8/3OExZY+mxlIvluMfCtChGRd4nJfnCdjXvR+hTzDA==",
+      "version": "2.57.3-rc4",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.3-rc4.tgz",
+      "integrity": "sha512-74R74vP4tMdMzL+acfrRryKBVX+H4pHuMa8vN7iCz9ajv0zNe4fDgKeLFFSEFXpUgGViYcjJ5Kv9wyztAB/PmA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.57.3-rc3"
+    "@tacc/core-styles": "^2.57.3-rc4"
   }
 }

--- a/taccsite_cms/management/commands/README.md
+++ b/taccsite_cms/management/commands/README.md
@@ -6,6 +6,7 @@
   - [for Sections](#for-sections)
   - [for Cards](#for-cards)
   - [for Alerts](#for-alerts)
+  - [for Buttons](#for-buttons)
 - [Set Groups & Permissions](#set-groups--permissions)
 - [Reference](#reference)
 
@@ -78,6 +79,18 @@ python manage.py create_test_page_alert_style --replace
 ```
 
 Path: `/test/test-alert-style/`
+
+### for Buttons
+
+Test Bootstrap 4 Link/Button plugin (all context variants).
+
+Usage:
+
+```sh
+python manage.py create_test_page_button_style --replace
+```
+
+Path: `/test/test-button-style/`
 
 ## Set Groups & Permissions
 

--- a/taccsite_cms/management/commands/create_test_page_button_style.py
+++ b/taccsite_cms/management/commands/create_test_page_button_style.py
@@ -1,0 +1,150 @@
+"""
+Create a published CMS page that exercises Bootstrap 4 Link/Button plugin contexts.
+
+For manual UI checks after Core-Styles or button plugin setting changes.
+"""
+
+import warnings
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from cms.api import add_plugin, create_page, publish_page
+
+from cms.plugin_pool import plugin_pool
+
+Bootstrap4LinkPlugin = plugin_pool.plugins['Bootstrap4LinkPlugin']
+
+from taccsite_cms.management.test_page_util import (
+    delete_draft_pages_by_reverse_id,
+    ensure_test_parent_page,
+)
+
+
+DEFAULT_REVERSE_ID = 'core_cms_test_page_button_style'
+DEFAULT_TITLE = 'Test Button Style'
+DEFAULT_SLUG = 'test-button-style'
+DEFAULT_TEMPLATE = 'standard.html'
+
+CONTEXTS = [
+    'primary',
+    'secondary',
+    'success',
+    'danger',
+    'warning',
+    'info',
+    'light',
+    'dark',
+]
+
+
+class Command(BaseCommand):
+    help = (
+        'Create a published page with Bootstrap 4 Link/Button plugins '
+        '(all context variants) for visual QA.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--title',
+            default=DEFAULT_TITLE,
+            help=f'Default: {DEFAULT_TITLE!r}',
+        )
+        parser.add_argument(
+            '--slug',
+            default=DEFAULT_SLUG,
+            help=f'Default: {DEFAULT_SLUG!r}',
+        )
+        parser.add_argument(
+            '--reverse-id',
+            dest='reverse_id',
+            default=DEFAULT_REVERSE_ID,
+            help=f'Default: {DEFAULT_REVERSE_ID!r} (used with --replace)',
+        )
+        parser.add_argument(
+            '--language',
+            default=settings.LANGUAGE_CODE,
+            help='Page language (default: LANGUAGE_CODE)',
+        )
+        parser.add_argument(
+            '--template',
+            default=DEFAULT_TEMPLATE,
+            help=f'CMS template key (default: {DEFAULT_TEMPLATE!r})',
+        )
+        parser.add_argument(
+            '--replace',
+            action='store_true',
+            help='Delete any existing page with the same reverse_id first',
+        )
+        parser.add_argument(
+            '--no-publish',
+            action='store_true',
+            help='Leave the page as draft (plugins are still created)',
+        )
+
+    def handle(self, *args, **options):
+        language = options['language']
+        reverse_id = options['reverse_id']
+        title = options['title']
+        slug = options['slug']
+        template = options['template']
+
+        User = get_user_model()
+        publisher = User.objects.filter(is_superuser=True).first()
+        if not publisher:
+            raise CommandError(
+                'No superuser found; create one or publish the draft manually.'
+            )
+
+        if options['replace']:
+            delete_draft_pages_by_reverse_id(
+                reverse_id,
+                stdout=self.stdout,
+                style=self.style,
+            )
+
+        parent = ensure_test_parent_page(
+            language,
+            publisher,
+            publish=True,
+            stdout=self.stdout,
+            style=self.style,
+        )
+
+        page = create_page(
+            title=title,
+            template=template,
+            language=language,
+            slug=slug,
+            reverse_id=reverse_id,
+            created_by=publisher,
+            parent=parent,
+            in_navigation=True,
+            published=False,
+        )
+
+        placeholder = page.placeholders.get(slot='content')
+
+        for context in CONTEXTS:
+            add_plugin(
+                placeholder,
+                Bootstrap4LinkPlugin,
+                language,
+                name=f'{context.capitalize()} button',
+                link_type='btn',
+                link_context=context,
+                external_link='#',
+            )
+
+        if not options['no_publish']:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                page = publish_page(page, publisher, language)
+            self.stdout.write(self.style.SUCCESS('Published.'))
+        else:
+            self.stdout.write(self.style.WARNING('Left as draft (--no-publish).'))
+
+        url = page.get_absolute_url()
+        self.stdout.write(f'Page title: {title}')
+        self.stdout.write(f'URL: {url}')


### PR DESCRIPTION
## Overview

1. Offer color to buttons of style success, warning, and danger.
2. Offer command to create test page.

## Related

Minimal solution to gotcha introduced by #1195.

## Changes

- **updates** @tacc/core-styles
- **adds** `manage.py` command to create test page

## Testing

1. Create page.
2. Add buttons of various types.
    ```
    docker exec core_cms python manage.py create_test_page_button_style --replace
    ```
3. Review buttons use and reuse blue, gray, and white.


## UI

<img width="780" height="460" alt="Screenshot 2026-07-02 at 22 57 46" src="https://github.com/user-attachments/assets/dcff9529-6192-44dc-9bae-c45ae79aa57e" />
