### PR TITLE
feat: new custom django command for devs

### DIFF
--- a/taccsite_cms/management/commands/README.md
+++ b/taccsite_cms/management/commands/README.md
@@ -2,6 +2,7 @@
 
 - [How to Use](#how-to-use)
 - [List Pages Using Each Template](#list-pages-using-each-template)
+- [List Pages Using Plugins](#list-pages-using-plugins)
 - [Create Test Pages](#create-test-pages)
   - [for Sections](#for-sections)
   - [for Cards](#for-cards)
@@ -29,6 +30,20 @@ This command lists all pages using each template in the CMS, along with their fu
 Usage:
 ```sh
 python manage.py list_page_templates
+```
+
+## List Pages Using Plugins
+
+This command lists all pages that use a specific plugin instance (given a plugin instance ID), along with the page's path.
+
+Usage:
+```sh
+python manage.py list_plugin_pages <plugin_instance_id> [<plugin_instance_id> ...]
+```
+
+Example:
+```sh
+python manage.py list_plugin_pages 42 99
 ```
 
 ## Create Test Pages

--- a/taccsite_cms/management/commands/list_plugin_pages.py
+++ b/taccsite_cms/management/commands/list_plugin_pages.py
@@ -1,0 +1,25 @@
+from django.core.management import BaseCommand
+from django.apps import apps
+
+class Command(BaseCommand):
+    help = 'Finds the page that uses a specific plugin instance by its ID'
+
+    def add_arguments(self, parser):
+        parser.add_argument('plugin_instance_ids', nargs='+', type=str)
+
+    def handle(self, *args, **options):
+        for plugin_instance_id in options['plugin_instance_ids']:
+            page = self.find_page_using_plugin_instance(plugin_instance_id)
+            if page:
+                self.stdout.write(f'Plugin instance ID {plugin_instance_id} is used on page: {page.get_path()}')
+            else:
+                self.stdout.write(f'No page found using plugin instance ID {plugin_instance_id}')
+
+    def find_page_using_plugin_instance(self, plugin_instance_id):
+        try:
+            CMSPlugin = apps.get_model('cms', 'CMSPlugin')
+            plugin_instance = CMSPlugin.objects.get(id=plugin_instance_id)
+            page = plugin_instance.placeholder.page if plugin_instance.placeholder else None
+            return page
+        except CMSPlugin.DoesNotExist:
+            return None


### PR DESCRIPTION
## Overview

Recreates #728, whose commit is no longer reachable from `main`'s current history. Adds a `list_plugin_pages` management command to look up which page uses a given plugin instance.

## Related

- recreates #728
- required by #983 (once merged, rebasing/merging `main` into #983 should drop the portion of its diff that duplicates this)

## Changes

- **added** `list_plugin_pages` command to find what page uses a given plugin instance
- **added** README section documenting the command

## Testing

1. Open a local or staging server.
2. Find a plugin instance ID (e.g. via CMS admin or browsing the page's plugin tree).
3. Run `python manage.py list_plugin_pages THAT_ID`.
4. Verify output reports the page it's used on.

## UI

Skipped. Non-UI change (management command).

## Notes

Proof of success is #728 which is in `release/v4.36.X`.