### PR TITLE
chore(deps): bump html-filter-sort CDN pin to v1

### DIFF
--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -9,7 +9,7 @@
 
 {# TACC/Core-CMS + @tacc/html-filter-sort #}
 {# SEE: https://github.com/wesleyboar/Core-HTML-Filter-Sort #}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tacc/html-filter-sort@0/src/filtersort.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tacc/html-filter-sort@1/src/filtersort.css" />
 <script
   src="https://cdn.jsdelivr.net/npm/list.js@2.3.1/dist/list.min.js"
   integrity="sha384-FhEOA/pIE4BfDuwGksHaZD8ms5j+dfB9QIWo7naDMzAVoCE1My4G2iu8/n/R3AAH"
@@ -17,7 +17,7 @@
 ></script>
 <script type="module">
   import updateEmailLinkHrefs from '{% static "site_cms/js/modules/updateEmailLinkHrefs.js" %}';
-  import filtersort from 'https://cdn.jsdelivr.net/npm/@tacc/html-filter-sort@0/src/filtersort.js';
+  import filtersort from 'https://cdn.jsdelivr.net/npm/@tacc/html-filter-sort@1/src/filtersort.js';
 
   const scopeElement = document.getElementById('cms-content');
   const fakeText = '__REMOVE_THIS__';

--- a/taccsite_cms/templates/assets_core_delayed.html
+++ b/taccsite_cms/templates/assets_core_delayed.html
@@ -9,10 +9,13 @@
 
 {# TACC/Core-CMS + @tacc/html-filter-sort #}
 {# SEE: https://github.com/wesleyboar/Core-HTML-Filter-Sort #}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tacc/html-filter-sort@1/src/filtersort.css" />
+<link
+  rel="stylesheet"
+  id="user-projects-assets-table-css"
+  href="https://cdn.jsdelivr.net/npm/@tacc/html-filter-sort@1/src/filtersort.css"
+/>
 <script
-  src="https://cdn.jsdelivr.net/npm/list.js@2.3.1/dist/list.min.js"
-  integrity="sha384-FhEOA/pIE4BfDuwGksHaZD8ms5j+dfB9QIWo7naDMzAVoCE1My4G2iu8/n/R3AAH"
+  src="https://cdn.jsdelivr.net/npm/list.js-fixed@2/dist/list.min.js"
   crossorigin="anonymous"
 ></script>
 <script type="module">


### PR DESCRIPTION
## Overview

Bumps the `@tacc/html-filter-sort` CDN URL from major version 0 to 1, now that v1.0.0 is released.

## Related

- https://github.com/wesleyboar/Core-HTML-Filter-Sort/pull/39

## Changes

- **bumped** `html-filter-sort` CDN pin in `assets_core_delayed.html`

## Testing

1. Load a CMS page with a `js-filtersort` table and confirm sorting/filtering still works
2. Filter to zero results and confirm a centered "No results found" row spans the table

> [!TIP]
> Tested on [live TACC Research page](https://tacc.utexas.edu/research/tacc-research/) using https://github.com/TACC/Core-CMS-Custom/pull/579.