### PR TITLE
fix: center figure/link wrapper when combined with img-fluid

### DIFF
--- a/taccsite_cms/management/commands/create_picture_test_page.py
+++ b/taccsite_cms/management/commands/create_picture_test_page.py
@@ -113,6 +113,18 @@ CASES = [
                                                'alt':   'fluid centered alt'},   False, True),
 ]
 
+# Same img-fluid align-center cases, but with width/height set on the
+# Picture plugin (see DIMENSIONED_CASES usage in handle()). CASES above
+# default to no dimensions: the common real-world case for editor-entered
+# external images, where the browser has no intrinsic-size hint until the
+# image loads.
+DIMENSIONED_CASES = [
+    ('img-fluid align-center | link | with dimensions',    {'class': 'img-fluid align-center',
+                                               'alt':   'fluid centered alt'},   True,  False),
+    ('img-fluid align-center | figure | with dimensions',  {'class': 'img-fluid align-center',
+                                               'alt':   'fluid centered alt'},   False, True),
+]
+
 
 class Command(BaseCommand):
     help = (
@@ -234,6 +246,14 @@ class Command(BaseCommand):
         for i, (label, attrs, has_link, has_caption) in enumerate(CASES):
             self._add_case(placeholder, language, i, label, attrs, has_link, has_caption)
 
+        i = len(CASES)
+        for label, attrs, has_link, has_caption in DIMENSIONED_CASES:
+            self._add_case(
+                placeholder, language, i, label, attrs, has_link, has_caption,
+                set_dims=True,
+            )
+            i += 1
+
         if not options['no_publish']:
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', UserWarning)
@@ -254,7 +274,7 @@ class Command(BaseCommand):
             "  document.head.appendChild(l);\n"
         )
 
-    def _add_case(self, placeholder, language, index, label, attrs, has_link, has_caption):
+    def _add_case(self, placeholder, language, index, label, attrs, has_link, has_caption, set_dims=False):
         attrs_display = ' '.join(f'{k}="{v}"' for k, v in attrs.items()) or '(none)'
         wrapper = []
         if has_link:
@@ -290,8 +310,8 @@ class Command(BaseCommand):
             placeholder, 'PicturePlugin', language,
             target=section,
             external_picture=EXT_IMAGE,
-            width=EXT_IMAGE_WIDTH,
-            height=EXT_IMAGE_HEIGHT,
+            width=EXT_IMAGE_WIDTH if set_dims else None,
+            height=EXT_IMAGE_HEIGHT if set_dims else None,
             template=picture_template,
             attributes=attrs,
             link_url=LINK_URL if has_link else '',

--- a/taccsite_cms/management/commands/create_picture_test_page.py
+++ b/taccsite_cms/management/commands/create_picture_test_page.py
@@ -31,6 +31,8 @@ DEFAULT_TEMPLATE = 'standard.html'
 
 # A reliable externally-hosted placeholder; no local file upload needed.
 EXT_IMAGE = 'https://placehold.co/800x400/336699/white.png?text=Test+Image'
+EXT_IMAGE_WIDTH = 800
+EXT_IMAGE_HEIGHT = 400
 LINK_URL = 'https://example.com'
 CAPTION = 'Test caption text'
 
@@ -288,6 +290,8 @@ class Command(BaseCommand):
             placeholder, 'PicturePlugin', language,
             target=section,
             external_picture=EXT_IMAGE,
+            width=EXT_IMAGE_WIDTH,
+            height=EXT_IMAGE_HEIGHT,
             template=picture_template,
             attributes=attrs,
             link_url=LINK_URL if has_link else '',

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -14,14 +14,14 @@ a:has(.img-fluid) {
 
 /* Support centering originating from Core-Styles */
 /* FAQ: We set display in client, so Core-Styles does not assume display */
+/* FAQ: `margin-inline: auto` ineffectual if:
+        1. either image wrapper is an inline-block
+           (e.g. from the img-fluid rule above)
+        2. or image wrapper is full-width block */
 /* SEE: https://github.com/TACC/Core-Styles/blob/dd2bbb0/src/lib/_imports/components/align.css#L16-L19 */
 img.align-center {
   display: block;
 }
-
-/* `margin-inline: auto` (above) only centers a block box that's narrower than
-   its container; it's a no-op on `inline-block` (e.g. from the img-fluid rule
-   above) or on the default full-width `block` of an unstyled figure/anchor. */
 :is(figure, a):has(.align-center) {
   display: block;
   width: fit-content;

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.picture.css
@@ -19,6 +19,14 @@ img.align-center {
   display: block;
 }
 
+/* `margin-inline: auto` (above) only centers a block box that's narrower than
+   its container; it's a no-op on `inline-block` (e.g. from the img-fluid rule
+   above) or on the default full-width `block` of an unstyled figure/anchor. */
+:is(figure, a):has(.align-center) {
+  display: block;
+  width: fit-content;
+}
+
 /* Try to auto-clear image floats */
 /* WARNING: The commented solution clears float BUT also negates float */
 /*


### PR DESCRIPTION
## Overview

Stacks on #1127. `align-center` wrapper (figure/link) wasn't actually centering when combined with `img-fluid`.

## Related

- stacks on #1127
- follows up on the to-do call-out added to #1127's Overview

## Changes

- **fixed** `:is(figure, a):has(.align-center)` to force `display:block; width:fit-content`, so `margin-inline:auto` centering isn't defeated by the `img-fluid` rule's `display:inline-block`
- **updated** `create_picture_test_page` to set `width`/`height` on test images, so the external placeholder has a known intrinsic size before load (avoids unrelated layout flakiness while testing this)

## Testing

1. `docker exec core_cms python manage.py create_picture_test_page --replace`
2. Open http://localhost:8000/test/test-picture-style/
3. Find `img-fluid align-center | link` and `img-fluid align-center | figure`.
4. Confirm the wrapper (not just the image) is horizontally centered.
5. Confirm captions aren't unexpectedly wrapped narrow or offset from the image.

## UI

| | Link | Figure |
| - | - | - |
| No dimensions | <img width="1025" height="439" alt="img-fluid align-center, link" src="https://github.com/user-attachments/assets/502d2785-5e5a-4545-afbc-1277daadda9a" /> | <img width="1025" height="439" alt="img-fluid align-center, figure" src="https://github.com/user-attachments/assets/2b78ecba-02d4-46e1-806b-91e8cc7bf3c6" /> |
| With dimensions | <img width="1025" height="439" alt="img-fluid align-center, link, with dimensions" src="https://github.com/user-attachments/assets/be950003-0559-4cbc-b2ee-eaa964e1fd4f" /> | <img width="1025" height="439" alt="img-fluid align-center, figure, with dimensions" src="https://github.com/user-attachments/assets/8966fed2-f121-4786-a4e2-008fc69bfff8" /> |