### PR TITLE
docs(agents): sync PR conventions from Core-Styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,6 @@
 - [Vocab](#vocab)
 - [Commits](#commits)
 - [Pull Requests](#pull-requests)
-  - [Review Comments](#review-comments)
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - [Vocab](#vocab)
 - [Commits](#commits)
 - [Pull Requests](#pull-requests)
+  - [Review Comments](#review-comments)
 
 ## Architecture
 
@@ -81,11 +82,29 @@ See `README.md` for full setup instructions.
 
 - **Title:** `.gitmessage` (fallback: `~/.gitmessage`)
 - **Description:** `.github/PULL_REQUEST_TEMPLATE.md` (fallback: `~/.github/PULL_REQUEST_TEMPLATE.md`)
-  - Be concise: plain language, simple sentences, present lists as bullets not prose.
-  - When summarizing changeset, say what changed and (only if it matters) why, never how.
-  - If listing a file change, then only describe change at a high level.
-  - In "Changes" section, group into as few bullets as the logical changes require (never one per file) and default to zero explanation per bullet (e.g. `**added** logos`). Leave the detail for the code diff itself — a bullet is not the place to restate what the diff already shows.
-  - In "Overview" section, match the template's example length (1 sentence), not its stated max (1–3).
-  - When updating, first re-read the current description, because it may have been edited.
+  - In general:
+    - When updating, first re-read the current description, because it may have been edited.
+    - Be concise: plain language, simple sentences, present lists as bullets not prose.
+    - Explanatory rationale specific to this PR's decisions belong in [review comments](#review-comments), not description.
+    - Code comments are only for durable, non-obvious facts for future readers regardless of PR history.
+    - Say each fact once (e.g. a dependency named in "Related" should not be repeated in "Notes").
+  - In "Overview" section, match the template's example length (1 sentence) and density — not just its stated max (1–3), and not a single sentence stitched together from several clauses.
+    - Say what changed and (only if omitting it would leave a reviewer confused or suspicious) why, never how.
   - In "Related" section, links to PRs should instead just be raw URLs (because GitHub will auto-create rich links).
-  - If responding to a PR comment as the user instead of a bot, then quote and sign your entire reply.
+  - In "Changes" section:
+    - Group changes into as few bullets as the logical changes require (never one per file)
+    - Default to zero explanation per bullet (e.g. `**added** logos`). Leave the detail for the code diff itself — a bullet is not the place to restate what the diff already shows.
+    - Name files/identifiers by their bare name (`x-button.css`), not full path, unless the bare name is ambiguous.
+    - Describe even the "what" at the highest level that's still meaningful — prefer a general noun ("shared rules") to an enumeration of the specifics behind it ("the such-and-such code block").
+    - When several similarly-patterned names are affected the same way (e.g. a rename applied to 3 things), give one example plus `…` instead of listing all of them.
+  - In "Testing" section:
+    - One action per numbered step.
+    - Prefer a step that compares directly against a running reference (e.g. production).
+
+### Review Comments
+
+- Group it into one self-review with inline comments.
+- Prefix each such comment with:
+    - either **Explanation:**, **Question:**, **Suggestion:**
+    - or appropriate callout syntax (e.g. [GitHub Alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts))
+- If commenting on a PR as the user instead of a distinct bot identity, then quote and sign your entire message.


### PR DESCRIPTION
## Overview

Sync recent AGENTS.md updates from Core-Styles to keep PR conventions aligned across repos.

## Related

- https://github.com/TACC/Core-Styles/pull/704
- https://github.com/TACC/Core-Styles/pull/705
- https://github.com/TACC/Core-Styles/pull/707
- https://github.com/TACC/Core-Styles/pull/713
- https://github.com/TACC/Core-Styles/commit/bd21cc9e3fe47146edda3dfb4c9853e20cbf59fa

## Changes

- **restructured** Pull Requests description rules into general/Overview/Related/Changes/Testing subgroups
- **added** rules on where PR rationale belongs, redundancy, file naming, and testing steps
- **added** a Review Comments subsection covering self-review and comment formatting

## Testing

1. Read AGENTS.md and confirm rendering/links look correct