### PR TITLE
fix(settings): restore custom_app_settings for v4.40 rollout

### DIFF
--- a/taccsite_cms/settings/settings.py
+++ b/taccsite_cms/settings/settings.py
@@ -672,6 +672,15 @@ except ModuleNotFoundError:
 # TODO: Make clients not use nor set these
 ########################
 
+# For older (pre-v4.40.0-rc10) custom app settings
+try:
+    from taccsite_cms import custom_app_settings
+    INSTALLED_APPS += getattr(custom_app_settings, 'CUSTOM_APPS', [])
+    STATICFILES_DIRS += getattr(custom_app_settings, 'STATICFILES_DIRS', ())
+    MIDDLEWARE += getattr(custom_app_settings, 'CUSTOM_MIDDLEWARE', ())
+except ImportError:
+    pass
+
 deprecated_SETTINGS_EXPORT = []
 
 # For header_branding.html


### PR DESCRIPTION
## Overview

Restore `custom_app_settings.py` support.

## Related

- backward-compatibility for https://github.com/TACC/Core-CMS/pull/1177
- reduces urgency of https://github.com/TACC/Core-Portal-Deployments/pull/197

## Changes

- **added** legacy import of `taccsite_cms.custom_app_settings` (`CUSTOM_APPS`, `STATICFILES_DIRS`, `CUSTOM_MIDDLEWARE`) after `settings_local`

## Testing

<details>
<summary>If you really want to test working code that I merely restored…</summary>

1. Mount a `custom_app_settings.py` with `CUSTOM_APPS` (e.g. blog stack) at `taccsite_cms/custom_app_settings.py` as Camino does on `main`.
2. Start CMS on this branch and confirm blog-related apps are in `INSTALLED_APPS`.
3. Mount a `settings_custom.py` with `EXTRA_INSTALLED_APPS` only (no `custom_app_settings`) and confirm CMS starts and apps load.
4. Confirm CMS starts when neither legacy nor `EXTRA_*` keys are present.

</details>

## UI

N/A