### PR TITLE
chore(deps): bump @tacc/core-styles to v2.57.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.57.3"
+        "@tacc/core-styles": "^2.57.4"
       },
       "engines": {
         "node": ">=20",
@@ -1510,9 +1510,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.57.3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.3.tgz",
-      "integrity": "sha512-PsVtdUUL0Np/HP7gtIhYAkK6H7GWyb5CgBfX2clhxgzNl+xn2ptV6p2PpJllr0qAlfXVCXTQHlYAGA5DWnMZgw==",
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.4.tgz",
+      "integrity": "sha512-xTEFR+MsP4xYjmCGxlOuuULbDdLIm9Ous1NAKd3//kubky9XHSQz+91wbxfNy5axmYEtLx+g+ropOhIHk7nhsA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5747,9 +5747,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.57.3",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.3.tgz",
-      "integrity": "sha512-PsVtdUUL0Np/HP7gtIhYAkK6H7GWyb5CgBfX2clhxgzNl+xn2ptV6p2PpJllr0qAlfXVCXTQHlYAGA5DWnMZgw==",
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.4.tgz",
+      "integrity": "sha512-xTEFR+MsP4xYjmCGxlOuuULbDdLIm9Ous1NAKd3//kubky9XHSQz+91wbxfNy5axmYEtLx+g+ropOhIHk7nhsA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.57.3"
+    "@tacc/core-styles": "^2.57.4"
   }
 }


### PR DESCRIPTION
## Overview

Bumps `@tacc/core-styles` to v2.57.4.

## Related

- https://github.com/TACC/Core-Styles/releases/tag/v2.57.4

## Changes

- **updated** `package.json` / `package-lock.json`

## Testing

1. `npm ci && npm run build`
2. Verify CSS build completes with no errors