### PR TITLE
fix(search): gray header background gaps

### DIFF
--- a/apps/search_page/static/search_page/css/google-search.css
+++ b/apps/search_page/static/search_page/css/google-search.css
@@ -13,15 +13,29 @@
 
 
 
+  /* SEARCH WRAPPERS */
+
+  /* To not shrink content width */
+  /* To avoid gaps in fake background on wide screen */
+  .gsc-wrapper,
+  .gsc-above-wrapper-area {
+    max-width: unset;
+  }
+
+
+
   /* TABLE OF SEARCH STATS & SORTING OPTIONS */
 
-  /* To remove border from search analytics, add gray background */
+  /* To replace border with fake background */
   & .gsc-above-wrapper-area {
     --bkgd-color: var(--global-color-primary--x-light);
 
     background-color: var(--bkgd-color);
-    box-shadow: 40vw 0 var(--bkgd-color), -40vw 0 var(--bkgd-color);
+    box-shadow:
+      100vw 0 0 100vh var(--bkgd-color),
+      -100vw 0 0 100vh var(--bkgd-color);
     border-bottom: unset;
+    clip-path: inset(0 -100vw);
   }
 
   & .gsc-above-wrapper-area-container {

--- a/apps/search_page/static/search_page/css/google-search.css
+++ b/apps/search_page/static/search_page/css/google-search.css
@@ -30,12 +30,13 @@
   & .gsc-above-wrapper-area {
     --bkgd-color: var(--global-color-primary--x-light);
 
-    background-color: var(--bkgd-color);
+    background-color: var(--bkgd-color); /* the real bkgd */
     box-shadow:
-      100vw 0 0 100vh var(--bkgd-color),
-      -100vw 0 0 100vh var(--bkgd-color);
+      100vw 0 0 100vw var(--bkgd-color),
+      -100vw 0 0 100vw var(--bkgd-color); /* the extended bkgd */
+    clip-path: inset(0 -100vw); /* to hide vertical overflow of extended bkgd */
+
     border-bottom: unset;
-    clip-path: inset(0 -100vw);
   }
 
   & .gsc-above-wrapper-area-container {


### PR DESCRIPTION
## Overview

Fixes gray background gaps on wide screens beside the search stats/sorting bar, and prevents that bar from shrinking the content width.

## Related

- [WP-1313 comment's bug #1](https://tacc-main.atlassian.net/browse/WP-1313?focusedCommentId=40743)
- similar to https://github.com/TACC/Core-Styles/pull/675
- required to later undo https://github.com/TACC/Core-CMS-Custom/pull/553

## Changes

- **fixed** `.gsc-wrapper` / `.gsc-above-wrapper-area` shrinking content width by unsetting `max-width`
- **fixed** fake background gaps on wide screens by using a full `box-shadow` spread with `clip-path` to contain overflow

## Testing

1. `make start`
2. Visit the search page at a wide viewport (e.g. 1920px)
3. Verify the gray background behind the stats/sorting row has no gaps and content width is unaffected

## UI

| before | after |
| - | - |
| <img width="900" height="505" alt="before" src="https://github.com/user-attachments/assets/d0a29eec-c479-40c2-8b54-08d044b42e93" /> | <img width="900" height="505" alt="after" src="https://github.com/user-attachments/assets/6402b8d9-9844-4db4-b9ed-1c9b3aa2ee2a" /> |