### PR TITLE
fix: docker exec commands for portal_cms

### DIFF
--- a/docs/test-releases/v4.40.0-rc10.md
+++ b/docs/test-releases/v4.40.0-rc10.md
@@ -52,7 +52,7 @@
 **Tests:** `success`, `danger`, `warning`, `info` alert colors ([v4.40.0-rc9](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc9)).
 
 1. Log in.
-2. `docker exec core_cms python manage.py create_test_page_alert_style --replace`
+2. `docker exec portal_cms python manage.py create_test_page_alert_style --replace`
 3. Open the generated test page.
 4. Confirm all 8 alert variants render with the correct Bootstrap color class.
 5. Optionally, add a Bootstrap Alert plugin manually and confirm all 8 contexts appear in the **Context** dropdown.
@@ -65,7 +65,7 @@
 **Tests:** `success`, `warning`, `danger` button colors ([v4.40.0-rc9](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc9)).
 
 1. Log in.
-2. `docker exec core_cms python manage.py create_test_page_button_style --replace`
+2. `docker exec portal_cms python manage.py create_test_page_button_style --replace`
 3. Open the generated test page.
 4. Confirm buttons reuse blue, gray, and white across the color variants (not distinct colors per variant).
 
@@ -74,7 +74,7 @@
 **Tests:** new Card plugin ([v4.40.0-rc9](https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc9)).
 
 1. Log in.
-2. `docker exec core_cms python manage.py create_test_page_card_style --replace`
+2. `docker exec portal_cms python manage.py create_test_page_card_style --replace`
 3. Open the generated test page.
 4. Confirm Card blocks render `c-card` plus expected skin/layout classes in the DOM.
 5. Add a Card plugin manually.


### PR DESCRIPTION
## Overview

Typo in testing doc, because deployed CMS are `portal_cms` not `core_cms`.
