### PR TITLE
refactor(sortableTable): use data-* attrs API

### DIFF
--- a/taccsite_cms/static/site_cms/js/modules/sortableTable.html
+++ b/taccsite_cms/static/site_cms/js/modules/sortableTable.html
@@ -14,14 +14,12 @@
   });
 </script>
 
-<!-- TABLE (filters built in JS when data-sortable-filters is set) -->
+<!-- TABLE (filters built in JS from data-sortable-* attrs) -->
 <table
   id="example-table"
   class="js-sortable"
-  data-sortable-filters='[
-    {"type":"search", "placeholder":"Search..."},
-    {"type":"select", "column":3, "label":"Umbrella"}
-  ]'
+  data-sortable-search
+  data-sortable-select-cols="3"
 >
 <!--
 <table id="example-table" class="js-sortable o-fixed-header-table" data-sortable-filters="…">

--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -9,7 +9,7 @@
 
 {# TACC/Core-CMS + @tacc/sortable-table #}
 {# SEE: https://github.com/wesleyboar/sortable-table #}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@fb956d9f/src/sortableTable.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/wesleyboar/sort-table@e63f5427/src/sortableTable.css" />
 <script
   src="https://cdn.jsdelivr.net/npm/list.js@2.3.1/dist/list.min.js"
   integrity="sha384-FhEOA/pIE4BfDuwGksHaZD8ms5j+dfB9QIWo7naDMzAVoCE1My4G2iu8/n/R3AAH"
@@ -17,7 +17,7 @@
 ></script>
 <script type="module">
   import updateEmailLinkHrefs from '{% static "site_cms/js/modules/updateEmailLinkHrefs.js" %}';
-  import sortableTable from 'https://cdn.jsdelivr.net/gh/wesleyboar/sortable-table@fb956d9f/src/sortableTable.js';
+  import sortableTable from 'https://cdn.jsdelivr.net/gh/wesleyboar/sort-table@e63f5427/src/sortableTable.js';
 
   const scopeElement = document.getElementById('cms-content');
   const fakeText = '__REMOVE_THIS__';

--- a/tmp/pr-1169.html
+++ b/tmp/pr-1169.html
@@ -26,7 +26,7 @@
   <link
     rel="stylesheet"
     id="research-projects-assets-table-css"
-    cdn-href="https://cdn.jsdelivr.net/gh/TACC/Core-CMS@v4.40.0-rc6/taccsite_cms/static/site_cms/css/modules/sortableTable.css"
+    cdn-href="https://cdn.jsdelivr.net/gh/wesleyboar/sort-table@e63f5427/src/sortableTable.css"
     href="./sortableTable.css"
   />
   <script
@@ -50,40 +50,13 @@
 </head>
 <body>
 
-  <template id="sortable-table-filters">
-    <fieldset class="js-sortable-filter-list sortable-filter-list">
-      <legend class="sr-only">Results in the table update as you type or select filters</legend>
-      <label class="sortable-filter mr-auto">
-        <i
-          class="icon icon-search icon-md sortable-filter__icon"
-          aria-label="Search"
-        >Search</i>
-        <input
-          type="search"
-          class="sortable-filter__input"
-          placeholder="Search…"
-        />
-        <output class="js-sortable-total text-truncate" aria-atomic="true"></output>
-      </label>
-      <label class="sortable-filter">
-        <span class="sortable-filter__label"></span>
-        <select class="sortable-filter__input">
-          <option value="">any</option>
-        </select>
-      </label>
-    </fieldset>
-  </template>
-
   <main id="cms-content">
 
     <table
       id="projects-table"
       class="js-sortable o-fixed-header-table w-100"
-      data-sortable-filters='[
-        {"type":"search", "placeholder":"Search..."},
-        {"type":"select", "column":3,"label":"Umbrella"},
-        {"type":"select", "column":4,"label":"Category"}
-      ]'
+      data-sortable-search
+      data-sortable-select-cols="3,4"
     >
       <caption class="sr-only">Project Introductions</caption>
       <thead>


### PR DESCRIPTION
## Overview

Updates demo files to use the new `data-sortable-search` / `data-sortable-select-cols` attribute API and bumps the CDN pin to `wesleyboar/sort-table@e63f5427`.

## Related

- updates #1178
- mimics https://github.com/TACC/tup-ui/pull/564
- requires https://github.com/wesleyboar/sort-table/pull/3

## Changes

- **replaced** `data-sortable-filters` JSON with `data-sortable-search` and `data-sortable-select-cols` in demo files
- **deleted** inline `<template>` from `tmp/pr-1169.html` (JS self-injects)
- **updated** CDN pin from `wesleyboar/sortable-table@fb956d9f` to `wesleyboar/sort-table@e63f5427`

## Notes

> [!IMPORTANT]
> jsDelivr SHA pin will be updated to a versioned npm URL after `@tacc/sort-table@0.1.0` is published.