### PR TITLE
docs(agents): add Vocab section and clarify Changes bullet rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
 - [Architecture](#architecture)
+- [Vocab](#vocab)
 - [Commits](#commits)
 - [Pull Requests](#pull-requests)
 
@@ -68,6 +69,10 @@ As necessary for given task:
 
 See `README.md` for full setup instructions.
 
+## Vocab
+
+- Use the word "deleted", not "removed".
+
 ## Commits
 
 - **Format:** `.gitmessage` (fallback: `~/.gitmessage`)
@@ -79,7 +84,7 @@ See `README.md` for full setup instructions.
   - Be concise: plain language, simple sentences, present lists as bullets not prose.
   - When summarizing changeset, say what changed and (only if it matters) why, never how.
   - If listing a file change, then only describe change at a high level.
-  - In "Changes" section, group into as few bullets as the logical changes require (never one per file) and default to zero explanation per bullet (e.g. `**added** logos`).
+  - In "Changes" section, group into as few bullets as the logical changes require (never one per file) and default to zero explanation per bullet (e.g. `**added** logos`). Leave the detail for the code diff itself — a bullet is not the place to restate what the diff already shows.
   - In "Overview" section, match the template's example length (1 sentence), not its stated max (1–3).
   - When updating, first re-read the current description, because it may have been edited.
   - In "Related" section, links to PRs should instead just be raw URLs (because GitHub will auto-create rich links).


### PR DESCRIPTION
## Overview

Port two AGENTS.md updates from Core-Styles into this repo's AGENTS.md.

## Related

- https://github.com/TACC/Core-Styles/pull/694
- https://github.com/TACC/Core-Styles/pull/695

## Changes

- **added** Vocab section standardizing on "deleted" over "removed"
- **updated** "Changes" bullet rule to clarify detail belongs in the diff, not the bullet

## Testing

1. Read `AGENTS.md` and confirm the Vocab section and updated Pull Requests rule render correctly

## UI

…