### PR TITLE
chore(claude): gitignore the .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ cms_name.var
 .buildpath
 .project
 .settings
+
+# Claude Code (force-add specific files if they should be shared/committed)
+.claude/
 atlassian-ide-plugin.xml
 
 # Virtualenv

--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,9 @@ urls_custom.py
 # Postgres secret files (not required for dev)
 conf/postgres/*.secret
 
-# Agents
+# AI
 docker-compose.agent.yml
+.claude/
 
 # Makefile var
 cms_name.var
@@ -48,9 +49,6 @@ cms_name.var
 .buildpath
 .project
 .settings
-
-# Claude Code (force-add specific files if they should be shared/committed)
-.claude/
 atlassian-ide-plugin.xml
 
 # Virtualenv


### PR DESCRIPTION
## Overview

Ignores the `.claude/` directory so Claude Code's local config (commands, agents, settings, launch configs) stays out of the repo by default.

## Changes

- **added** `.claude/` to `.gitignore`