### PR TITLE
docs(test-releases): + button colors + footer label

### DIFF
--- a/docs/test-releases/v4.40.0-rc10.md
+++ b/docs/test-releases/v4.40.0-rc10.md
@@ -4,7 +4,9 @@
     1. [Disclosure Markup (`<summary>` and ARIA)](#disclosure-markup-summary-and-aria)
     2. [Picture Default Caption](#picture-default-caption)
     3. [Bootstrap 4 Alert Colors](#bootstrap-4-alert-colors)
-    4. [TACC Site Card](#tacc-site-card)
+    4. [Bootstrap Button Colors](#bootstrap-button-colors)
+    5. [TACC Site Card](#tacc-site-card)
+    6. [Footer Static Placeholder Label](#footer-static-placeholder-label)
 2. [Deployment / Settings](#deployment--settings)
     1. [Custom App Settings → `EXTRA_*` Settings](#custom-app-settings--extra_-settings)
 
@@ -55,6 +57,18 @@
 4. Confirm all 8 alert variants render with the correct Bootstrap color class.
 5. Optionally, add a Bootstrap Alert plugin manually and confirm all 8 contexts appear in the **Context** dropdown.
 
+### Bootstrap Button Colors
+
+> [!NOTE]
+> Follow-up to [Bootstrap 4 Alert Colors](#bootstrap-4-alert-colors): buttons offer the same `success`/`warning`/`danger` styles but always render blue/gray/white.
+
+**Tests:** `success`, `warning`, `danger` button colors ([v4.40.0-rc9](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc9)).
+
+1. Log in.
+2. `docker exec core_cms python manage.py create_test_page_button_style --replace`
+3. Open the generated test page.
+4. Confirm buttons reuse blue, gray, and white across the color variants (not distinct colors per variant).
+
 ### TACC Site Card
 
 **Tests:** new Card plugin ([v4.40.0-rc9](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc9)).
@@ -65,6 +79,14 @@
 4. Confirm Card blocks render `c-card` plus expected skin/layout classes in the DOM.
 5. Add a Card plugin manually.
 6. Confirm the **Tag Type** field's help text links (article/aside/div to MDN) open in a new tab.
+
+### Footer Static Placeholder Label
+
+**Tests:** "Footer content" label in Structure mode ([v4.40.0-rc9](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc9)).
+
+1. Log in.
+2. Open any page and enter Structure mode.
+3. Confirm the footer static placeholder is labeled "Footer content" (not the raw `footer-content` code).
 
 ## Deployment / Settings
 

--- a/docs/test-releases/v4.40.0-rc10.md
+++ b/docs/test-releases/v4.40.0-rc10.md
@@ -85,7 +85,7 @@
 **Tests:** "Footer content" label in Structure mode ([v4.40.0-rc9](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc9)).
 
 1. Log in.
-2. Open any page and enter Structure mode.
+2. Open any page and enter Structure mode (e.g. `?structure`).
 3. Confirm the footer static placeholder is labeled "Footer content" (not the raw `footer-content` code).
 
 ## Deployment / Settings

--- a/docs/test-releases/v4.40.0-rc10.md
+++ b/docs/test-releases/v4.40.0-rc10.md
@@ -60,7 +60,7 @@
 ### Bootstrap Button Colors
 
 > [!NOTE]
-> Follow-up to [Bootstrap 4 Alert Colors](#bootstrap-4-alert-colors): buttons offer the same `success`/`warning`/`danger` styles but always render blue/gray/white.
+> Offers same options as [Bootstrap 4 Alert Colors](#bootstrap-4-alert-colors).
 
 **Tests:** `success`, `warning`, `danger` button colors ([v4.40.0-rc9](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc9)).
 


### PR DESCRIPTION
## Overview

Two rc9 changes were missed in the v4.40.0-rc10 smoke-test doc because their commit messages under-described what they actually did (`test: Button styles`, `chore(cms): label footer-content`) — both are portal-testable.

## Related

- TACC/Core-CMS#1197
- TACC/Core-CMS#1188

## Changes

- **added** "Bootstrap Button Colors" section: `success`/`warning`/`danger` button styles, which always render blue/gray/white (#1197)
- **added** "Footer Static Placeholder Label" section: Structure mode shows "Footer content" instead of raw code (#1188)

## Testing

1. Read `docs/test-releases/v4.40.0-rc10.md` on the branch.
2. Confirm the new sections' steps match #1197 and #1188.

## UI

N/A (documentation only).