### PR TITLE
docs(publishing): versioning

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,7 +1,7 @@
 # How to Publish
 
 1. [Create release and tag on GitHub.](https://github.com/TACC/Core-CMS/releases/new)
-2. [Build & Deploy](README.md#build--deploy-project) off of `vN.N.N`.
+2. [Build & Deploy](README.md#build--deploy-project) off of the new release tag.
 
 ## Release Candidates
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -7,10 +7,10 @@
 ## Versioning
 
 1. Always pre-release `vX.Y.Z-rc1` before a production release `vX.Y.Z`.
-2. Does your team need to verify pre-release changes in pre-production?
+2. Does your team need to verify changes in pre-production?
     - If **yes**, then create the next pre-release e.g. `vX.Y.Z-rc2`, `-rc3`.
-    - If **not**, then let them be part of production **release `vX.Y.Z`**.
+    - If **not**, then let the changes be part of production **release `vX.Y.Z`**.
 3. Can your team fix all the pre-release bugs before production release?
     - If **yes**, then — when they are fixed — **release `vX.Y.Z`**.
     - If **not**, then remove the buggy code.
-4. If `vX.Y.Z` has still nto been released, then repeat step 2.
+4. If `vX.Y.Z` has _still **not**_ been released, then repeat step 2.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,3 +2,14 @@
 
 1. [Create release and tag on GitHub.](https://github.com/TACC/Core-CMS/releases/new)
 2. [Build & Deploy](README.md#build--deploy-project) off of `vN.N.N`.
+
+## Release Candidates
+
+1. Always pre-release `vX.Y.Z-rc1` before a production release `vX.Y.Z`.
+2. Do your team need to verify pre-release changes in pre-production?
+    - If **yes**, then create the next pre-release e.g. `vX.Y.Z-rc2`, `-rc3`.
+    - If **not**, then let them be part of production **release `vX.Y.Z`**.
+3. Can your team fix all the pre-release bugs before production release?
+    - If **yes**, then — when they are fixed — **release `vX.Y.Z`**.
+    - If **not**, then remove the buggy code.
+4. If you have not released `vX.Y.Z`, then repeat step 2.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -13,4 +13,4 @@
 3. Can your team fix all the pre-release bugs before production release?
     - If **yes**, then — when they are fixed — **release `vX.Y.Z`**.
     - If **not**, then remove the buggy code.
-4. If you have not released `vX.Y.Z`, then repeat step 2.
+4. If `vX.Y.Z` has still nto been released, then repeat step 2.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,12 +1,13 @@
 # How to Publish
 
+0. Read [Versioning](#versioning).
 1. [Create release and tag on GitHub.](https://github.com/TACC/Core-CMS/releases/new)
 2. [Build & Deploy](README.md#build--deploy-project) off of the new release tag.
 
-## Release Candidates
+## Versioning
 
 1. Always pre-release `vX.Y.Z-rc1` before a production release `vX.Y.Z`.
-2. Do your team need to verify pre-release changes in pre-production?
+2. Does your team need to verify pre-release changes in pre-production?
     - If **yes**, then create the next pre-release e.g. `vX.Y.Z-rc2`, `-rc3`.
     - If **not**, then let them be part of production **release `vX.Y.Z`**.
 3. Can your team fix all the pre-release bugs before production release?


### PR DESCRIPTION
## Overview

Document release process to:
- avoid excess `-rc#`
- avoid surprise new features before scheduled release
- be consistent with [TACC/Core-Portal](https://github.com/TACC/Core-Portal)

## Testing / UI

Read [`PUBLISHING.md` @ "Versioning"](https://github.com/TACC/Core-CMS/blob/49b0e69/PUBLISHING.md#versioning).