### PR TITLE
refactor(breadcrumbs): move script-dependent `<style>` to `<script>`

### DIFF
--- a/taccsite_cms/templates/nav_cms_breadcrumbs.html
+++ b/taccsite_cms/templates/nav_cms_breadcrumbs.html
@@ -1,15 +1,6 @@
 {# @var className #}
 {% load menu_tags %}
 
-{# To adjust style of "disabled" link #}
-{# NOTE: Not using `block`, so markup is together for devs in live markup #}
-<style>
-  .s-breadcrumbs a:not([href]) {
-    opacity: 1;
-    color: unset;
-  }
-</style>
-
 <nav class="s-breadcrumbs  {{className}}" id="cms-breadcrumbs">
 
   {# To support structured data, item* attributes are used #}
@@ -40,6 +31,11 @@
     const isDirectNavLink = href && cmsNav && cmsNav.querySelector(
       'a.nav-link:not(.dropdown-toggle)[href="' + href + '"]'
     );
-    if (!isDirectNavLink) secondLink.removeAttribute('href');
+    if (!isDirectNavLink) {
+      secondLink.removeAttribute('href');
+      {# To undo the browser's disabled-link look, since this link is "current page", not truly disabled #}
+      secondLink.style.opacity = 1;
+      secondLink.style.color = 'unset';
+    }
   }
 </script>

--- a/taccsite_cms/templates/nav_cms_breadcrumbs.html
+++ b/taccsite_cms/templates/nav_cms_breadcrumbs.html
@@ -34,7 +34,7 @@
     if (!isDirectNavLink) {
       secondLink.removeAttribute('href');
 
-      {# To undo Core-Styles' disabled-link look; link is "current page" #}
+      {# To undo Core-Styles' disabled look for parent root pages #}
       {# https://github.com/TACC/Core-Styles/blob/v2.57.3/src/lib/_imports/elements/links.css#L14-L16 #}
       secondLink.style.opacity = 1;
       secondLink.style.color = 'unset';

--- a/taccsite_cms/templates/nav_cms_breadcrumbs.html
+++ b/taccsite_cms/templates/nav_cms_breadcrumbs.html
@@ -33,7 +33,9 @@
     );
     if (!isDirectNavLink) {
       secondLink.removeAttribute('href');
-      {# To undo the browser's disabled-link look, since this link is "current page", not truly disabled #}
+
+      {# To undo Core-Styles' disabled-link look; link is "current page" #}
+      {# https://github.com/TACC/Core-Styles/blob/v2.57.3/src/lib/_imports/elements/links.css#L14-L16 #}
       secondLink.style.opacity = 1;
       secondLink.style.color = 'unset';
     }


### PR DESCRIPTION
## Overview

The "disabled" second-level breadcrumb link's style override lived in a standalone `<style>` block, separated from the script that strips its `href` and creates the need for that override — making it look like generic breadcrumb styling worth moving to a shared design system, when it's actually specific to this script's DOM change.

## Related

- discussion: https://github.com/TACC/Core-Portal/pull/1332#discussion_r3606778994

## Changes

- **moved** script-dependent `<style>` to `<script>`

## Testing

1. `make start`
2. Visit a page nested at least two levels deep in the CMS nav.
3. Verify the second breadcrumb link still renders normally (full opacity, inherited color) instead of looking disabled.
4. Verify it's still non-clickable when its target isn't a direct nav link, same as before.

## UI

<img width="900" height="525" alt="Screenshot 2026-07-20 at 18 17 36" src="https://github.com/user-attachments/assets/a98a41b6-8bad-497b-8a99-ebd82cd84f50" />

## Notes

No dependency or cross-repo changes needed — an earlier plan to migrate this CSS into Core-Styles (and Core-Portal) turned out to be based on a false premise: the style only compensates for CMS-specific JS that Core-Portal's breadcrumbs component doesn't have.