### PR TITLE
fix(blog): preserve space when back link is hidden

### DIFF
--- a/taccsite_cms/templates/djangocms_blog/post_list.html
+++ b/taccsite_cms/templates/djangocms_blog/post_list.html
@@ -63,10 +63,8 @@
     <p class="blog-empty">{% trans "No article found." %}</p>
     {% endfor %}
     {# TACC (hide back link): #}
-    {% if settings.PORTAL_BLOG_SHOW_BACK_LINK %}
     {% if author or archive_date or tagged_entries %}
-    <p class="blog-back"><a href="{% url 'djangocms_blog:posts-latest' %}">{% trans "Back" %}</a></p>
-    {% endif %}
+    <p class="blog-back"{% if not settings.PORTAL_BLOG_SHOW_BACK_LINK %} style="visibility: hidden"{% endif %}><a href="{% url 'djangocms_blog:posts-latest' %}">{% trans "Back" %}</a></p>
     {% endif %}
     {# /TACC #}
     {% if is_paginated %}


### PR DESCRIPTION
## Overview

Filtered news list pages lost vertical space below the list after #1200 because the back link was omitted when `PORTAL_BLOG_SHOW_BACK_LINK` is false. The markup stays in place and is hidden with `visibility: hidden` so layout matches the previous back link spacing.

## Related

- fixes https://github.com/TACC/Core-CMS/pull/1200
- mimicked by https://github.com/TACC/tup-ui/pull/562

## Changes

- **updated** `post_list.html` to always render `.blog-back` on author, archive, and tag views when the setting is false

## Testing

1. With default `PORTAL_BLOG_SHOW_BACK_LINK`, open a filtered news list URL.
2. Confirm the “Back” link is not visible and spacing below the list is preserved.
3. Set `PORTAL_BLOG_SHOW_BACK_LINK = True` and confirm the link is visible.

## UI

<img width="900" height="475" alt="keep extra space, but hide text" src="https://github.com/user-attachments/assets/e2b09405-6391-4623-9db1-f428b60f05e7" />
