### PR TITLE
deps(core-styles): v2.58 + fix(styles): abandon @extend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.58.0-rc2"
+        "@tacc/core-styles": "^2.58.0"
       },
       "engines": {
         "node": ">=20",
@@ -1510,16 +1510,16 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.58.0-rc2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.58.0-rc2.tgz",
-      "integrity": "sha512-kYhKmQ5395kKtnleRG8e10+xq/3fd+W4TbrnFrq3KrjcBl2r2TQPwSWr9Pu/cCJCBqmpKO07SR3SJa10I6mG2Q==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.58.0.tgz",
+      "integrity": "sha512-MV70SVWot/n+96vDPmSRs8mRF0gM+H/XcY1Ba1/Ht1B19NWLnSIIvx89QDT4vQWP7VemFTOd9siaHoQtNpZVlA==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "core-styles": "src/cli.js"
       },
       "engines": {
-        "node": ">=20.x",
+        "node": ">=22.x",
         "npm": ">=7.x"
       },
       "peerDependencies": {
@@ -1532,7 +1532,6 @@
         "postcss": "^8.4.38",
         "postcss-banner": "^4.0.1",
         "postcss-cli": "^10.0.0",
-        "postcss-extend": "^1.0.5",
         "postcss-import": "^15.0.0",
         "postcss-mixins": "^10.0.1",
         "postcss-preset-env": "^10.0.2",
@@ -1759,71 +1758,6 @@
       ],
       "license": "CC-BY-4.0",
       "peer": true
-    },
-    "node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chalk/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -2368,17 +2302,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -2562,42 +2485,6 @@
       "license": "ISC",
       "peer": true
     },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2700,14 +2587,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -3464,45 +3343,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-extend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-extend/-/postcss-extend-1.0.5.tgz",
-      "integrity": "sha512-zplAc8IovPMe/JqV0B9nl6o6sElIX7VX1CP2FbV+lGZud3hcnDMr4clN0S8xdHthQoTNDN2K1Q+z0YEW5FWc8A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "postcss": "^5.0.4"
-      }
-    },
-    "node_modules/postcss-extend/node_modules/postcss": {
-      "version": "5.2.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "js-base64": "^2.1.9",
-        "source-map": "^0.5.6",
-        "supports-color": "^3.2.3"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/postcss-extend/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss-focus-visible": {
@@ -4915,20 +4755,6 @@
         "postcss": "^8.3.3"
       }
     },
-    "node_modules/supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -5747,9 +5573,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.58.0-rc2",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.58.0-rc2.tgz",
-      "integrity": "sha512-kYhKmQ5395kKtnleRG8e10+xq/3fd+W4TbrnFrq3KrjcBl2r2TQPwSWr9Pu/cCJCBqmpKO07SR3SJa10I6mG2Q==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.58.0.tgz",
+      "integrity": "sha512-MV70SVWot/n+96vDPmSRs8mRF0gM+H/XcY1Ba1/Ht1B19NWLnSIIvx89QDT4vQWP7VemFTOd9siaHoQtNpZVlA==",
       "dev": true,
       "requires": {}
     },
@@ -5873,53 +5699,6 @@
       "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "peer": true
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-          "dev": true,
-          "peer": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-          "dev": true,
-          "peer": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-          "dev": true,
-          "peer": true
-        }
-      }
     },
     "chokidar": {
       "version": "3.6.0",
@@ -6260,13 +6039,6 @@
       "dev": true,
       "peer": true
     },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "peer": true
-    },
     "fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -6389,32 +6161,6 @@
       "dev": true,
       "peer": true
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
-    "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
-      "dev": true,
-      "peer": true
-    },
     "hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -6480,13 +6226,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "peer": true
-    },
-    "js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true,
       "peer": true
     },
@@ -6926,38 +6665,6 @@
         "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0",
         "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-extend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-extend/-/postcss-extend-1.0.5.tgz",
-      "integrity": "sha512-zplAc8IovPMe/JqV0B9nl6o6sElIX7VX1CP2FbV+lGZud3hcnDMr4clN0S8xdHthQoTNDN2K1Q+z0YEW5FWc8A==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "postcss": "^5.0.4"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true,
-          "peer": true
-        }
       }
     },
     "postcss-focus-visible": {
@@ -7735,16 +7442,6 @@
       "dev": true,
       "peer": true,
       "requires": {}
-    },
-    "supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "has-flag": "^1.0.0"
-      }
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "minimist": "^1.2.6"
       },
       "devDependencies": {
-        "@tacc/core-styles": "^2.57.4"
+        "@tacc/core-styles": "^2.58.0-rc2"
       },
       "engines": {
         "node": ">=20",
@@ -1510,9 +1510,9 @@
       }
     },
     "node_modules/@tacc/core-styles": {
-      "version": "2.57.4",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.4.tgz",
-      "integrity": "sha512-xTEFR+MsP4xYjmCGxlOuuULbDdLIm9Ous1NAKd3//kubky9XHSQz+91wbxfNy5axmYEtLx+g+ropOhIHk7nhsA==",
+      "version": "2.58.0-rc2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.58.0-rc2.tgz",
+      "integrity": "sha512-kYhKmQ5395kKtnleRG8e10+xq/3fd+W4TbrnFrq3KrjcBl2r2TQPwSWr9Pu/cCJCBqmpKO07SR3SJa10I6mG2Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5747,9 +5747,9 @@
       }
     },
     "@tacc/core-styles": {
-      "version": "2.57.4",
-      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.57.4.tgz",
-      "integrity": "sha512-xTEFR+MsP4xYjmCGxlOuuULbDdLIm9Ous1NAKd3//kubky9XHSQz+91wbxfNy5axmYEtLx+g+ropOhIHk7nhsA==",
+      "version": "2.58.0-rc2",
+      "resolved": "https://registry.npmjs.org/@tacc/core-styles/-/core-styles-2.58.0-rc2.tgz",
+      "integrity": "sha512-kYhKmQ5395kKtnleRG8e10+xq/3fd+W4TbrnFrq3KrjcBl2r2TQPwSWr9Pu/cCJCBqmpKO07SR3SJa10I6mG2Q==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.58.0-rc2"
+    "@tacc/core-styles": "^2.58.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/TACC/Core-CMS",
   "devDependencies": {
-    "@tacc/core-styles": "^2.57.4"
+    "@tacc/core-styles": "^2.58.0-rc2"
   }
 }

--- a/taccsite_cms/static/site_cms/css/src/_imports/components/lightgallery.css
+++ b/taccsite_cms/static/site_cms/css/src/_imports/components/lightgallery.css
@@ -1,8 +1,10 @@
 /* To style lightGallery (https://www.lightgalleryjs.com/) */
-@import url("@tacc/core-styles/src/lib/_imports/trumps/s-image-grid.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-grid.css");
 
 .lightgallery {
-  @extend .s-image-grid;
+  /* To mimic .s-image-grid */
+  /* https://github.com/TACC/Core-Styles/blob/v2.57.4/src/lib/_imports/trumps/s-image-grid.css */
+  @mixin grid--layout-cols-equal-min-width-max-count;
 }
 
 .lg-sub-html a {


### PR DESCRIPTION
## Overview

- Replaces `postcss-extend` usage with `@mixin`.
- Bumps Core-Styles to `v2.58.0`.

## Related

- https://github.com/TACC/Core-Styles/issues/340
- https://github.com/TACC/Core-Portal/pull/1344

## Changes

- **replaced** `@extend .s-image-grid` with `@mixin grid--layout-cols-equal-min-width-max-count` in `lightgallery.css`
- **bumped** `@tacc/core-styles` to `v2.58.0`

## Testing

1. `make start`
2. Add an "Image Gallery" plugin (`djangocms-tacc-image-gallery`) to a page, nested with a few Picture plugins.
3. Verify images render in the same responsive grid as before this change.

## UI

<img width="1400" height="900" alt="lightgallery-mixin--wide" src="https://github.com/user-attachments/assets/50a85370-9ff4-473b-a2dd-463848bff704" />

<img width="900" height="475" alt="Screenshot 2026-08-25 at 23 30 35" src="https://github.com/user-attachments/assets/860b76a4-2702-4e98-9032-1672669e9580" />
