### PR TITLE
docs(test-releases): add v4.40.1-rc1 test doc

### DIFF
--- a/docs/test-releases/v4.40.1-rc1.md
+++ b/docs/test-releases/v4.40.1-rc1.md
@@ -1,0 +1,158 @@
+# [v4.40.1-rc1](https://github.com/TACC/Core-CMS/releases/tag/v4.40.1-rc1)
+
+1. [Standard Features](#standard-features)
+    1. [Picture Alignment & Class Hoisting](#picture-alignment--class-hoisting)
+    2. [Breadcrumb Second-Level Link Style](#breadcrumb-second-level-link-style)
+    3. [Input File Field Height](#input-file-field-height)
+    4. [Section Background Gaps on Wide Screens](#section-background-gaps-on-wide-screens)
+2. [Optional](#optional)
+    1. [`list_plugin_pages` Command](#list_plugin_pages-command)
+    2. [Style Editor & Snippet User Groups](#style-editor--snippet-user-groups)
+
+## Standard Features
+
+> [!TIP]
+> **All** portals have these features. You may create/edit one test page for all of these.
+
+### Picture Alignment & Class Hoisting
+
+**Tests:** Picture `class`/`alt` is not hoisted to `<figure>`/`<a>`. Alignment of linked/captioned images. ([Core-CMS #1127](https://github.com/TACC/Core-CMS/pull/1127))
+
+1. On server, run:
+    ```sh
+    sudo docker exec portal_cms python manage.py create_picture_test_page --replace
+    ```
+2. In browser, open http://localhost:8000/test/test-picture-style/
+3. Open the browser console and run…
+    <details><summary>…this JavaScript</summary>
+
+    ```javascript
+    (() => {
+      // Strips Django CMS noise ("cms-plugin cms-plugin-<id>")
+      function stripCmsPluginClasses(classAttr) {
+        return (classAttr || '')
+          .split(/\s+/)
+          .filter(c => c && !/^cms-plugin(-\d+)?$/.test(c))
+          .join(' ');
+      }
+
+      const rows = [...document.querySelectorAll('section.o-section')]
+        .filter(s => s.querySelector('h2') && s.querySelector('img'));
+      const failures = [];
+
+      rows.forEach(section => {
+        const label = section.querySelector('h2').textContent.trim();
+        const attrsText = section.querySelector('p code')?.textContent.trim() ?? '';
+        const expectedClass = (attrsText.match(/class="([^"]*)"/) || [])[1] ?? null;
+        const expectedAlt = (attrsText.match(/alt="([^"]*)"/) || [])[1] ?? null;
+
+        const img = section.querySelector('img');
+        const a = section.querySelector('a');
+        const figure = section.querySelector('figure');
+
+        // <a>/<figure> must never carry the Picture's class/alt (the bug this PR fixes)
+        [['a', a], ['figure', figure]].forEach(([tag, el]) => {
+          if (!el) return;
+          const cls = stripCmsPluginClasses(el.getAttribute('class'));
+          const parts = [];
+          if (cls) parts.push(`class="${cls}"`);
+          if (el.hasAttribute('alt')) parts.push(`alt="${el.getAttribute('alt')}"`);
+          if (parts.length) {
+            failures.push(`[${label}] <${tag}> has class/alt: ${parts.join(' ')}`);
+          }
+        });
+
+        // <img> must carry its own class/alt, matching the row's declared attributes
+        const actualClass = stripCmsPluginClasses(img.getAttribute('class'));
+        if (expectedClass && actualClass !== expectedClass) {
+          failures.push(`[${label}] <img> class mismatch: expected "${expectedClass}", got "${actualClass}"`);
+        }
+        if (expectedAlt && img.getAttribute('alt') !== expectedAlt) {
+          failures.push(`[${label}] <img> alt mismatch: expected "${expectedAlt}", got "${img.getAttribute('alt')}"`);
+        }
+      });
+
+      console.log(`Checked ${rows.length} rows.`);
+      failures.length
+        ? (console.error(`${failures.length} failure(s):`), failures.forEach(f => console.error(f)))
+        : console.log('PASS: <a>/<figure> carry no class/alt; <img> carries its own.');
+
+      // Lists every align-left/align-right/align-center row, for the visual check in step 5
+      console.group('TASK: Visually check alignment of these sections:');
+      rows
+        .filter(s => /align-(left|right|center)/.test(s.querySelector('h2').textContent))
+        .forEach(s => console.log(s.querySelector('h2').textContent.trim()));
+      console.groupEnd();
+    })();
+    ```
+
+    </details>
+4. Confirm the console logs `PASS: ...` with no failures listed.\
+    <sup>Verifies `<a>`/`<figure>` never carry the image's `class`/`alt`, and `<img>` carries its own.</sup>
+5. Find (or scroll to) the "**align-**" sections.\
+    <sup>(as listed under "TASK: Visually check alignment …")</sup>
+6. Confirm the wrapper (`<figure>` or `<a>`), not just the image, floats or centers.
+
+### Breadcrumb Second-Level Link Style
+
+**Tests:** move script-dependent breadcrumb `<style>` into `<script>` ([Core-CMS #1211](https://github.com/TACC/Core-CMS/pull/1211)).
+
+1. Visit/Create a page that is nested at least two levels deep in the nav.
+2. On that page, confirm the second breadcrumb link renders normally.\
+    <sup>(renders full opacity and inherited color; does not look visually disabled)</sup>
+3. Confirm that breadcrumb is **not** clickable (no `href`).
+
+### Input File Field Height
+
+**Tests:** `<input type="file">` UI is no longer cut off. ([Core-Styles #673](https://github.com/TACC/Core-Styles/pull/673))
+
+1. Log in.
+2. Open a page with `?edit`.
+3. Add/Edit a Text plugin.
+4. Switch to "Source" view and paste:
+    ```html
+    <input type="file">
+    ```
+5. Save and view the rendered page.
+6. Confirm the native file-picker button and "No file chosen" label are fully visible.\
+    <sup>(not vertically cropped)</sup>
+
+### Section Background Gaps on Wide Screens
+
+**Tests:** `o-section--style` fake full-width background has no gaps on wide screens. ([Core-Styles #675](https://github.com/TACC/Core-Styles/pull/675))
+
+1. On server, run:
+    ```sh
+    sudo docker exec portal_cms python manage.py create_test_page_section_style --replace
+    ```
+2. Open the generated test page at a wide viewport (e.g. 1920px).
+3. Confirm the `o-section--style-accent` and "Container + accent section" blocks' full-width background shows no gaps on either side.
+
+## Optional
+
+> [!NOTE]
+> Developer tooling only; not user-facing.
+
+### `list_plugin_pages` Command
+
+**Tests:** New `list_plugin_pages` management command. ([Core-CMS #1217](https://github.com/TACC/Core-CMS/pull/1217))
+
+1. Find a plugin instance ID (e.g. via CMS admin or browsing the page's plugin tree).
+2. On server, run:
+    ```sh
+    sudo docker exec portal_cms python manage.py list_plugin_pages __THAT_ID__
+    ```
+3. Confirm it prints the page(s) that use that plugin instance.
+
+### Style Editor & Snippet User Groups
+
+**Tests:** New opt-in "Style Editor" and "Snippet User" groups. ([Core-CMS #940](https://github.com/TACC/Core-CMS/pull/940))
+
+0. Log in (if not already logged in).
+1. If CMS already has these new Groups (`/admin/auth/group/`), delete them.
+2. On server, run:
+    ```sh
+    sudo docker exec portal_cms python manage.py set_group_perms style_editor_basic style_editor_advanced snippet_user
+    ```
+3. In browser, open `/admin/auth/group/`.
+4. Confirm the 3 Groups exist with the expected permissions.


### PR DESCRIPTION
## Overview

Adds the manual/scripted testing doc for the v4.40.1-rc1 release.

## Related

- https://github.com/TACC/Core-CMS/releases/tag/v4.40.1-rc1

## Changes

- **added** `docs/test-releases/v4.40.1-rc1.md`

## Testing

1. Open [`docs/test-releases/v4.40.1-rc1.md`](docs/test-releases/v4.40.1-rc1.md) and follow its own steps.